### PR TITLE
RoomInputToolBar: Prevent long placeholder to be displayed on small devices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Fix analytics in order to track performance improvements.
+ * Fix long placeholder cropping in room input toolbar. Prevent long placeholder to be display on small devices.
 
 ⚠️ API Changes
  * Xcode 12 is now mandatory to build the project.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Fix analytics in order to track performance improvements.
- * Fix long placeholder cropping in room input toolbar. Prevent long placeholder to be display on small devices.
+ * Fix long placeholder cropping in room input toolbar. Prevent long placeholder to be displayed on small devices.
 
 ⚠️ API Changes
  * Xcode 12 is now mandatory to build the project.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Fix analytics in order to track performance improvements.
- * Fix long placeholder cropping in room input toolbar. Prevent long placeholder to be displayed on small devices.
+ * Fix long placeholder cropping in room input toolbar. Prevent long placeholder to be displayed on small devices (#3790).
 
 ⚠️ API Changes
  * Xcode 12 is now mandatory to build the project.

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -132,28 +132,7 @@
 {
     _isEncryptionEnabled = isEncryptionEnabled;
     
-    // Consider the default placeholder
-    NSString *placeholder= NSLocalizedStringFromTable(@"room_message_short_placeholder", @"Vector", nil);
-    
-    if (_isEncryptionEnabled)
-    {
-        // Check the device screen size before using large placeholder
-        if ([GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch)
-        {
-            placeholder = NSLocalizedStringFromTable(@"encrypted_room_message_placeholder", @"Vector", nil);
-        }
-    }
-    else
-    {
-        // Check the device screen size before using large placeholder
-        if ([GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch)
-        {
-            placeholder = NSLocalizedStringFromTable(@"room_message_placeholder", @"Vector", nil);
-        }
-    }
-    
-    
-    self.placeholder = placeholder;
+    [self updatePlaceholder];
 }
 
 - (void)setSendMode:(RoomInputToolbarViewSendMode)sendMode
@@ -192,7 +171,7 @@
     NSString *placeholder;
     
     // Check the device screen size before using large placeholder
-    BOOL shouldDisplayLargePlaceholder = [GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch;
+    BOOL shouldDisplayLargePlaceholder = [GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay5p8Inch;
     
     if (!shouldDisplayLargePlaceholder)
     {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/3790.