### PR TITLE
The Invite cell behaviour is not driven by `MXRoom.isDirect` property…

### DIFF
--- a/Riot/Modules/Common/Recents/RecentsViewController+RoomInvite.swift
+++ b/Riot/Modules/Common/Recents/RecentsViewController+RoomInvite.swift
@@ -19,11 +19,6 @@ import Foundation
 extension RecentsViewController {
     
     @objc func canShowRoomPreview(for room: MXRoom) -> Bool {
-        // Do not show room preview if room is not direct
-        guard room.isDirect else {
-            return false
-        }
-        
         let membershipTransitionState = room.summary.membershipTransitionState
         
         // NOTE: For the moment do not offer the possibility to show room preview when invitation action is in progress

--- a/Riot/Modules/People/Views/InviteRecentTableViewCell.m
+++ b/Riot/Modules/People/Views/InviteRecentTableViewCell.m
@@ -80,11 +80,7 @@ NSString *const kInviteRecentTableViewCellRoomKey = @"kInviteRecentTableViewCell
 
 - (void)onRightButtonPressed:(id)sender
 {
-    MXRoom *room = roomCellData.roomSummary.room;
-    
-    NSString *actionIdentifier = room.isDirect ? kInviteRecentTableViewCellAcceptButtonPressed : kInviteRecentTableViewCellPreviewButtonPressed;
-    
-    [self notifyDelegateWithActionIdentifier:actionIdentifier];
+    [self notifyDelegateWithActionIdentifier:kInviteRecentTableViewCellAcceptButtonPressed];
 }
 
 - (void)notifyDelegateWithActionIdentifier:(NSString*)actionIdentifier


### PR DESCRIPTION
fix #4001