### PR TITLE
Remove extraneous space from string

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -655,7 +655,7 @@ Tap the + to start adding people.";
 "identity_server_settings_add" = "Add";
 "identity_server_settings_change" = "Change";
 
-"identity_server_settings_disconnect_info" = "Disconnecting from your identity server will mean you won’t be discoverable by other users and  be able to invite others by email or phone.";
+"identity_server_settings_disconnect_info" = "Disconnecting from your identity server will mean you won’t be discoverable by other users and be able to invite others by email or phone.";
 "identity_server_settings_disconnect" = "Disconnect";
 
 "identity_server_settings_alert_no_terms_title" = "Identity server has no terms of services";


### PR DESCRIPTION
“and  be” > “and be”

Signed-off-by: Peter Lewis <820394+peterlewis@users.noreply.github.com >

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
