### PR TITLE
Fix retain cycle between the RoomTitleView (strong tapGestureDelegate…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * Room lists: Hide invited rooms if auto-accept option enabled.
 
 🐛 Bugfix
- * 
+ * Fixed retain cycle between the RoomTitleView and RoomViewController
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Room/Views/Title/RoomTitleView.h
+++ b/Riot/Modules/Room/Views/Title/RoomTitleView.h
@@ -55,7 +55,7 @@
 /**
  The tap gesture delegate.
  */
-@property (nonatomic) id<RoomTitleViewTapGestureDelegate> tapGestureDelegate;
+@property (weak, nonatomic) id<RoomTitleViewTapGestureDelegate> tapGestureDelegate;
 
 /**
  the typing notification string to be displayed (default nil if notification is hidden).


### PR DESCRIPTION
…) and the RoomViewController.