### PR TITLE
Cross-signing: Detect when cross-signing keys have been changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * Cross-signing: Detect when cross-signing keys have been changed.
 
 🐛 Bugfix
  * 

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -4282,11 +4282,16 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         return;
     }
     
+    MXWeakify(self);
+
     self.userDidChangeCrossSigningKeysObserver = [NSNotificationCenter.defaultCenter addObserverForName:MXCrossSigningDidChangeCrossSigningKeysNotification
                                                                                                  object:crossSigning
                                                                                                   queue:[NSOperationQueue mainQueue]
                                                                                              usingBlock:^(NSNotification *notification)
                                                   {
+                                                  
+         MXStrongifyAndReturnIfNil(self);
+               
         NSLog(@"[AppDelegate] registerDidChangeCrossSigningKeysNotificationForSession");
         
         if (self.userNewSignInAlertController)

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -227,6 +227,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 @property (nonatomic, weak) id userDidSignInOnNewDeviceObserver;
 @property (weak, nonatomic) UIAlertController *userNewSignInAlertController;
 
+@property (nonatomic, weak) id userDidChangeCrossSigningKeysObserver;
+
 /**
  Related push notification service instance. Will be created when launch finished.
  */
@@ -1772,6 +1774,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
             
             // Register to user new device sign in notification
             [self registerUserDidSignInOnNewDeviceNotificationForSession:mxSession];
+            
+            [self registerDidChangeCrossSigningKeysNotificationForSession:mxSession];
             
             // Register to new key verification request
             [self registerNewRequestNotificationForSession:mxSession];
@@ -4262,6 +4266,29 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     self.userNewSignInAlertController = alert;
 }
+
+
+#pragma mark - Cross-signing reset detection
+
+- (void)registerDidChangeCrossSigningKeysNotificationForSession:(MXSession*)session
+{
+    MXCrossSigning *crossSigning = session.crypto.crossSigning;
+    
+    if (!crossSigning)
+    {
+        return;
+    }
+    
+    self.userDidChangeCrossSigningKeysObserver = [NSNotificationCenter.defaultCenter addObserverForName:MXCrossSigningDidChangeCrossSigningKeysNotification
+                                                                                            object:crossSigning
+                                                                                             queue:[NSOperationQueue mainQueue]
+                                                                                        usingBlock:^(NSNotification *notification)
+                                             {
+        NSLog(@"[AppDelegate] registerDidChangeCrossSigningKeysNotificationForSession");
+        [self.masterTabBarController presentVerifyCurrentSessionAlertIfNeededWithSession:session];
+    }];
+}
+
 
 #pragma mark - Complete security
 


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-sdk/pull/928

When it happens (on a reset), tt displays the verify this session prompt we already have:

<img width="371" alt="Screenshot 2020-10-13 at 15 39 33" src="https://user-images.githubusercontent.com/8418515/95880625-ffdee880-0d77-11eb-892a-0d5359da195c.png">
