### PR TITLE
Fix Pin Code Screen Layout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changes to be released in next version
  * Fix "Unable to open the link" error when using non-Safari browsers (#3673).
  * Biometrics: Handle retry case.
  * Room: Remove membership events from room creation modal (#3679).
+ * PIN: Fix layout on small screens.
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.storyboard
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="V8j-Lb-PgC">
-    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -13,14 +13,14 @@
             <objects>
                 <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="V8j-Lb-PgC" customClass="EnterPinCodeViewController" customModule="Riot" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EL9-GA-lwo">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1YE-D1-eHn">
-                                <rect key="frame" x="0.0" y="64" width="375" height="694"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="627"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="app_symbol" translatesAutoresizingMaskIntoConstraints="NO" id="8qz-Yk-9a4">
-                                        <rect key="frame" x="137.66666666666666" y="277" width="100" height="100"/>
+                                        <rect key="frame" x="137.5" y="243.5" width="100" height="100"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="Ux9-pH-SW9"/>
                                             <constraint firstAttribute="height" constant="100" id="o3K-YH-5tn"/>
@@ -33,52 +33,34 @@
                                     <constraint firstItem="8qz-Yk-9a4" firstAttribute="centerX" secondItem="1YE-D1-eHn" secondAttribute="centerX" id="cPb-3H-3yK"/>
                                 </constraints>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="DMT-DS-IA8">
-                                <rect key="frame" x="0.0" y="52" width="375" height="718"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DMT-DS-IA8">
+                                <rect key="frame" x="0.0" y="8" width="375" height="651"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ztg-5t-ECh" userLabel="Container">
-                                        <rect key="frame" x="20" y="0.0" width="335" height="172.33333333333334"/>
-                                        <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="app_symbol" translatesAutoresizingMaskIntoConstraints="NO" id="UHg-qE-anw">
-                                                <rect key="frame" x="147.66666666666666" y="8" width="40" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="40" id="ERR-Np-6I1"/>
-                                                    <constraint firstAttribute="height" constant="40" id="zYD-Rk-nOH"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose a PIN for security" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxI-mu-qng">
-                                                <rect key="frame" x="0.0" y="57.000000000000007" width="335" height="26.333333333333336"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PINs help keep your profile, messages and contacts secure, so only you can access them." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rn2-qe-htS">
-                                                <rect key="frame" x="0.0" y="111.33333333333334" width="335" height="61"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="app_symbol" translatesAutoresizingMaskIntoConstraints="NO" id="UHg-qE-anw">
+                                        <rect key="frame" x="167.5" y="0.0" width="40" height="40"/>
                                         <constraints>
-                                            <constraint firstItem="Rn2-qe-htS" firstAttribute="centerX" secondItem="ztg-5t-ECh" secondAttribute="centerX" id="18L-xF-ADZ"/>
-                                            <constraint firstItem="Rn2-qe-htS" firstAttribute="top" secondItem="bxI-mu-qng" secondAttribute="bottom" constant="28" id="HtF-cu-6el"/>
-                                            <constraint firstItem="bxI-mu-qng" firstAttribute="leading" secondItem="ztg-5t-ECh" secondAttribute="leading" id="IMC-TT-zWD"/>
-                                            <constraint firstAttribute="bottom" secondItem="Rn2-qe-htS" secondAttribute="bottom" id="IW3-jM-53d"/>
-                                            <constraint firstAttribute="trailing" secondItem="Rn2-qe-htS" secondAttribute="trailing" id="Jda-DD-urk"/>
-                                            <constraint firstItem="UHg-qE-anw" firstAttribute="centerX" secondItem="ztg-5t-ECh" secondAttribute="centerX" id="Vhm-GS-xYs"/>
-                                            <constraint firstAttribute="trailing" secondItem="bxI-mu-qng" secondAttribute="trailing" id="Vug-jC-5c4"/>
-                                            <constraint firstItem="Rn2-qe-htS" firstAttribute="leading" secondItem="ztg-5t-ECh" secondAttribute="leading" id="kWf-33-mfM"/>
-                                            <constraint firstItem="bxI-mu-qng" firstAttribute="top" secondItem="UHg-qE-anw" secondAttribute="bottom" constant="9" id="laj-kY-eW1"/>
-                                            <constraint firstItem="bxI-mu-qng" firstAttribute="centerX" secondItem="ztg-5t-ECh" secondAttribute="centerX" id="p4o-hz-jZJ"/>
-                                            <constraint firstItem="UHg-qE-anw" firstAttribute="top" secondItem="ztg-5t-ECh" secondAttribute="top" constant="8" id="uj5-KC-7FD"/>
+                                            <constraint firstAttribute="height" constant="40" id="5If-kl-LuA"/>
+                                            <constraint firstAttribute="width" constant="40" id="EK6-ed-26b"/>
                                         </constraints>
-                                    </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="l5x-qO-sdf">
-                                        <rect key="frame" x="2" y="211" width="371" height="78.666666666666686"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Welcome back.Choose a PIN for security" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxI-mu-qng">
+                                        <rect key="frame" x="16" y="59" width="343" height="53"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rn2-qe-htS">
+                                        <rect key="frame" x="16" y="131.5" width="343" height="54"/>
+                                        <string key="text">Setting up a PIN lets you protect data like messages and contacts, so only you can access them by entering the PIN at the start of the app.</string>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="l5x-qO-sdf">
+                                        <rect key="frame" x="2" y="204.5" width="371" height="79"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="xi9-P9-8WP">
-                                                <rect key="frame" x="101.66666666666669" y="0.0" width="168" height="24"/>
+                                                <rect key="frame" x="101.5" y="0.0" width="168" height="24"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="selection_untick" translatesAutoresizingMaskIntoConstraints="NO" id="Gwx-8X-ZWk">
                                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
@@ -88,14 +70,14 @@
                                                         </constraints>
                                                     </imageView>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="1" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="selection_untick" translatesAutoresizingMaskIntoConstraints="NO" id="qDY-R1-l5l">
-                                                        <rect key="frame" x="47.999999999999986" y="0.0" width="24" height="24"/>
+                                                        <rect key="frame" x="48" y="0.0" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="24" id="QDg-LP-R4J"/>
                                                             <constraint firstAttribute="height" constant="24" id="f4G-d8-hoA"/>
                                                         </constraints>
                                                     </imageView>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="selection_untick" translatesAutoresizingMaskIntoConstraints="NO" id="X0l-q3-fXm">
-                                                        <rect key="frame" x="95.999999999999986" y="0.0" width="24" height="24"/>
+                                                        <rect key="frame" x="96" y="0.0" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="24" id="HQA-9R-8bC"/>
                                                             <constraint firstAttribute="height" constant="24" id="Zjd-RW-DiW"/>
@@ -111,7 +93,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CBc-7Z-a5Z">
-                                                <rect key="frame" x="0.0" y="23.999999999999996" width="371" height="54.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="24" width="371" height="55"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q0w-RD-JD3">
                                                         <rect key="frame" x="0.0" y="8" width="371" height="2"/>
@@ -121,7 +103,7 @@
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="For security reasons, this PIN isn't available. Please try another PIN" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H5g-FI-xEj">
-                                                        <rect key="frame" x="8" y="18" width="355" height="28.666666666666671"/>
+                                                        <rect key="frame" x="8" y="18" width="355" height="29"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -141,11 +123,11 @@
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="center" spacing="21" translatesAutoresizingMaskIntoConstraints="NO" id="W0M-eq-abZ">
-                                        <rect key="frame" x="65.666666666666686" y="328.33333333333331" width="244" height="302.99999999999994"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="W0M-eq-abZ">
+                                        <rect key="frame" x="77.5" y="302.5" width="220" height="276"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Uqh-o2-7HP">
-                                                <rect key="frame" x="0.0" y="0.0" width="244" height="60"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Uqh-o2-7HP">
+                                                <rect key="frame" x="0.0" y="0.0" width="220" height="60"/>
                                                 <subviews>
                                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BEe-II-qt8">
                                                         <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -160,7 +142,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vRL-nn-bIH">
-                                                        <rect key="frame" x="91.999999999999986" y="0.0" width="60.000000000000014" height="60"/>
+                                                        <rect key="frame" x="80" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="60" id="HaJ-0E-bl3"/>
                                                             <constraint firstAttribute="width" constant="60" id="JJz-zL-t77"/>
@@ -172,7 +154,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m5E-4b-a2B">
-                                                        <rect key="frame" x="184" y="0.0" width="60" height="60"/>
+                                                        <rect key="frame" x="160" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="60" id="9Uy-xG-5Vq"/>
                                                             <constraint firstAttribute="width" constant="60" id="EZw-k5-DP8"/>
@@ -185,8 +167,8 @@
                                                     </button>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Z9D-6N-neq">
-                                                <rect key="frame" x="0.0" y="81" width="244" height="60"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Z9D-6N-neq">
+                                                <rect key="frame" x="0.0" y="72" width="220" height="60"/>
                                                 <subviews>
                                                     <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q2U-ek-vSc">
                                                         <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -201,7 +183,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ziv-SY-nXQ">
-                                                        <rect key="frame" x="91.999999999999986" y="0.0" width="60.000000000000014" height="60"/>
+                                                        <rect key="frame" x="80" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="60" id="5Ry-eq-V0D"/>
                                                             <constraint firstAttribute="height" constant="60" id="iCm-G8-2Us"/>
@@ -213,7 +195,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PNU-iI-oCX">
-                                                        <rect key="frame" x="184" y="0.0" width="60" height="60"/>
+                                                        <rect key="frame" x="160" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="60" id="odD-FC-4eB"/>
                                                             <constraint firstAttribute="height" constant="60" id="zHt-bd-Jwg"/>
@@ -226,8 +208,8 @@
                                                     </button>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="YeU-UN-Uo0">
-                                                <rect key="frame" x="0.0" y="162.00000000000006" width="244" height="60"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="YeU-UN-Uo0">
+                                                <rect key="frame" x="0.0" y="144" width="220" height="60"/>
                                                 <subviews>
                                                     <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lnz-5u-oFb">
                                                         <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -242,7 +224,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="8" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OCE-R0-CMN">
-                                                        <rect key="frame" x="91.999999999999986" y="0.0" width="60.000000000000014" height="60"/>
+                                                        <rect key="frame" x="80" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="60" id="5LE-yh-yoi"/>
                                                             <constraint firstAttribute="height" constant="60" id="65e-mr-hid"/>
@@ -254,7 +236,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="9" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1dz-Qd-zCl">
-                                                        <rect key="frame" x="184" y="0.0" width="60" height="60"/>
+                                                        <rect key="frame" x="160" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="60" id="rS1-XX-Xw9"/>
                                                             <constraint firstAttribute="height" constant="60" id="zza-iD-Oue"/>
@@ -267,8 +249,8 @@
                                                     </button>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Nrp-tS-u1k">
-                                                <rect key="frame" x="0.0" y="243.00000000000006" width="244" height="60"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Nrp-tS-u1k">
+                                                <rect key="frame" x="0.0" y="216" width="220" height="60"/>
                                                 <subviews>
                                                     <button opaque="NO" userInteractionEnabled="NO" tag="-99" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DEv-rc-fGB">
                                                         <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -279,7 +261,7 @@
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="28"/>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sc1-u3-yvh">
-                                                        <rect key="frame" x="91.999999999999986" y="0.0" width="60.000000000000014" height="60"/>
+                                                        <rect key="frame" x="80" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="60" id="DDy-yf-FOR"/>
                                                             <constraint firstAttribute="width" constant="60" id="vSL-tm-biX"/>
@@ -291,7 +273,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="-1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LpO-9j-dlN">
-                                                        <rect key="frame" x="184" y="0.0" width="60" height="60"/>
+                                                        <rect key="frame" x="160" y="0.0" width="60" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="60" id="DAY-CR-kKO"/>
                                                             <constraint firstAttribute="height" constant="60" id="iDt-BW-fEz"/>
@@ -306,31 +288,27 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nCW-ER-9SF" userLabel="Container">
-                                        <rect key="frame" x="67.666666666666686" y="670" width="240" height="48"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CRt-Fb-0Dq">
-                                                <rect key="frame" x="0.0" y="0.0" width="240" height="48"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <state key="normal" title="Forgot PIN"/>
-                                                <connections>
-                                                    <action selector="forgotPinButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="hE4-CJ-Bdh"/>
-                                                </connections>
-                                            </button>
-                                        </subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CRt-Fb-0Dq">
+                                        <rect key="frame" x="146.5" y="598" width="82" height="33"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <state key="normal" title="Forgot PIN"/>
+                                        <connections>
+                                            <action selector="forgotPinButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="hE4-CJ-Bdh"/>
+                                        </connections>
+                                    </button>
+                                    <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N9V-f7-d5k">
+                                        <rect key="frame" x="67.5" y="650" width="240" height="1"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="CRt-Fb-0Dq" firstAttribute="top" secondItem="nCW-ER-9SF" secondAttribute="top" id="QVD-G0-uHm"/>
-                                            <constraint firstAttribute="bottom" secondItem="CRt-Fb-0Dq" secondAttribute="bottom" id="gJw-QQ-7PO"/>
-                                            <constraint firstAttribute="trailing" secondItem="CRt-Fb-0Dq" secondAttribute="trailing" id="gnV-kg-BCW"/>
-                                            <constraint firstAttribute="height" constant="48" id="whx-HV-FXN"/>
-                                            <constraint firstItem="CRt-Fb-0Dq" firstAttribute="leading" secondItem="nCW-ER-9SF" secondAttribute="leading" id="wxI-iX-ugm"/>
+                                            <constraint firstAttribute="height" constant="1" id="oFX-h1-fx7"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="ztg-5t-ECh" secondAttribute="trailing" constant="20" id="ADS-wF-wRi"/>
-                                    <constraint firstItem="ztg-5t-ECh" firstAttribute="leading" secondItem="DMT-DS-IA8" secondAttribute="leading" constant="20" id="YU9-Am-aht"/>
+                                    <constraint firstAttribute="trailing" secondItem="Rn2-qe-htS" secondAttribute="trailing" constant="16" id="WIb-QJ-vx7"/>
+                                    <constraint firstItem="bxI-mu-qng" firstAttribute="leading" secondItem="DMT-DS-IA8" secondAttribute="leading" constant="16" id="cg2-vW-LtI"/>
+                                    <constraint firstAttribute="trailing" secondItem="bxI-mu-qng" secondAttribute="trailing" constant="16" id="j5H-f5-nqY"/>
+                                    <constraint firstItem="Rn2-qe-htS" firstAttribute="leading" secondItem="DMT-DS-IA8" secondAttribute="leading" constant="16" id="y20-NI-Hl0"/>
                                 </constraints>
                             </stackView>
                         </subviews>
@@ -348,6 +326,7 @@
                         <viewLayoutGuide key="safeArea" id="bFg-jh-JZB"/>
                     </view>
                     <connections>
+                        <outlet property="bottomView" destination="N9V-f7-d5k" id="H5X-Px-d4w"/>
                         <outlet property="digitsStackView" destination="W0M-eq-abZ" id="xnb-6w-dtC"/>
                         <outlet property="explanatoryLabel" destination="Rn2-qe-htS" id="8WG-b4-nhE"/>
                         <outlet property="forgotPinButton" destination="CRt-Fb-0Dq" id="kHp-wn-P0o"/>
@@ -364,7 +343,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zK0-v6-7Wt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-3199.1999999999998" y="-648.02955665024638"/>
+            <point key="canvasLocation" x="-3199.1999999999998" y="-648.12593703148434"/>
         </scene>
     </scenes>
     <resources>

--- a/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
+++ b/Riot/Modules/SetPinCode/EnterPinCode/EnterPinCodeViewController.swift
@@ -42,6 +42,7 @@ final class EnterPinCodeViewController: UIViewController {
     @IBOutlet private weak var informationLabel: UILabel!
     @IBOutlet private weak var explanatoryLabel: UILabel!
     @IBOutlet private weak var forgotPinButton: UIButton!
+    @IBOutlet private weak var bottomView: UIView!
     
     // MARK: Private
 
@@ -160,6 +161,11 @@ final class EnterPinCodeViewController: UIViewController {
     }
     
     private func setupViews() {
+        let cancelBarButtonItem = MXKBarButtonItem(title: VectorL10n.cancel, style: .plain) { [weak self] in
+            self?.cancelButtonAction()
+        }
+        
+        self.navigationItem.rightBarButtonItem = cancelBarButtonItem
         showCancelButton()
         
         self.title = ""
@@ -177,15 +183,11 @@ final class EnterPinCodeViewController: UIViewController {
     }
     
     private func showCancelButton() {
-        let cancelBarButtonItem = MXKBarButtonItem(title: VectorL10n.cancel, style: .plain) { [weak self] in
-            self?.cancelButtonAction()
-        }
-        
-        self.navigationItem.rightBarButtonItem = cancelBarButtonItem
+        self.navigationController?.navigationBar.isHidden = false
     }
     
     private func hideCancelButton() {
-        self.navigationItem.rightBarButtonItem = nil
+        self.navigationController?.navigationBar.isHidden = true
     }
     
     private func render(viewState: EnterPinCodeViewState) {
@@ -224,6 +226,7 @@ final class EnterPinCodeViewController: UIViewController {
         self.informationLabel.text = VectorL10n.pinProtectionChoosePin
         self.explanatoryLabel.isHidden = false
         self.forgotPinButton.isHidden = true
+        self.bottomView.isHidden = false
         self.notAllowedPinView.isHidden = true
     }
     
@@ -242,6 +245,7 @@ final class EnterPinCodeViewController: UIViewController {
         self.mainStackView.isHidden = false
         self.logoImageView.isHidden = true
         self.forgotPinButton.isHidden = true
+        self.bottomView.isHidden = false
         self.notAllowedPinView.isHidden = false
         
         renderPlaceholdersCount(.max, error: true)
@@ -273,8 +277,9 @@ final class EnterPinCodeViewController: UIViewController {
         self.mainStackView.isHidden = false
         self.logoImageView.isHidden = false
         self.informationLabel.text = VectorL10n.pinProtectionEnterPin
-        self.explanatoryLabel.text = nil
+        self.explanatoryLabel.isHidden = true
         self.forgotPinButton.isHidden = false
+        self.bottomView.isHidden = true
         self.notAllowedPinView.isHidden = true
     }
     
@@ -282,7 +287,7 @@ final class EnterPinCodeViewController: UIViewController {
         self.inactiveView.isHidden = true
         self.mainStackView.isHidden = false
         self.notAllowedPinView.isHidden = true
-        self.explanatoryLabel.text = nil
+        self.explanatoryLabel.isHidden = true
         self.placeholderStackView.vc_shake()
     }
     
@@ -317,8 +322,9 @@ final class EnterPinCodeViewController: UIViewController {
         self.mainStackView.isHidden = false
         self.logoImageView.isHidden = true
         self.informationLabel.text = VectorL10n.pinProtectionConfirmPinToDisable
-        self.explanatoryLabel.text = nil
+        self.explanatoryLabel.isHidden = true
         self.forgotPinButton.isHidden = true
+        self.bottomView.isHidden = false
         self.notAllowedPinView.isHidden = true
     }
     
@@ -327,7 +333,7 @@ final class EnterPinCodeViewController: UIViewController {
         self.inactiveView.isHidden = false
         self.mainStackView.isHidden = true
         self.notAllowedPinView.isHidden = true
-        self.explanatoryLabel.text = nil
+        self.explanatoryLabel.isHidden = true
     }
     
     private func renderPlaceholdersCount(_ count: Int, error: Bool = false) {


### PR DESCRIPTION
Shrinked spaces a bit for small screens. For 5S, it'll be like:

![Simulator Screen Shot - iPhone 5s - 2020-10-02 at 14 09 00](https://user-images.githubusercontent.com/3072286/94917978-4c920c00-04ba-11eb-8605-b927cbfd37ad.png)
