### PR TITLE
Dismiss description textview on user tap on background.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Crash report cannot be submitted (on small phones) #3819
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/BugReport/BugReportViewController.m
+++ b/Riot/Modules/BugReport/BugReportViewController.m
@@ -133,6 +133,9 @@
         
     }];
     [self userInterfaceThemeDidChange];
+    
+    UIGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(backgroundViewTapped)];
+    [self.view addGestureRecognizer:recognizer];
 }
 
 - (void)userInterfaceThemeDidChange
@@ -448,6 +451,11 @@
 - (IBAction)onSendScreenshotTap:(id)sender
 {
     self.sendScreenshot = !self.sendScreenshot;
+}
+
+- (void)backgroundViewTapped {
+    // Dismiss keyboard if user taps on background view: https://github.com/vector-im/element-ios/issues/3819
+    [self.bugReportDescriptionTextView resignFirstResponder];
 }
 
 @end


### PR DESCRIPTION
fix https://github.com/vector-im/element-ios/issues/3819

I cannot do much as the popup is stretched with my iPhone SE (iOS 14) so the usr can tap send button (see screenshot). Nevertheless, the user can now tap on the background view to dismiss the keyboard.

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-12-23 at 14 43 14](https://user-images.githubusercontent.com/15386762/103002766-ce308d80-452f-11eb-918f-a03696fb4a9a.png)
