### PR TITLE
Improve App Config:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes to be released in next version
  * Empty views: Add empty screen when there is nothing to display on home, people, favourites and rooms screen (#3836).
 
 🐛 Bugfix
- * 
+ * Restore the modular widget events in the rooms histories.
 
 ⚠️ API Changes
  * Slight API changes for SlidingModalPresenter to avoid race conditions while sharing a presenter. (#3842)

--- a/Config/AppConfiguration.swift
+++ b/Config/AppConfiguration.swift
@@ -31,6 +31,10 @@ class AppConfiguration: CommonConfiguration {
         // Enable CallKit for app
         MXKAppSettings.standard()?.isCallKitEnabled = true
         
+        // Get modular widget events in rooms histories
+        MXKAppSettings.standard()?.addSupportedEventTypes([kWidgetMatrixEventTypeString,
+                                                           kWidgetModularEventTypeString])
+        
         // Hide undecryptable messages that were sent while the user was not in the room
         MXKAppSettings.standard()?.hidePreJoinedUndecryptableEvents = true
         

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -25,19 +25,31 @@ final class BuildSettings: NSObject {
     
     // MARK: - Bundle Settings
     static var bundleDisplayName: String {
-        Bundle.app.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+        guard let bundleDisplayName = Bundle.app.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String else {
+            fatalError("CFBundleDisplayName should be defined")
+        }
+        return bundleDisplayName
     }
     
     static var applicationGroupIdentifier: String {
-        Bundle.app.object(forInfoDictionaryKey: "applicationGroupIdentifier") as! String
+        guard let applicationGroupIdentifier = Bundle.app.object(forInfoDictionaryKey: "applicationGroupIdentifier") as? String else {
+            fatalError("applicationGroupIdentifier should be defined")
+        }
+        return applicationGroupIdentifier
     }
     
     static var baseBundleIdentifier: String {
-        Bundle.app.object(forInfoDictionaryKey: "baseBundleIdentifier") as! String
+        guard let baseBundleIdentifier = Bundle.app.object(forInfoDictionaryKey: "baseBundleIdentifier") as? String else {
+            fatalError("baseBundleIdentifier should be defined")
+        }
+        return baseBundleIdentifier
     }
     
     static var keychainAccessGroup: String {
-        Bundle.app.object(forInfoDictionaryKey: "keychainAccessGroup") as! String
+        guard let keychainAccessGroup = Bundle.app.object(forInfoDictionaryKey: "keychainAccessGroup") as? String else {
+            fatalError("keychainAccessGroup should be defined")
+        }
+        return keychainAccessGroup
     }
     
     static var pushKitAppIdProd: String {


### PR DESCRIPTION
- BuildSettings: Fix warnings about some force_cast
- AppConfiguration: Restore modular widget events in rooms histories (they were added previously). I consider we still want them because of this: https://github.com/vector-im/element-ios/blob/develop/Config/AppConfiguration.swift#L57, I may be wrong.
