### PR TITLE
Timeline: Hide encrypted history (pre-invite)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * Pin: Implement not allowed PINs feature. There is no restriction by default.
 
 🐛 Bugfix
- * 
+ * Timeline: Hide encrypted history (pre-invite) (#3660).
 
 ⚠️ API Changes
  * 

--- a/Config/AppConfiguration.swift
+++ b/Config/AppConfiguration.swift
@@ -31,6 +31,9 @@ class AppConfiguration: CommonConfiguration {
         // Enable CallKit for app
         MXKAppSettings.standard()?.isCallKitEnabled = true
         
+        // Hide undecryptable messages that were sent while the user was not in the room
+        MXKAppSettings.standard()?.hidePreJoinedUndecryptableEvents = true
+        
         // Enable long press on event in bubble cells
         MXKRoomBubbleTableViewCell.disableLongPressGesture(onEvent: false)
         


### PR DESCRIPTION
Fix #3660 