### PR TITLE
Fix memory leak in [RecentsDataSource dataSource:didStateChange:]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changes to be released in next version
  * Black theme uses dark background for composer (#4192)
  * Vertical layout of typing notifs can go wonky (#4159)
  * Crash in [RoomViewController refreshTypingNotification] (#4161)
+ * Memory leak in [RecentsDataSource dataSource:didStateChange:]
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -337,8 +337,11 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
         if ((aState == MXKDataSourceStateReady) && dataSource.mxSession.myUser.userId)
         {
             // Register the room tags updates to refresh the favorites order
+            MXWeakify(self);
             id roomTagsListener = [dataSource.mxSession listenToEventsOfTypes:@[kMXEventTypeStringRoomTag]
                                                                 onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
+
+                                                                    MXStrongifyAndReturnIfNil(self);
 
                                                                     // Consider only live event
                                                                     if (direction == MXTimelineDirectionForwards)


### PR DESCRIPTION
The block passed into `[MXSession listenToEventsOfTypes:onEvent:]` is stored with a strong reference in the `listenerBlock` property of `MXSessionEventListener`. The method also returns the listener and it is then stored into the `roomTagsListenerByUserId` dictionary on `self`. Since a strong reference to `self` is captured in the block that means the block retains `self` (via the capture) and `self` retains the block (via `roomTagsListenerByUserId`) so there is a memory leak.

The bug is most easily reproduced during testing #4168 which involves closing the current and creating a new session.

![Screenshot 2021-04-08 at 20 39 24](https://user-images.githubusercontent.com/1137962/114081014-56069180-98ac-11eb-9dcd-232cd3f8670d.png)

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
