### PR TITLE
Fix crash when running on macOS with Apple Silicon.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes to be released in next version
  * 
 
 🐛 Bugfix
- * 
+ * Fix crash on Apple Silicon Macs.
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -351,6 +351,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     NSURL *messageSoundURL = [[NSBundle mainBundle] URLForResource:@"message" withExtension:@"caf"];
     AudioServicesCreateSystemSoundID((__bridge CFURLRef)messageSoundURL, &_messageSound);
     
+    // Set app info now as Mac (Designed for iPad) accesses it before didFinishLaunching is called
+    self.appInfo = AppInfo.current;
+    
     MXLogDebug(@"[AppDelegate] willFinishLaunchingWithOptions: Done");
 
     return YES;
@@ -370,8 +373,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     MXLogDebug(@"[AppDelegate] didFinishLaunchingWithOptions: isProtectedDataAvailable: %@", @([application isProtectedDataAvailable]));
 
     _configuration = [AppConfiguration new];
-    
-    self.appInfo = AppInfo.current;
     
     // Log app information
     NSString *appDisplayName = self.appInfo.displayName;


### PR DESCRIPTION
The app was crashing on launch when running on macOS with an M1 Mac.

It turns out that `viewDidLoad` is getting called before `applicationDidFinishLaunching` on macOS and so `Analytics` was requesting the app's version before it had been set.