### PR TITLE
Polish Pin Screen

### DIFF
--- a/Riot/Categories/UIDevice.swift
+++ b/Riot/Categories/UIDevice.swift
@@ -33,4 +33,10 @@ import UIKit
             return false
         }
     }
+    
+    /// Returns if the device is a Phone
+    var isPhone: Bool {
+        return userInterfaceIdiom == .phone
+    }
+    
 }

--- a/Riot/Modules/Common/NavigationController/RiotNavigationController.m
+++ b/Riot/Modules/Common/NavigationController/RiotNavigationController.m
@@ -28,4 +28,31 @@
     return self.topViewController;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    if (self.topViewController)
+    {
+        return self.topViewController.supportedInterfaceOrientations;
+    }
+    return [super supportedInterfaceOrientations];
+}
+
+- (BOOL)shouldAutorotate
+{
+    if (self.topViewController)
+    {
+        return self.topViewController.shouldAutorotate;
+    }
+    return [super shouldAutorotate];
+}
+
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
+{
+    if (self.topViewController)
+    {
+        return self.topViewController.preferredInterfaceOrientationForPresentation;
+    }
+    return [super preferredInterfaceOrientationForPresentation];
+}
+
 @end

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
@@ -67,11 +67,6 @@ final class EnterPinCodeViewController: UIViewController {
         self.update(theme: self.theme)
         
         self.viewModel.viewDelegate = self
-        
-        if #available(iOS 13.0, *) {
-            modalPresentationStyle = .fullScreen
-            isModalInPresentation = true
-        }
 
         self.viewModel.process(viewAction: .loadData)
     }

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
@@ -80,6 +80,10 @@ final class EnterPinCodeViewController: UIViewController {
         return self.theme.statusBarStyle
     }
     
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+    
     // MARK: - Private
     
     private func update(theme: Theme) {

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
@@ -69,6 +69,11 @@ final class EnterPinCodeViewController: UIViewController {
         self.viewModel.viewDelegate = self
 
         self.viewModel.process(viewAction: .loadData)
+        
+        //  force orientation to portrait if phone
+        if UIDevice.current.isPhone {
+            UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
+        }
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -76,7 +81,18 @@ final class EnterPinCodeViewController: UIViewController {
     }
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .portrait
+        //  limit orientation to portrait only for phone
+        if UIDevice.current.isPhone {
+            return .portrait
+        }
+        return super.supportedInterfaceOrientations
+    }
+    
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        if UIDevice.current.isPhone {
+            return .portrait
+        }
+        return super.preferredInterfaceOrientationForPresentation
     }
     
     // MARK: - Private

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
@@ -280,4 +280,12 @@ extension EnterPinCodeViewController: EnterPinCodeViewModelViewDelegate {
         self.renderPlaceholdersCount(count)
     }
     
+    func enterPinCodeViewModel(_ viewModel: EnterPinCodeViewModelType, didUpdateCancelButtonHidden isHidden: Bool) {
+        if isHidden {
+            hideCancelButton()
+        } else {
+            showCancelButton()
+        }
+    }
+    
 }

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewModel.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewModel.swift
@@ -143,6 +143,7 @@ final class EnterPinCodeViewModel: EnterPinCodeViewModelType {
         switch viewMode {
         case .setPin:
             update(viewState: .choosePin)
+            self.viewDelegate?.enterPinCodeViewModel(self, didUpdateCancelButtonHidden: pinCodePreferences.forcePinProtection)
         case .unlock:
             update(viewState: .unlock)
         case .confirmPinToDeactivate:

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewModelType.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewModelType.swift
@@ -21,6 +21,7 @@ import Foundation
 protocol EnterPinCodeViewModelViewDelegate: class {
     func enterPinCodeViewModel(_ viewModel: EnterPinCodeViewModelType, didUpdateViewState viewSate: EnterPinCodeViewState)
     func enterPinCodeViewModel(_ viewModel: EnterPinCodeViewModelType, didUpdatePlaceholdersCount count: Int)
+    func enterPinCodeViewModel(_ viewModel: EnterPinCodeViewModelType, didUpdateCancelButtonHidden isHidden: Bool)
 }
 
 protocol EnterPinCodeViewModelCoordinatorDelegate: class {

--- a/Riot/Modules/SetPinCode/SetPinCoordinator.swift
+++ b/Riot/Modules/SetPinCode/SetPinCoordinator.swift
@@ -70,7 +70,11 @@ final class SetPinCoordinator: SetPinCoordinatorType {
     }
     
     func toPresentable() -> UIViewController {
-        return self.navigationRouter.toPresentable()
+        let controller = self.navigationRouter.toPresentable()
+        if #available(iOS 13.0, *) {
+            controller.modalPresentationStyle = .fullScreen
+        }
+        return controller
     }
     
     // MARK: - Private methods


### PR DESCRIPTION
- [ ] Numbers buttons color is not the same as Figma. Color in Figma is not in the palette also.
- [ ] Forgot button text color is not the same as Figma.
- [x] Lock the orientation to portrait only on iPhone
- [x] Check if we keep a cancel button when setting the pin code after login, if no make the presentation full screen
- [ ] Make UI more responsive to improve iPad portrait UI

Fixes #3514 