### PR TITLE
Self-verification: Fix compatibility with Element-Web

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Self-verification: Fix compatibility with Element-Web (#4217).
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -3975,7 +3975,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         }
     };
 
-    /// ooo
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"key_verification_tile_request_incoming_title", @"Vector", nil)
                                                                                              message:senderInfo
                                                                                       preferredStyle:UIAlertControllerStyleAlert];

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -4113,7 +4113,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
      
     [self presentViewController:alert animated:YES completion:nil];
     
-    //// ooo
     self.userNewSignInAlertController = alert;
 }
 

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -3934,6 +3934,18 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         [self.incomingKeyVerificationRequestAlertController dismissViewControllerAnimated:NO completion:nil];
     }
     
+    if (self.userNewSignInAlertController
+        && [session.myUserId isEqualToString:senderId])
+    {
+        // If it is a self verification for my device, we can discard the new signin alert.
+        // Note: It will not work well with several devices to verify at the same time.
+        NSLog(@"[AppDelegate] presentNewKeyVerificationRequest: Remove the alert for new sign in detected");
+        [self.userNewSignInAlertController dismissViewControllerAnimated:NO completion:^{
+            self.userNewSignInAlertController = nil;
+            [self presentNewKeyVerificationRequestAlertForSession:session senderName:senderName senderId:senderId request:keyVerificationRequest];
+        }];
+    }
+    
     NSString *senderInfo;
     
     if (senderName)
@@ -3955,7 +3967,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         }
     };
 
-    
+    /// ooo
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"key_verification_tile_request_incoming_title", @"Vector", nil)
                                                                                              message:senderInfo
                                                                                       preferredStyle:UIAlertControllerStyleAlert];
@@ -4093,6 +4105,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
      
     [self presentViewController:alert animated:YES completion:nil];
     
+    //// ooo
     self.userNewSignInAlertController = alert;
 }
 

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
@@ -91,6 +91,21 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
         } else {
             //  be sure that session has completed its first sync
             if session.state >= MXSessionStateRunning {
+                
+                // Always send request instead of waiting for an incoming one as per recent EW changes
+                print("[KeyVerificationSelfVerifyWaitViewModel] loadData: Send a verification request to all devices instead of waiting")
+                
+                let keyVerificationService = KeyVerificationService()
+                self.verificationManager.requestVerificationByToDevice(withUserId: self.session.myUserId, deviceIds: nil, methods: keyVerificationService.supportedKeyVerificationMethods(), success: { [weak self] (keyVerificationRequest) in
+                    guard let self = self else {
+                        return
+                    }
+                    
+                    self.keyVerificationRequest = keyVerificationRequest
+                    
+                }, failure: { [weak self] error in
+                    self?.update(viewState: .error(error))
+                })
                 continueLoadData()
             } else {
                 //  show loader


### PR DESCRIPTION
Fix #4217

The change is similar as for EA: https://github.com/vector-im/element-android/pull/3140. We had the same failures as android.

It just makes the flow work. UX and even wording need more work but we need to fix all platform.

Tests in both direction
- 👍  iOS vs web with small account. Known issue: the QR option is not proposed on iOS
- 👍  iOS vs android
- 👍 👎  iOS vs web with my real account: verification works but secrets cannot be shared - this is not a new issue.
