### PR TITLE
UserSessionsService: Fix room lists lost after a reset cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * SettingsViewController: Fix crash when changing the app language (#4377).
+ * UserSessionsService: Fix room lists lost after a reset cache (#4395).
 
 ⚠️ API Changes
  * 

--- a/Riot/Managers/UserSessions/UserSessionsService.swift
+++ b/Riot/Managers/UserSessions/UserSessionsService.swift
@@ -70,6 +70,18 @@ class UserSessionsService: NSObject {
         self.removeUserSession(relatedToAccount: account, postNotification: true)
     }
     
+    func removeUserSession(relatedToMatrixSession matrixSession: MXSession) {
+        let foundUserSession = self.userSessions.first { (userSession) -> Bool in
+            userSession.matrixSession == matrixSession
+        }
+        
+        guard let userSessionToRemove = foundUserSession else {
+            return
+        }
+        
+        self.removeUserSession(relatedToAccount: userSessionToRemove.account)
+    }
+    
     func isUserSessionExists(withUserId userId: String) -> Bool {
         return self.userSessions.contains { (userSession) -> Bool in
             return userSession.userId == userId

--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -139,6 +139,8 @@ extension AppCoordinator: LegacyAppDelegateDelegate {
     }
     
     func legacyAppDelegate(_ legacyAppDelegate: LegacyAppDelegate!, didRemoveMatrixSession session: MXSession!) {
+        // Handle user session removal on clear cache. On clear cache the account has his session closed but the account is not removed.
+        self.userSessionsService.removeUserSession(relatedToMatrixSession: session)
     }
     
     func legacyAppDelegate(_ legacyAppDelegate: LegacyAppDelegate!, didAdd account: MXKAccount!) {

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -34,7 +34,7 @@
 @interface MasterTabBarController () <AuthenticationViewControllerDelegate>
 {
     // Array of `MXSession` instances.
-    NSMutableArray *mxSessionArray;    
+    NSMutableArray<MXSession*> *mxSessionArray;    
     
     // Tell whether the authentication screen is preparing.
     BOOL isAuthViewControllerPreparing;
@@ -284,7 +284,7 @@
 
 #pragma mark -
 
-- (NSArray*)mxSessions
+- (NSArray<MXSession*>*)mxSessions
 {
     return [NSArray arrayWithArray:mxSessionArray];
 }
@@ -339,7 +339,7 @@
         [self.groupsViewController displayList:groupsDataSource];
         
         // Check whether there are others sessions
-        NSArray* mxSessions = self.mxSessions;
+        NSArray<MXSession*>* mxSessions = self.mxSessions;
         if (mxSessions.count > 1)
         {
             for (MXSession *mxSession in mxSessions)

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -356,6 +356,12 @@
 
 - (void)addMatrixSession:(MXSession *)mxSession
 {
+    if ([mxSessionArray containsObject:mxSession])
+    {
+        MXLogDebug(@"MasterTabBarController already has %@ in mxSessionArray", mxSession)
+        return;
+    }
+    
     // Check whether the controller's view is loaded into memory.
     if (self.homeViewController)
     {
@@ -394,6 +400,12 @@
 
 - (void)removeMatrixSession:(MXSession *)mxSession
 {
+    if (![mxSessionArray containsObject:mxSession])
+    {
+        MXLogDebug(@"MasterTabBarController does not contain %@ in mxSessionArray", mxSession)
+        return;
+    }
+    
     [recentsDataSource removeMatrixSession:mxSession];
     
     // Check whether there are others sessions

--- a/Riot/Modules/TabBar/TabBarCoordinator.swift
+++ b/Riot/Modules/TabBar/TabBarCoordinator.swift
@@ -291,18 +291,12 @@ final class TabBarCoordinator: NSObject, TabBarCoordinatorType {
     
     // TODO: Remove Matrix session handling from the view controller
     private func addMatrixSessionToMasterTabBarController(_ matrixSession: MXSession) {
-        guard self.masterTabBarController.mxSessions.contains(matrixSession) == false else {
-            return
-        }
         MXLog.debug("[TabBarCoordinator] masterTabBarController.addMatrixSession")
         self.masterTabBarController.addMatrixSession(matrixSession)
     }
     
     // TODO: Remove Matrix session handling from the view controller
     private func removeMatrixSessionFromMasterTabBarController(_ matrixSession: MXSession) {
-        guard self.masterTabBarController.mxSessions.contains(matrixSession) else {
-            return
-        }
         MXLog.debug("[TabBarCoordinator] masterTabBarController.removeMatrixSession")
         self.masterTabBarController.removeMatrixSession(matrixSession)
     }


### PR DESCRIPTION
Fix #4395 

FTR: A crash occurred in `TabBarCoordinator` with `self.masterTabBarController.mxSessions.contains(matrixSession)` due to a Xcode 12.5 runtime issue with Objective-C interoperability, more information here >  https://forums.swift.org/t/objective-c-interoperability-type-mismatch/12464