### PR TITLE
[Internal] [CI] Fix switcheroo logic

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -317,19 +317,24 @@ platform :ios do
     kit_branch = find_branch(kit_slug, branch_pattern) || 'develop'
     sdk_branch = find_branch(sdk_slug, branch_pattern) || 'develop'
 
+    kit_spec = { git: 'https://github.com/matrix-org/matrix-ios-kit.git', branch: kit_branch }
+    kit_podspec = { podspec: 'MatrixKit.edited.podspec' }
+    sdk_spec = { git: 'https://github.com/matrix-org/matrix-ios-sdk.git', branch: sdk_branch }
+
     UI.message("✏️ Making a local copy of MatrixKit.podspec from the \`#{kit_branch}\` branch...")
     podspec_content = Net::HTTP.get(URI("https://raw.githubusercontent.com/#{kit_slug}/#{kit_branch}/MatrixKit.podspec"))
 
     UI.message "✏️ Editing local MatrixKit podspec to remove version constaint on 'MatrixSDK*' dependencies..."
     podspec_content.gsub!(%r{(\.dependency\s+(['"])MatrixSDK(\/[^'"]+)?\2).*$}, '\1')
+    podspec_content.gsub!(%r{(\.source\s*=\s*).*$}, "\\1#{kit_spec}")
     File.write('../MatrixKit.edited.podspec', podspec_content) # current dir is 'fastlane/' hence the '../'
+    UI.command_output("Content of MatrixKit.edited.podspec:\n" + podspec_content)
 
     UI.message "✏️ Modify Podfile to point MatrixKit to local podspec and `MatrixSDK/*` to \`#{sdk_branch}\` branch..."
     podfile_content = File.read('../Podfile') # current dir is 'fastlane/' hence the '../'
-    kit_spec = { podspec: 'MatrixKit.edited.podspec' }
-    sdk_spec = { git: 'https://github.com/matrix-org/matrix-ios-sdk.git', branch: sdk_branch }
-    podfile_content.gsub!(%r{^\$matrixKitVersion\s*=\s*.*$}, "$matrixKitVersion = { #{kit_spec} => #{sdk_spec} }")
+    podfile_content.gsub!(%r{^\$matrixKitVersion\s*=\s*.*$}, "$matrixKitVersion = { #{kit_podspec} => #{sdk_spec} }")
     File.write('../Podfile', podfile_content)
+    UI.command_output("Content of modified Podfile:\n" + podfile_content)
   end
 
   # Find the latest branch with the given name pattern in the given repo


### PR DESCRIPTION
Fix switcheroo logic: we need to also edit the `:tag => s.version.to_s` from the `MatrixKit.podspec`
So that it downloads from the branch and not the tag when using that podspec in the Podfile

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
