### PR TITLE
Room lists: Avoid app freezes by building them on a separated thread

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changes to be released in next version
  * Security settings: The Secure backup section has been updated to match element-web UX (#4430).
  * Wording: Replace Recovery Passphrase and Recovery Key by Security Phrase and Security Key (#4268).
  * Room directory: Join room by alias or id (#4429).
+ * Room lists: Avoid app freezes by building them on a separated thread (#3777).
 
 🐛 Bugfix
  * StartChatViewController: Add more helpful message when trying to start DM with a user that does not exist (#224).

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -74,7 +74,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     self = [super init];
     if (self)
     {
-        processingQueue = dispatch_queue_create("MXRestClient", DISPATCH_QUEUE_SERIAL);
+        processingQueue = dispatch_queue_create("RecentsDataSource", DISPATCH_QUEUE_SERIAL);
         
         _crossSigningBannerDisplay = CrossSigningBannerDisplayNone;
         crossSigningBannerSection = -1;

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSourceState.swift
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSourceState.swift
@@ -1,0 +1,79 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// The state for a room list screens.
+@objcMembers
+class RecentsDataSourceState: NSObject {
+    
+    // MARK: - Properties
+    
+    // MARK: Cells
+    let invitesCellDataArray: [MXKRecentCellDataStoring]
+    let favoriteCellDataArray: [MXKRecentCellDataStoring]
+    let peopleCellDataArray: [MXKRecentCellDataStoring]
+    let conversationCellDataArray: [MXKRecentCellDataStoring]
+    let lowPriorityCellDataArray: [MXKRecentCellDataStoring]
+    let serverNoticeCellDataArray: [MXKRecentCellDataStoring]
+    
+    // MARK: Notifications counts
+    let favouriteMissedDiscussionsCount: MissedDiscussionsCount
+    let directMissedDiscussionsCount: MissedDiscussionsCount
+    let groupMissedDiscussionsCount: MissedDiscussionsCount
+    
+    // MARK: Unsent counts
+    let unsentMessagesDirectDiscussionsCount: UInt
+    let unsentMessagesGroupDiscussionsCount: UInt
+    
+    
+    // MARK: - Setup
+    init(invitesCellDataArray: [MXKRecentCellDataStoring],
+         favoriteCellDataArray: [MXKRecentCellDataStoring],
+         peopleCellDataArray: [MXKRecentCellDataStoring],
+         conversationCellDataArray: [MXKRecentCellDataStoring],
+         lowPriorityCellDataArray: [MXKRecentCellDataStoring],
+         serverNoticeCellDataArray: [MXKRecentCellDataStoring],
+         favouriteMissedDiscussionsCount: MissedDiscussionsCount,
+         directMissedDiscussionsCount: MissedDiscussionsCount,
+         groupMissedDiscussionsCount: MissedDiscussionsCount,
+         unsentMessagesDirectDiscussionsCount: UInt,
+         unsentMessagesGroupDiscussionsCount: UInt) {
+        self.invitesCellDataArray = invitesCellDataArray
+        self.favoriteCellDataArray = favoriteCellDataArray
+        self.peopleCellDataArray = peopleCellDataArray
+        self.conversationCellDataArray = conversationCellDataArray
+        self.lowPriorityCellDataArray = lowPriorityCellDataArray
+        self.serverNoticeCellDataArray = serverNoticeCellDataArray
+        self.favouriteMissedDiscussionsCount = favouriteMissedDiscussionsCount
+        self.directMissedDiscussionsCount = directMissedDiscussionsCount
+        self.groupMissedDiscussionsCount = groupMissedDiscussionsCount
+        self.unsentMessagesDirectDiscussionsCount = unsentMessagesDirectDiscussionsCount
+        self.unsentMessagesGroupDiscussionsCount = unsentMessagesGroupDiscussionsCount
+        super.init()
+    }
+}
+
+
+/// Noticiations counts per section
+@objcMembers
+class MissedDiscussionsCount: NSObject {
+    /// Regular notifications
+    var count: UInt = 0
+    
+    /// Mentions like notications
+    var highlightCount: UInt = 0
+}


### PR DESCRIPTION
Partial fix for #3777.

List computation is surprisingly shorter. It varies from 50 to 150ms on my account. It used to 200ms every time.
This is still slow but it is done now in a separate thread.

Must be reviewed by ignoring white spaces.


