### PR TITLE
Do not connect to clients3.google.com every 60 seconds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -130,6 +130,9 @@ platform :ios do
     # Perform a pod install
     cocoapods(repo_update: true)
 
+    # Workaround for https://github.com/vector-im/element-ios/issues/3190
+    rewrite_react_native_netinfo_reachability
+
     # Select a config
     if adhoc
       export_method = "ad-hoc"
@@ -335,6 +338,17 @@ platform :ios do
     list.split("\n")
         .map { |line| line.sub(%r{[0-9a-f]+\trefs/heads/}, '').chomp }
         .last # Latest ref found, in "version:refname" semantic order
+  end
+
+  desc "Rewrite react-native-netinfo internet reachability url"
+  private_lane :rewrite_react_native_netinfo_reachability do
+      reachability_url = ENV['REACHABILITY_URL']
+
+      if reachability_url.to_s.empty?
+          reachability_url = "https://app.element.io/"
+      end
+
+      sh("sed", "-i.bak", "s,https://clients3.google.com/generate_204,#{reachability_url},g", "../Pods/JitsiMeetSDK/Frameworks/JitsiMeetSDK.xcframework/ios-arm64/JitsiMeetSDK.framework/main.jsbundle")
   end
 end
 


### PR DESCRIPTION
Workaround for https://github.com/vector-im/element-ios/issues/3190,
better adjust to a element.io URL that only generates empty 204 instead of 5KB download

### Pull Request Checklist

* [X] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [X] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

Signed-off-by: Christoph Settgast <csett86@web.de>