### PR TITLE
iPad Crashes when you select a contact in search and then collapse a section or clear the query text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changes to be released in next version
 🐛 Bugfix
  * RoomDirectCallStatusBubbleCell: Fix crash when entering a DM after a call is hung-up/rejected while being answered (#4403).
  * ContactsDataSource: iPad Crashes when you select a contact in search and then collapse a section or clear the query text (#4414).
+ 
 ⚠️ API Changes
  * 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes to be released in next version
 
 🐛 Bugfix
  * RoomDirectCallStatusBubbleCell: Fix crash when entering a DM after a call is hung-up/rejected while being answered (#4403).
-
+ * ContactsDataSource: iPad Crashes when you select a contact in search and then collapse a section or clear the query text (#4414).
 ⚠️ API Changes
  * 
 

--- a/Riot/Modules/Contacts/DataSources/ContactsDataSource.m
+++ b/Riot/Modules/Contacts/DataSources/ContactsDataSource.m
@@ -688,12 +688,16 @@
     NSUInteger index = [filteredLocalContacts indexOfObject:contact];
     if (index != NSNotFound)
     {
-        indexPath = [NSIndexPath indexPathForRow:index inSection:filteredLocalContactsSection];
+        // if local section is collapsed there is no cell
+        if (!(shrinkedSectionsBitMask & CONTACTSDATASOURCE_LOCALCONTACTS_BITWISE)) {
+            indexPath = [NSIndexPath indexPathForRow:index inSection:filteredLocalContactsSection];
+        }
     }
     else
     {
         index = [filteredMatrixContacts indexOfObject:contact];
-        if (index != NSNotFound)
+        // if matrix section is collapsed or we are not showing the matrix section(as with empty query) there is no cell
+        if (index != NSNotFound && !(shrinkedSectionsBitMask & CONTACTSDATASOURCE_USERDIRECTORY_BITWISE) && filteredMatrixContactsSection != -1)
         {
             indexPath = [NSIndexPath indexPathForRow:index inSection:filteredMatrixContactsSection];
         }


### PR DESCRIPTION
Fixes #4414 
