### PR TITLE
BuildSettings.messageDetailsAllowShare now hide /show action button in document preview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Changes in 1.1.2 (2020-12-02)
 🙌 Improvements
  * Room History: Remove the report option for outgoing messages.
  * Empty views: Add empty screen when there is nothing to display on home, people, favourites and rooms screen (#3836).
+ * BuildSettings.messageDetailsAllowShare now hide /show action button in document preview
 
 🐛 Bugfix
  * Restore the modular widget events in the rooms histories.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ Changes in 1.1.2 (2020-12-02)
 🙌 Improvements
  * Room History: Remove the report option for outgoing messages.
  * Empty views: Add empty screen when there is nothing to display on home, people, favourites and rooms screen (#3836).
- * BuildSettings.messageDetailsAllowShare now hide /show action button in document preview
+ * BuildSettings.messageDetailsAllowShare now hide /show action button in document preview (#3864).
 
 🐛 Bugfix
  * Restore the modular widget events in the rooms histories.

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -294,6 +294,9 @@
     // Listen to the event sent state changes
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventDidChangeSentState:) name:kMXEventDidChangeSentStateNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventDidChangeIdentifier:) name:kMXEventDidChangeIdentifierNotification object:nil];
+    
+    // Show / hide actions button in document preview according BuildSettings
+    self.allowActionsInDocumentPreview = BuildSettings.messageDetailsAllowShare;
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/3864