### PR TITLE
Fix issue with wording in localization for room participants

### DIFF
--- a/Riot/Assets/de.lproj/Vector.strings
+++ b/Riot/Assets/de.lproj/Vector.strings
@@ -300,7 +300,7 @@
 "room_participants_invite_another_user" = "Suchen/Einladen mittels Benutzer ID, Name oder E-Mail-Adresse";
 "room_participants_invite_malformed_id" = "Ungültige ID. Sollte eine E-Mail-Adresse oder Matrix-ID wie \"@thomas:matrix.org' sein";
 "room_participants_idle" = "Untätig";
-"room_participants_ago" = "her";
+"room_participants_since" = "seit";
 "room_participants_action_section_admin_tools" = "Admin Werkzeuge";
 "room_participants_action_unban" = "Entsperren";
 "room_participants_action_set_default_power_level" = "Zurück auf normale Berechtigung";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -205,7 +205,7 @@
 "room_participants_unknown" = "Unknown";
 "room_participants_idle" = "Idle";
 "room_participants_now" = "now";
-"room_participants_ago" = "ago";
+"room_participants_since" = "since";
 
 "room_participants_action_section_admin_tools" = "Admin tools";
 "room_participants_action_section_direct_chats" = "Direct chats";

--- a/Riot/Utils/Tools.m
+++ b/Riot/Utils/Tools.m
@@ -51,8 +51,8 @@
         else if (-1 != user.lastActiveAgo && 0 < user.lastActiveAgo)
         {
             presenceText = [presenceText stringByAppendingString:[NSString stringWithFormat:@" %@ %@",
-                                                                  [MXKTools formatSecondsIntervalFloored:(user.lastActiveAgo / 1000)],
-                                                                  NSLocalizedStringFromTable(@"room_participants_ago", @"Vector", nil)]];
+                                                                  NSLocalizedStringFromTable(@"room_participants_since", @"Vector", nil),
+                                                                  [MXKTools formatSecondsIntervalFloored:(user.lastActiveAgo / 1000)]]];
         }
     }
 


### PR DESCRIPTION
The German translation in the room participants view doesn't quite work and feels weird to read.

This commit fixes that, although the change probably breaks every other translation as it changes a localization key. One idea is to change the formatting so we have something like:

"room_participants_offline" = "Last Online: %@ ago"

This would require an update for every localization, but also allow for more freedom.

The current commit changes the German localization to:
<img width="370" alt="albert_screenshot" src="https://user-images.githubusercontent.com/44062083/49955322-d26a4f00-ff02-11e8-9d2d-97705dc41ad8.png">