### PR TITLE
Use new MXProfiler to get and report accurate durations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
  * Xcode 12: Make Xcode 12 and fastlane(xcodebuild) happy while some pods are not updated.
  * Update Gemfile.lock.
  * MXAnalyticsDelegate: Make it fully agnostic on tracked data.
+ * MXProfiler: Use this new module to track launch animation time reliably.
  * KeyValueStore improvements.
 
 🐛 Bugfix

--- a/Riot/Managers/Analytics/Analytics.h
+++ b/Riot/Managers/Analytics/Analytics.h
@@ -18,6 +18,12 @@
 
 #import <MatrixSDK/MatrixSDK.h>
 
+
+// Metrics related to notifications
+FOUNDATION_EXPORT NSString *const AnalyticsNoficationsCategory;
+FOUNDATION_EXPORT NSString *const AnalyticsNoficationsTimeToDisplayContent;
+
+
 /**
  `Analytics` sends analytics to an analytics tool.
  */

--- a/Riot/Managers/Analytics/Analytics.m
+++ b/Riot/Managers/Analytics/Analytics.m
@@ -19,6 +19,10 @@
 #import "Riot-Swift.h"
 
 
+NSString *const AnalyticsNoficationsCategory = @"notifications";
+NSString *const AnalyticsNoficationsTimeToDisplayContent = @"timelineDisplay";
+
+
 // Duration data will be visible under the Piwik category called "Performance".
 // Other values will be visible in "Metrics".
 // Some Matomo screenshots are available at https://github.com/vector-im/element-ios/pull/3789.

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1109,6 +1109,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 
 - (void)pushNotificationService:(PushNotificationService *)pushNotificationService shouldNavigateToRoomWithId:(NSString *)roomId
 {
+    [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:AnalyticsNoficationsTimeToDisplayContent
+                                                            category:AnalyticsNoficationsCategory];
+    
     _lastNavigatedRoomIdFromPush = roomId;
     [self navigateToRoomById:roomId];
 }

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -204,7 +204,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
      The launch animation container view
      */
     UIView *launchAnimationContainerView;
-    NSDate *launchAnimationStart;
 }
 
 @property (strong, nonatomic) UIAlertController *mxInAppNotification;
@@ -454,9 +453,15 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     _handleSelfVerificationRequest = YES;
     
     // Configure our analytics. It will indeed start if the option is enabled
-    [MXSDKOptions sharedInstance].analyticsDelegate = [Analytics sharedInstance];
+    Analytics *analytics = [Analytics sharedInstance];
+    [MXSDKOptions sharedInstance].analyticsDelegate = analytics;
     [DecryptionFailureTracker sharedInstance].delegate = [Analytics sharedInstance];
-    [[Analytics sharedInstance] start];
+    
+    MXBaseProfiler *profiler = [MXBaseProfiler new];
+    profiler.analytics = analytics;
+    [MXSDKOptions sharedInstance].profiler = profiler;
+    
+    [analytics start];
 
     self.localAuthenticationService = [[LocalAuthenticationService alloc] initWithPinCodePreferences:[PinCodePreferences shared]];
 
@@ -588,6 +593,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     [self.pushNotificationService applicationDidEnterBackground];
     
+    // Pause profiling
+    [MXSDKOptions.sharedInstance.profiler pause];
+    
     // Analytics: Force to send the pending actions
     [[DecryptionFailureTracker sharedInstance] dispatch];
     [[Analytics sharedInstance] dispatch];
@@ -599,6 +607,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
 
+    [MXSDKOptions.sharedInstance.profiler resume];
+    
     // Force each session to refresh here their publicised groups by user dictionary.
     // When these publicised groups are retrieved for a user, they are cached and reused until the app is backgrounded and enters in the foreground again
     for (MXSession *session in mxSessionArray)
@@ -2407,7 +2417,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         [window addSubview:launchLoadingView];
         
         launchAnimationContainerView = launchLoadingView;
-        launchAnimationStart = [NSDate date];
+        
+        [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:kMXAnalyticsStartupLaunchScreen
+                                                        category:kMXAnalyticsStartupCategory];
     }
 }
 
@@ -2415,16 +2427,14 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 {
     if (launchAnimationContainerView)
     {
-        NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:launchAnimationStart];
-        NSLog(@"[AppDelegate] hideLaunchAnimation: LaunchAnimation was shown for %.3fms", duration * 1000);
-        
-        // Track it on our analytics
-        [[MXSDKOptions sharedInstance].analyticsDelegate trackDuration:duration
-                                                              category:kMXAnalyticsStartupCategory
-                                                                  name:kMXAnalyticsStartupLaunchScreen];
-        
-        // TODO: Send durationMs to Piwik
-        // Such information should be the same on all platforms
+        id<MXProfiler> profiler = MXSDKOptions.sharedInstance.profiler;
+        MXTaskProfile *launchTaskProfile = [profiler taskProfileWithName:kMXAnalyticsStartupLaunchScreen category:kMXAnalyticsStartupCategory];
+        if (launchTaskProfile)
+        {
+            [profiler stopMeasuringTaskWithProfile:launchTaskProfile];
+            
+            NSLog(@"[AppDelegate] hideLaunchAnimation: LaunchAnimation was shown for %.3fms", launchTaskProfile.duration * 1000);
+        }
         
         [self->launchAnimationContainerView removeFromSuperview];
         self->launchAnimationContainerView = nil;

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -204,6 +204,9 @@
     
     // Formatted body parser for events
     FormattedBodyParser *formattedBodyParser;
+    
+    // Time to display notification content in the timeline
+    MXTaskProfile *notificationTaskProfile;
 }
 
 @property (nonatomic, weak) IBOutlet UIView *overlayContainerView;
@@ -500,6 +503,9 @@
         [self startActivityIndicator];
         [self.roomDataSource reload];
         [LegacyAppDelegate theDelegate].lastNavigatedRoomIdFromPush = nil;
+        
+        notificationTaskProfile = [MXSDKOptions.sharedInstance.profiler startMeasuringTaskWithName:AnalyticsNoficationsTimeToDisplayContent
+                                                                                          category:AnalyticsNoficationsCategory];
     }
 }
 
@@ -840,6 +846,18 @@
     // Re-enable the read marker display, and disable its update.
     self.roomDataSource.showReadMarker = YES;
     self.updateRoomReadMarker = NO;
+}
+
+- (void)stopActivityIndicator
+{
+    if (notificationTaskProfile)
+    {
+        // Consider here we have displayed the message corresponding to the notification
+        [MXSDKOptions.sharedInstance.profiler stopMeasuringTaskWithProfile:notificationTaskProfile];
+        notificationTaskProfile = nil;
+    }
+    
+    [super stopActivityIndicator];
 }
 
 - (void)displayRoom:(MXKRoomDataSource *)dataSource


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-sdk/pull/941

Durations were corrupted when the app went to background. In this case, the app process is stopped but not the clock. It explains huge values we had for the animation screen.

MXProfiler handles this case now and avoid those crazy values.

This PR provides a new analytic that will be useful to track improvement on #3579.

