### PR TITLE
buildRelease.sh: Pass a `git_tag` parameter to fastlane

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Changes to be released in next version
  * 
 
 Others
- * 
+ * buildRelease.sh: Pass a `git_tag` parameter to fastlane because fastlane `git_branch` method can fail.
 
 Changes in 1.0.10 (2020-09-08)
 =================================================

--- a/Tools/Release/buildRelease.sh
+++ b/Tools/Release/buildRelease.sh
@@ -47,7 +47,7 @@ cd $REPO_NAME
 bundle exec fastlane point_dependencies_to_same_feature
 
 # Build
-bundle exec fastlane app_store build_number:$BUILD_NUMBER
+bundle exec fastlane app_store build_number:$BUILD_NUMBER git_tag:$TAG
 
 if [ -e out/Riot.ipa ]; then
     # Here is the artefact

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,9 +90,13 @@ platform :ios do
     # ad-hoc or app-store?
     adhoc = options.fetch(:adhoc, false)
 
-    # Retrieve GIT branch name
-    git_branch_name = git_branch
-    UI.user_error!("Unable to retrieve GIT branch name") unless !git_branch_name.to_s.empty?
+    # Extract git information to show within the app
+    git_branch_name = options[:git_tag]
+    if git_branch_name.to_s.empty?
+      # Retrieve the current git branch as a fallback
+      git_branch_name = git_branch
+    end
+    UI.user_error!("Unable to retrieve GIT tag or branch") unless !git_branch_name.to_s.empty?
 
     # Fetch team id from Appfile
     team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)


### PR DESCRIPTION
because fastlane `git_branch` method can fail.

It failed when using ./buildRelease.sh with a tag.