### PR TITLE
EmojiStore: Include short name when searching for emojis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Emoji store: Include short name when searching emojis (#4063).
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Room/EmojiPicker/Data/Store/EmojiStore.swift
+++ b/Riot/Modules/Room/EmojiPicker/Data/Store/EmojiStore.swift
@@ -43,6 +43,10 @@ final class EmojiStore {
                 
                 // Do not use `String.localizedCaseInsensitiveContains` here as EmojiItem data is not localized for the moment
                 
+                if emojiItem.shortName.vc_caseInsensitiveContains(searchText) {
+                    return true
+                }
+
                 if emojiItem.name.vc_caseInsensitiveContains(searchText) {
                     return true
                 }

--- a/RiotTests/EmojiStoreTests.swift
+++ b/RiotTests/EmojiStoreTests.swift
@@ -1,0 +1,72 @@
+/*
+ Copyright 2021 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+
+@testable import Riot
+
+class EmojiStoreTests: XCTestCase {
+
+    private lazy var store = loadStore()
+
+    // MARK: - Tests
+
+    func testFinds💯WhenSearchingForHundred() {
+        find("hundred", expect: "💯")
+    }
+
+    func testFinds💯WhenSearchingFor100() {
+        find("100", expect: "💯")
+    }
+
+    func testFinds2️⃣WhenSearchingForTwo() {
+        find("two", expect: "2️⃣")
+    }
+
+    func testFinds2️⃣WhenSearchingFor2() {
+        find("2", expect: "2️⃣")
+    }
+
+    // MARK: - Helpers
+
+    private func loadStore() -> EmojiStore {
+        let store = EmojiStore()
+        let emojiService = EmojiMartService()
+        let expectation = self.expectation(description: "The wai-ai-ting is the hardest part")
+
+        emojiService.getEmojiCategories { response in
+            switch response {
+            case .success(let categories):
+                store.set(categories)
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail("Failed to load emojis: \(error)")
+            }
+        }
+
+        waitForExpectations(timeout: 2) { error in
+            XCTAssertNil(error)
+        }
+
+        return store
+    }
+
+    private func find(_ searchText: String, expect emoji: String) {
+        let emojis = store.findEmojiItemsSortedByCategory(with: searchText).flatMap { $0.emojis.map { $0.value } }
+        XCTAssert(emojis.contains(emoji), "Search text \"\(searchText)\" should find \"\(emoji)\" but only found \(emojis)")
+    }
+
+}


### PR DESCRIPTION
This adds the "common" short name to the list of strings to match the search text against. Previously, only the "other" short names were included in the comparison. This causes an issue for certain emojis like, for instance, the "Hundred Points Symbol" where the term "100" is *only* included in the common short name. As a result, the emoji did not previously show up when searching for "100".

Note that as a side effect, searching for "2" will now also return things such as the "dog2" emoji. This matches the behavior in the Element Android app and also in the emoji-mart Node.js package.

**Before**

<img src="https://user-images.githubusercontent.com/1137962/110161208-57e0bf00-7ded-11eb-886a-842919014624.png" alt="before-100" width="200px">   <img src="https://user-images.githubusercontent.com/1137962/110161203-57482880-7ded-11eb-8c52-ea936292de88.png" alt="before-2" width="200px">

**After**

<img src="https://user-images.githubusercontent.com/1137962/110161188-52837480-7ded-11eb-9a27-6ff1f1641cba.png" alt="after-100" width="200px">   <img src="https://user-images.githubusercontent.com/1137962/110161182-4f888400-7ded-11eb-8ebe-fc5ac6f2f46b.png" alt="after-2" width="200px">

Closes: #4063

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
