### PR TITLE
Show target user avatars for collapsed membership changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes to be released in next version
  * 
 
 🙌 Improvements
- * 
+ * Show target user avatars for collapsed membership changes (#4102).
 
 🐛 Bugfix
  * 

--- a/Riot/Modules/Room/Views/BubbleCells/RoomMembershipCollapsedBubbleCell.m
+++ b/Riot/Modules/Room/Views/BubbleCells/RoomMembershipCollapsedBubbleCell.m
@@ -70,18 +70,18 @@
         // Handle user's picture by considering it is stored unencrypted on Matrix media repository
         
         // Use the Riot style placeholder
-        if (!nextBubbleData.senderAvatarPlaceholder)
+        if (!nextBubbleData.targetAvatarPlaceholder)
         {
-            nextBubbleData.senderAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.senderId withDisplayName:nextBubbleData.senderDisplayName];
+            nextBubbleData.targetAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.targetId withDisplayName:nextBubbleData.targetDisplayName];
         }
         
         avatarView.enableInMemoryCache = YES;
-        [avatarView setImageURI:nextBubbleData.senderAvatarUrl
+        [avatarView setImageURI:nextBubbleData.targetAvatarUrl
                        withType:nil
             andImageOrientation:UIImageOrientationUp
                   toFitViewSize:avatarView.frame.size
                      withMethod:MXThumbnailingMethodCrop
-                   previewImage:nextBubbleData.senderAvatarPlaceholder
+                   previewImage:nextBubbleData.targetAvatarPlaceholder
                    mediaManager:nextBubbleData.mxSession.mediaManager];
 
         // Clear the default background color of a MXKImageView instance


### PR DESCRIPTION
This commit switches to displaying the target user's avatar for collapsed membership changes which addresses the avatar issue reported in #4102.

This now brings the avatar display on par with the Element web app. Collapsed membership changes use the target avatar, expanded changes use the sender avatar. Note that the web app currently still has more sophisticated logic around combining membership changes (e.g. "... invited and joined") which allows it to show less collapsed avatars in certain cases.

![Screenshot 2021-03-25 at 10 38 26](https://user-images.githubusercontent.com/1137962/112455458-06778000-8d5a-11eb-954b-c4ac888def37.png)

Depends on: matrix-org/matrix-ios-kit#793

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
