### PR TITLE
Security screens: Update automatically shields when the trust changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * Room: Make topic links tappable (#3713).
  * Room: Add more to long room topics (#3715).
+ * Security screens: Update automatically shields when the trust changes.
 
 🐛 Bugfix
  * Push: Check crypto has keys to decrypt an event before decryption attempt, avoid sync loops on failure.

--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -114,6 +114,8 @@ enum {
         
     }];
     [self userInterfaceThemeDidChange];
+    
+    [self registerDeviceChangesNotification];
 }
 
 - (void)userInterfaceThemeDidChange
@@ -244,6 +246,29 @@ enum {
         [self reloadData];
         completion();
     }];
+}
+
+
+#pragma mark - Data update
+
+- (void)registerDeviceChangesNotification
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onDeviceInfoTrustLevelDidChangeNotification:)
+                                                 name:MXDeviceInfoTrustLevelDidChangeNotification
+                                               object:nil];
+}
+
+- (void)onDeviceInfoTrustLevelDidChangeNotification:(NSNotification*)notification
+{
+    MXDeviceInfo *deviceInfo = notification.object;
+    
+    NSString *deviceId = deviceInfo.deviceId;
+    if ([deviceId isEqualToString:device.deviceId])
+    {
+        [self reloadDeviceWithCompletion:^{
+        }];
+    }
 }
 
 

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -204,9 +204,11 @@ TableViewSectionsDelegate>
     }];
     [self userInterfaceThemeDidChange];
     
+    [self registerUserDevicesChangesNotification];
+    
     self.tableViewSections = [TableViewSections new];
     self.tableViewSections.delegate = self;
-    
+     
     [self updateSections];
 }
 
@@ -556,6 +558,57 @@ TableViewSectionsDelegate>
     
     // Update table view sections and trigger a tableView reloadData
     [self updateSections];
+}
+
+
+#pragma mark - Data update
+
+- (void)registerUserDevicesChangesNotification
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onDeviceInfoTrustLevelDidChangeNotification:)
+                                                 name:MXDeviceInfoTrustLevelDidChangeNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(crossSigningInfoTrustLevelDidChangeNotification:)
+                                                 name:MXCrossSigningInfoTrustLevelDidChangeNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onDidUpdateUsersDevicesNotification:)
+                                                 name:MXDeviceListDidUpdateUsersDevicesNotification
+                                               object:nil];
+}
+
+- (void)onDidUpdateUsersDevicesNotification:(NSNotification*)notification
+{
+    NSDictionary *usersDevices = notification.userInfo;
+    
+    if ([usersDevices.allKeys containsObject:self.mainSession.myUserId])
+    {
+        [self loadDevices];
+    }
+}
+
+- (void)onDeviceInfoTrustLevelDidChangeNotification:(NSNotification*)notification
+{
+    MXDeviceInfo *deviceInfo = notification.object;
+    
+    NSString *userId = deviceInfo.userId;
+    if ([userId isEqualToString:self.mainSession.myUserId])
+    {
+        [self loadDevices];
+    }
+}
+
+- (void)crossSigningInfoTrustLevelDidChangeNotification:(NSNotification*)notification
+{
+    MXCrossSigningInfo *crossSigningInfo = notification.object;
+    
+    NSString *userId = crossSigningInfo.userId;
+    if ([userId isEqualToString:self.mainSession.myUserId])
+    {
+        [self loadDevices];
+    }
 }
 
 


### PR DESCRIPTION
Before that, a device you just verified stayed red.