### PR TITLE
Analytics: Fix analytics in order to track performance improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changes to be released in next version
  * Update Gemfile.lock.
 
 🐛 Bugfix
- * 
+ * Fix analytics in order to track performance improvements.
 
 ⚠️ API Changes
  * Xcode 12 is now mandatory to build the project.

--- a/Riot/Managers/Analytics/Analytics.m
+++ b/Riot/Managers/Analytics/Analytics.m
@@ -104,7 +104,7 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 
 #ifdef DEBUG
         // Disable analytics in debug as it pollutes stats
-        [MatomoTracker shared].isOptedOut = YES;
+        matomoTracker.isOptedOut = YES;
 #endif
     }
     else

--- a/Riot/Managers/Analytics/Analytics.m
+++ b/Riot/Managers/Analytics/Analytics.m
@@ -32,28 +32,11 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 
 @import MatomoTracker;
 
-@interface MatomoTracker (MatomoTrackerMigration)
-+ (MatomoTracker *)shared;
-
-- (void)migrateFromFourPointFourSharedInstance;
-@end
-
-@implementation MatomoTracker (MatomoTrackerMigration)
-+ (MatomoTracker *)shared
+@interface Analytics ()
 {
-    MatomoTracker *matomoTracker = [[MatomoTracker alloc] initWithSiteId:BuildSettings.analyticsAppId
-                                                                 baseURL:BuildSettings.analyticsServerUrl
-                                                               userAgent:@"iOSMatomoTracker"];
-    [matomoTracker migrateFromFourPointFourSharedInstance];
-    return matomoTracker;
+    MatomoTracker *matomoTracker;
 }
 
-- (void)migrateFromFourPointFourSharedInstance
-{
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"migratedFromFourPointFourSharedInstance"]) return;
-    [self copyFromOldSharedInstance];
-    [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"migratedFromFourPointFourSharedInstance"];
-}
 @end
 
 @implementation Analytics
