### PR TITLE
Tweak auto theme message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ Changes to be released in next version
  * StartChatViewController: Add more helpful message when trying to start DM with a user that does not exist (#224).
  * RoomDirectCallStatusBubbleCell: Fix crash when entering a DM after a call is hung-up/rejected while being answered (#4403).
  * ContactsDataSource: iPad Crashes when you select a contact in search and then collapse a section or clear the query text (#4414).
- 
+ * SettingsViewController: Fix "auto" theme message to clarify that it matches the system theme on iOS 13+ (#2860).
+
 ⚠️ API Changes
  * 
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -520,7 +520,8 @@ Tap the + to start adding people.";
 "settings_ui_theme_dark" = "Dark";
 "settings_ui_theme_black" = "Black";
 "settings_ui_theme_picker_title" = "Select a theme";
-"settings_ui_theme_picker_message" = "\"Auto\" uses your device \"Invert Colours\" settings";
+"settings_ui_theme_picker_message_invert_colours" = "\"Auto\" uses your device's \"Invert Colours\" settings";
+"settings_ui_theme_picker_message_match_system_theme" = "\"Auto\" matches your device's system theme";
 
 "settings_unignore_user" = "Show all messages from %@?";
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4458,9 +4458,13 @@ internal enum VectorL10n {
   internal static var settingsUiThemeLight: String { 
     return VectorL10n.tr("Vector", "settings_ui_theme_light") 
   }
-  /// "Auto" uses your device "Invert Colours" settings
-  internal static var settingsUiThemePickerMessage: String { 
-    return VectorL10n.tr("Vector", "settings_ui_theme_picker_message") 
+  /// "Auto" uses your device's "Invert Colours" settings
+  internal static var settingsUiThemePickerMessageInvertColours: String { 
+    return VectorL10n.tr("Vector", "settings_ui_theme_picker_message_invert_colours") 
+  }
+  /// "Auto" matches your device's system theme
+  internal static var settingsUiThemePickerMessageMatchSystemTheme: String { 
+    return VectorL10n.tr("Vector", "settings_ui_theme_picker_message_match_system_theme") 
   }
   /// Select a theme
   internal static var settingsUiThemePickerTitle: String { 

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -3571,9 +3571,18 @@ TableViewSectionsDelegate>
     autoAction = [UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"settings_ui_theme_auto", @"Vector", nil)
                                           style:UIAlertActionStyleDefault
                                         handler:actionBlock];
-    
+
     // Explain what is "auto"
-    themePickerMessage = NSLocalizedStringFromTable(@"settings_ui_theme_picker_message", @"Vector", nil);  
+    if (@available(iOS 13, *))
+    {
+        // Observe application did become active for iOS appearance setting changes
+        themePickerMessage = NSLocalizedStringFromTable(@"settings_ui_theme_picker_message_match_system_theme", @"Vector", nil);
+    }
+    else
+    {
+        // Observe "Invert Colours" settings changes (available since iOS 11)
+        themePickerMessage = NSLocalizedStringFromTable(@"settings_ui_theme_picker_message_invert_colours", @"Vector", nil);
+    }
 
     lightAction = [UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"settings_ui_theme_light", @"Vector", nil)
                                           style:UIAlertActionStyleDefault


### PR DESCRIPTION
This updates the auto theme explanation to make it more obvious that it follows
the system theme when on iOS 13+.

![image](https://user-images.githubusercontent.com/279572/121604582-b9df3f00-ca42-11eb-9522-e938305e979f.png)

Fixes https://github.com/vector-im/element-ios/issues/2860