### PR TITLE
Added iOS version to UserAgent

### DIFF
--- a/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
+++ b/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
@@ -60,7 +60,13 @@ NSString *FallBackViewControllerJavascriptOnLogin = @"window.matrixLogin.onLogin
     
     // Due to https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html, we hack
     // the user agent to bypass the limitation of Google, as a quick fix (a proper solution will be to use the SSO SDK)
-    webView.customUserAgent = @"Mozilla/5.0";
+    // There is a bug in Webkit (fixed in iOS 13), that treats cookies with SameSite=None as SameSite=Strict.
+    // Therefore SSO Server return different Cookie properties, depending on the iOS Version.
+    // (see: https://bugs.webkit.org/show_bug.cgi?id=198181)
+    // The created UserAgent would look like this (on iPhone 6, IOS 12.4): "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4)"
+    NSString *model =  [[UIDevice currentDevice] model];
+    NSString *systemVersion = [[[UIDevice currentDevice] systemVersion] stringByReplacingOccurrencesOfString:@"." withString:@"_"];
+    webView.customUserAgent = [NSString stringWithFormat:@"Mozilla/5.0 (%@; CPU iPhone OS %@)", model, systemVersion];
 
     [self clearCookies];
 }


### PR DESCRIPTION
When using the App on an older iPhone (e.g. iPhone 6 with ios 12) and a custom server, that only accepts SSO, the redirection is not correctly working with this wrong user agent. 
The bug report #3876 describes the Problem. 

There is a bug in Webkit (fixed in iOS 13), that treats cookies with SameSite=None as SameSite=Strict. To overcome this bug SSO Servers return different Cookie properties, depending on the iOS version from the user agent string. I changed the user agent to include the iOS version. 
(see: https://bugs.webkit.org/show_bug.cgi?id=198181)
The created UserAgent would look like this (on iPhone 6, IOS 12.4): "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4)"

I also tested it with google auth and this is still working (it breaks if you remove the custom user agent). I used https://mozilla.modular.im as custom server for testing it. 

I already created an other pull request (#3886 ), but I think this change matches more to this branch.  

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
