### PR TITLE
Make our Fastfile compatible with all new xcconfig

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes to be released in next version
 🙌 Improvements
  * Podfile: Use MatrixKit for all targets and remove MatrixKit/AppExtension.
  * Fastlane: Use the "New Build System" to build releases.
+ * Fastlane: Re-enable parallelised builds.
 
 🐛 Bugfix
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes to be released in next version
 
 🙌 Improvements
  * Podfile: Use MatrixKit for all targets and remove MatrixKit/AppExtension.
+ * Fastlane: Use the "New Build System" to build releases.
 
 🐛 Bugfix
  * 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * Podfile: Use MatrixKit for all targets and remove MatrixKit/AppExtension.
 
 🐛 Bugfix
  * 

--- a/Podfile
+++ b/Podfile
@@ -32,17 +32,11 @@ $matrixKitVersionSpec = $matrixKitVersion
 $matrixSDKVersionSpec = {}
 end
 
-# Method to import the right MatrixKit flavour
+# Method to import the MatrixKit
 def import_MatrixKit
   pod 'MatrixSDK', $matrixSDKVersionSpec
   pod 'MatrixSDK/JingleCallStack', $matrixSDKVersionSpec
   pod 'MatrixKit', $matrixKitVersionSpec
-end
-
-# Method to import the right MatrixKit/AppExtension flavour
-def import_MatrixKitAppExtension
-  pod 'MatrixSDK', $matrixSDKVersionSpec
-  pod 'MatrixKit/AppExtension', $matrixKitVersionSpec
 end
 
 ########################################
@@ -81,15 +75,15 @@ abstract_target 'RiotPods' do
   end
 
   target "RiotShareExtension" do
-    import_MatrixKitAppExtension
+    import_MatrixKit
   end
 
   target "SiriIntents" do
-    import_MatrixKitAppExtension
+    import_MatrixKit
   end
 
   target "RiotNSE" do
-    import_MatrixKitAppExtension
+    import_MatrixKit
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,11 +30,6 @@ PODS:
     - DTFoundation/DTAnimatedGIF (~> 1.7.5)
     - DTFoundation/DTHTMLParser (~> 1.7.5)
     - DTFoundation/UIKit (~> 1.7.5)
-  - DTCoreText/Extension (1.6.25):
-    - DTFoundation/Core (~> 1.7.5)
-    - DTFoundation/DTAnimatedGIF (~> 1.7.5)
-    - DTFoundation/DTHTMLParser (~> 1.7.5)
-    - DTFoundation/UIKit (~> 1.7.5)
   - DTFoundation/Core (1.7.16)
   - DTFoundation/DTAnimatedGIF (1.7.16)
   - DTFoundation/DTHTMLParser (1.7.16):
@@ -66,13 +61,6 @@ PODS:
     - HPGrowingTextView (~> 1.1)
     - libPhoneNumber-iOS (~> 0.9.13)
     - MatrixKit/Core (= 0.14.0)
-    - MatrixSDK (= 0.18.0)
-  - MatrixKit/AppExtension (0.14.0):
-    - Down (~> 0.9.3)
-    - DTCoreText (~> 1.6.23)
-    - DTCoreText/Extension
-    - HPGrowingTextView (~> 1.1)
-    - libPhoneNumber-iOS (~> 0.9.13)
     - MatrixSDK (= 0.18.0)
   - MatrixKit/Core (0.14.0):
     - Down (~> 0.9.3)
@@ -128,7 +116,6 @@ DEPENDENCIES:
   - KTCenterFlowLayout (~> 1.3.1)
   - MatomoTracker (~> 7.2.2)
   - MatrixKit (= 0.14.0)
-  - MatrixKit/AppExtension (= 0.14.0)
   - MatrixSDK
   - MatrixSDK/JingleCallStack
   - OLMKit
@@ -212,6 +199,6 @@ SPEC CHECKSUMS:
   zxcvbn-ios: fef98b7c80f1512ff0eec47ac1fa399fc00f7e3c
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 911a1ef6f99d67013adcf34808bfb57a57d24886
+PODFILE CHECKSUM: d73c6d43fac29f88f16ed8d6097be2ad049cbc38
 
 COCOAPODS: 1.10.0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,7 +110,6 @@ platform :ios do
     # Generate xcodebuild additional arguments
     xcargs_hash = {
       "GCC_PREPROCESSOR_DEFINITIONS" => "$(GCC_PREPROCESSOR_DEFINITIONS) #{additional_preprocessor_definitions}",
-      "-UseNewBuildSystem" => "NO",
     }
 
     xcargs = xcargs_hash.map { |k, v| "#{k}=#{v.shellescape}" }.join(" ")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,11 +127,6 @@ platform :ios do
     # Update build number
     update_build_number(build_number: build_number)
 
-    # On Xcode 10 with 'Parallelize Build' option on, archive randomly fails with error title "** ARCHIVE FAILED **" for various reasons.
-    # Errors only occur on CocoaPods frameworks and the observed command that failed are CodeSign, CpHeader, CpResource, SetOwnerAndGroup.
-    # To make archive reliable disable 'Parallelize Build' option of scheme ENV["SCHEME"] for the moment.
-    disable_parallelize_builds
-
     # Perform a pod install
     cocoapods(repo_update: true)
 
@@ -300,17 +295,6 @@ platform :ios do
     end
 
     preprocessor_definitions
-  end
-
-  desc "Disable 'Parallelize Build' option of build action of main scheme"
-  private_lane :disable_parallelize_builds do
-    project_path = "../#{ENV["PROJECT_PATH"]}"
-    scheme_name = ENV["SCHEME"]
-
-    scheme_path = Xcodeproj::XCScheme.shared_data_dir(project_path) + "#{scheme_name}.xcscheme"
-    scheme = Xcodeproj::XCScheme.new(scheme_path)
-    scheme.build_action.xml_element.attributes["parallelizeBuildables"] = "NO"
-    scheme.save_as(project_path, scheme_name)
   end
 
   desc "Edit the Podfile in order to point MatrixKit and MatrixSDK to the appropriate branches."


### PR DESCRIPTION
This PR fixes 2 things.
Commits and their descriptions can be reviewed one by one.

1/ We need the `New Build System` introduced Xcode 10 so that $(inherited) in xcconfig files work as expected (https://stackoverflow.com/a/50731052). This is really important now because we moved everything to xcconfigs.

2/ All targets must use the same set of pods in order to build with the `New Build System`. This is a CocoaPods or Apple issue. This workaround is described at https://github.com/CocoaPods/CocoaPods/issues/8206#issuecomment-432252559.

