### PR TITLE
VoIP: Expose Dial Pad only if PSTN Supported

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * User-Interactive Authentication: Add UIA support for device deletion and add user 3PID action (#4016).
 
 🐛 Bugfix
- * 
+ * VoIP: Show dial pad option only if PSTN is supported (#4029).
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -3384,9 +3384,13 @@ NSNotificationName const RoomCallTileTappedNotification = @"RoomCallTileTappedNo
                 {
                     [self roomInputToolbarView:toolbarView placeCallWithVideo2:video];
                 }
-                else
+                else if (self.mainSession.callManager.supportsPSTN)
                 {
                     [self showVoiceCallActionSheetWith:toolbarView];
+                }
+                else
+                {
+                    [self roomInputToolbarView:toolbarView placeCallWithVideo2:NO];
                 }
             }
             else


### PR DESCRIPTION
Fix #4029 