### PR TITLE
Notifications: Fix sender display name that can miss

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * Self-verification: Fix compatibility with Element-Web (#4217).
+ * Notifications: Fix sender display name that can miss (#4222). 
 
 ⚠️ API Changes
  * 


### PR DESCRIPTION
Fix #4222

Require https://github.com/matrix-org/matrix-ios-sdk/pull/1073.

Review without whitespace changes. There is reindentation in this PR.