### PR TITLE
GH Actions: Make sure we use the latest version of MatrixKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      # Make sure we use the latest version of MatrixKit
+      - name: Reset MatrixKit pod
+        run: rm -rf Pods/MatrixKit
+
       # Common setup
       # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job
       - name: Bundle install
@@ -71,6 +75,10 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
+
+      # Make sure we use the latest version of MatrixKit
+      - name: Reset MatrixKit pod
+        run: rm -rf Pods/MatrixKit
 
       # Common setup
       # Note: GH actions do not support yaml anchor yet. We need to duplicate this for every job

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ DerivedData
 *.xcuserstate
 out/
 .vscode/
+vendor/
 
 # CocoaPods
 #

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Changes to be released in next version
  * 
     
 🧱 Build
- * 
+ * GH Actions: Make sure we use the latest version of MatrixKit.
 
 Others
  *


### PR DESCRIPTION
We use a local version of the MatrixKit podspec, MatrixKit.edited.podspec. This creates an issue in the computation of Podfile.lock. MatrixKit is not associated to a commit. `pod install` will be happy with its marketing version. It will not try to update if this marketing version matches with the one in the cache.

So delete the MatrixKit pod cache.

Generated Podfile.lock:
```
...
EXTERNAL SOURCES:
  MatrixKit:
    :podspec: MatrixKit.edited.podspec
  MatrixSDK:
    :branch: manu/test_ci_2
    :git: https://github.com/matrix-org/matrix-ios-sdk.git

CHECKOUT OPTIONS:
  MatrixSDK:
    :commit: 32614df19df3ef43e77f25a06ddb0b04e910f90b
    :git: https://github.com/matrix-org/matrix-ios-sdk.git
...
```