### PR TITLE
Complete Security: Make sure the authentication flow display it if auth is not complete yet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changes to be released in next version
 🐛 Bugfix
  * Timeline: Hide encrypted history (pre-invite) (#3660).
  * Fix floating action buttons' images.
+ * Complete Security: Let the authentication flow display it if this flow is not complete yet.
 
 ⚠️ API Changes
  *

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -1032,7 +1032,9 @@
 
 - (void)presentVerifyCurrentSessionAlertIfNeededWithSession:(MXSession*)session
 {
-    if (RiotSettings.shared.hideVerifyThisSessionAlert || self.reviewSessionAlertHasBeenDisplayed)
+    if (RiotSettings.shared.hideVerifyThisSessionAlert
+        || self.reviewSessionAlertHasBeenDisplayed
+        || self.authenticationInProgress)
     {
         return;
     }


### PR DESCRIPTION
The complete security flow can be unfortunately triggered from 2 places: AuthVC and MasterTabBarC.

On a fresh app installation, during authentication, it was unexpectedly displayed from MasterTabBarC. This prevented authentication flow from completing. The app stayed on the launching animation.

This commit fixes this race.
