### PR TITLE
Dismiss ShareExtension on success after sharing

### DIFF
--- a/RiotShareExtension/Managers/ShareExtensionManager.m
+++ b/RiotShareExtension/Managers/ShareExtensionManager.m
@@ -404,7 +404,7 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
         }
         else
         {
-            [self completeRequestReturningItems:returningExtensionItems completionHandler:nil];
+            [self completeRequestReturningItems:nil completionHandler:nil];
         }
     });
 }


### PR DESCRIPTION
Removed passing the data back to the host to dismiss the share extension on success like other iOS apps do
Without paying much attention to it it always felt like something went wrong while sharing with the extension staying on the screen afterwards

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

Signed-off-by: Dominik Fabisiewicz <domi.fab98@gmail.com>