@@ -70,26 +53,46 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
     return sharedInstance;
 }
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        matomoTracker = [[MatomoTracker alloc] initWithSiteId:BuildSettings.analyticsAppId
+                                                      baseURL:BuildSettings.analyticsServerUrl
+                                                    userAgent:@"iOSMatomoTracker"];
+        [self migrateFromFourPointFourSharedInstance];
+    }
+    return self;
+}
+
+- (void)migrateFromFourPointFourSharedInstance
+{
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"migratedFromFourPointFourSharedInstance"]) return;
+    [matomoTracker copyFromOldSharedInstance];
+    [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"migratedFromFourPointFourSharedInstance"];
+}
+
 - (void)start
 {
     // Check whether the user has enabled the sending of crash reports.
     if (RiotSettings.shared.enableCrashReport)
     {
-        [MatomoTracker shared].isOptedOut = NO;
+        matomoTracker.isOptedOut = NO;
 
-        [[MatomoTracker shared] setCustomVariableWithIndex:1 name:@"App Platform" value:@"iOS Platform"];
-        [[MatomoTracker shared] setCustomVariableWithIndex:2 name:@"App Version" value:[AppDelegate theDelegate].appVersion];
+        [matomoTracker setCustomVariableWithIndex:1 name:@"App Platform" value:@"iOS Platform"];
+        [matomoTracker setCustomVariableWithIndex:2 name:@"App Version" value:[AppDelegate theDelegate].appVersion];
 
         // The language is either the one selected by the user within the app
         // or, else, the one configured by the OS
         NSString *language = [NSBundle mxk_language] ? [NSBundle mxk_language] : [[NSBundle mainBundle] preferredLocalizations][0];
-        [[MatomoTracker shared] setCustomVariableWithIndex:4 name:@"Chosen Language" value:language];
+        [matomoTracker setCustomVariableWithIndex:4 name:@"Chosen Language" value:language];
 
         MXKAccount* account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
         if (account)
         {
-            [[MatomoTracker shared] setCustomVariableWithIndex:7 name:@"Homeserver URL" value:account.mxCredentials.homeServer];
-            [[MatomoTracker shared] setCustomVariableWithIndex:8 name:@"Identity Server URL" value:account.identityServerURL];
+            [matomoTracker setCustomVariableWithIndex:7 name:@"Homeserver URL" value:account.mxCredentials.homeServer];
+            [matomoTracker setCustomVariableWithIndex:8 name:@"Identity Server URL" value:account.identityServerURL];
         }
 
         // TODO: We should also track device and os version
@@ -107,14 +110,14 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
     else
     {
         NSLog(@"[AppDelegate] The user decided to not send analytics");
-        [MatomoTracker shared].isOptedOut = YES;
+        matomoTracker.isOptedOut = YES;
         [MXLogger logCrashes:NO];
     }
 }
 
 - (void)stop
 {
-    [MatomoTracker shared].isOptedOut = YES;
+    matomoTracker.isOptedOut = YES;
     [MXLogger logCrashes:NO];
 }
 
@@ -124,20 +127,20 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
     NSString *appName = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
     NSString *appVersion = [AppDelegate theDelegate].appVersion;
 
-    [[MatomoTracker shared] trackWithView:@[@"ios", appName, appVersion, screenName]
+    [matomoTracker trackWithView:@[@"ios", appName, appVersion, screenName]
                                      url:nil];
 }
 
 - (void)dispatch
 {
-    [[MatomoTracker shared] dispatch];
+    [matomoTracker dispatch];
 }
 
 - (void)trackLaunchScreenDisplayDuration:(NSTimeInterval)seconds
 {
     NSString *action = [NSString stringWithFormat:kAnalyticsMetricsActionPattern, kMXAnalyticsStartupCategory];
 
-    [[MatomoTracker shared] trackWithEventWithCategory:kAnalyticsMetricsCategory
+    [matomoTracker trackWithEventWithCategory:kAnalyticsMetricsCategory
                                                action:action
                                                  name:kMXAnalyticsStartupLaunchScreen
                                                number:@(seconds * 1000)
@@ -150,7 +153,7 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 {
     NSString *action = [NSString stringWithFormat:kAnalyticsMetricsActionPattern, kMXAnalyticsStartupCategory];
 
-    [[MatomoTracker shared] trackWithEventWithCategory:kAnalyticsMetricsCategory
+    [matomoTracker trackWithEventWithCategory:kAnalyticsMetricsCategory
                                                action:action
                                                  name:kMXAnalyticsStartupStorePreload
                                                number:@(seconds * 1000)
@@ -161,7 +164,7 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 {
     NSString *action = [NSString stringWithFormat:kAnalyticsMetricsActionPattern, kMXAnalyticsStartupCategory];
 
-    [[MatomoTracker shared] trackWithEventWithCategory:kAnalyticsMetricsCategory
+    [matomoTracker trackWithEventWithCategory:kAnalyticsMetricsCategory
                                                action:action
                                                  name:kMXAnalyticsStartupMountData
                                                number:@(seconds * 1000)
@@ -172,7 +175,7 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 {
     NSString *action = [NSString stringWithFormat:kAnalyticsMetricsActionPattern, kMXAnalyticsStartupCategory];
 
-    [[MatomoTracker shared] trackWithEventWithCategory:kAnalyticsMetricsCategory
+    [matomoTracker trackWithEventWithCategory:kAnalyticsMetricsCategory
                                                action:action
                                                  name:isInitial ? kMXAnalyticsStartupInititialSync : kMXAnalyticsStartupIncrementalSync
                                                number:@(seconds * 1000)
@@ -183,7 +186,7 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 {
     NSString *action = [NSString stringWithFormat:kAnalyticsMetricsActionPattern, kMXAnalyticsStatsCategory];
 
-    [[MatomoTracker shared] trackWithEventWithCategory:kAnalyticsMetricsCategory
+    [matomoTracker trackWithEventWithCategory:kAnalyticsMetricsCategory
                                                action:action
                                                  name:kMXAnalyticsStatsRooms
                                                number:@(roomCount)
@@ -196,7 +199,7 @@ NSString *const kAnalyticsE2eDecryptionFailureAction = @"Decryption failure";
 {
     for (NSString *reason in failuresCounts)
     {
-        [[MatomoTracker shared] trackWithEventWithCategory:kAnalyticsE2eCategory
+        [matomoTracker trackWithEventWithCategory:kAnalyticsE2eCategory
                                                    action:kAnalyticsE2eDecryptionFailureAction
                                                      name:reason
                                                    number:failuresCounts[reason]


### PR DESCRIPTION
It is probably broken since May 2019 and Matomo 6. Only the first value (StorePreload) was sent.

This PR avoids to create X instances of Matomo but only one.