### PR TITLE
Show user id in the room invite preview screen

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * Show user id in the room invite preview screen (#3839)
 
 🐛 Bugfix
  * 

--- a/Riot/Modules/Room/Views/Title/Preview/PreviewRoomTitleView.m
+++ b/Riot/Modules/Room/Views/Title/Preview/PreviewRoomTitleView.m
@@ -217,7 +217,8 @@
             //                        self.roomMembers.text = nil;
             //                    }
 
-            self.previewLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_invitation_format", @"Vector", nil), inviter];
+            NSString *displayName = [inviter isEqualToString:inviterUserId] ? inviter : [NSString stringWithFormat:@"%@ (%@)", inviter, inviterUserId];
+            self.previewLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_invitation_format", @"Vector", nil), displayName];
         };
 
         [self.mxRoom members:^(MXRoomMembers *roomMembers) {


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/3839