### PR TITLE
Fix duplicate results in the rooms directory.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes to be released in next version
  * More fixes to Main.storyboard layout on iPhone 12 Pro Max (#4527)
  * Fix crash on Apple Silicon Macs.
  * Media Picker: Generate video thumbnails with the correct orientation (#4515).
+ * Directory List (pop-up one): Fix duplicate rooms being shown (#4537).
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/GlobalSearch/Views/DirectoryRecentTableViewCell.m
+++ b/Riot/Modules/GlobalSearch/Views/DirectoryRecentTableViewCell.m
@@ -54,20 +54,20 @@
                 self.titleLabel.text = NSLocalizedStringFromTable(@"directory_search_results_title", @"Vector", nil);
 
                 // Do we need to display like ">20 results found" or "18 results found"?
-                NSString *descriptionLabel = (publicRoomsDirectoryDataSource.moreThanRoomsCount && publicRoomsDirectoryDataSource.roomsCount > 0) ? NSLocalizedStringFromTable(@"directory_search_results_more_than", @"Vector", nil) : NSLocalizedStringFromTable(@"directory_search_results", @"Vector", nil);
+                NSString *descriptionLabel = (publicRoomsDirectoryDataSource.searchResultsCountIsLimited && publicRoomsDirectoryDataSource.searchResultsCount > 0) ? NSLocalizedStringFromTable(@"directory_search_results_more_than", @"Vector", nil) : NSLocalizedStringFromTable(@"directory_search_results", @"Vector", nil);
 
                 self.descriptionLabel.text = [NSString stringWithFormat:descriptionLabel,
-                                              publicRoomsDirectoryDataSource.roomsCount,
+                                              publicRoomsDirectoryDataSource.searchResultsCount,
                                               publicRoomsDirectoryDataSource.searchPattern];
             }
             else
             {
                 self.titleLabel.text = NSLocalizedStringFromTable(@"directory_cell_title", @"Vector", nil);
                 self.descriptionLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"directory_cell_description", @"Vector", nil),
-                                              publicRoomsDirectoryDataSource.roomsCount];
+                                              publicRoomsDirectoryDataSource.searchResultsCount];
             }
 
-            if (publicRoomsDirectoryDataSource.roomsCount)
+            if (publicRoomsDirectoryDataSource.searchResultsCount)
             {
                 self.userInteractionEnabled = YES;
                 self.chevronImageView.hidden = NO;

--- a/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.h
+++ b/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.h
@@ -62,10 +62,15 @@
 @property (nonatomic, readonly) NSString *directoryServerDisplayname;
 
 /**
- The number of public rooms matching `searchPattern`.
- It is accurate only if 'moreThanRoomsCount' is NO.
+ The number of public rooms that have been fetched so far.
  */
 @property (nonatomic, readonly) NSUInteger roomsCount;
+
+/**
+ The total number of public rooms matching `searchPattern`.
+ It is accurate only if 'moreThanRoomsCount' is NO.
+ */
+@property (nonatomic, readonly) NSUInteger searchResultsCount;
 
 /**
  In case of search with a lot of matching public rooms, we cannot return an accurate
@@ -74,7 +79,7 @@
  This flag indicates that we know that there is more matching rooms than we got
  so far.
  */
-@property (nonatomic, readonly) BOOL moreThanRoomsCount;
+@property (nonatomic, readonly) BOOL searchResultsCountIsLimited;
 
 /**
  The maximum number of public rooms to retrieve during a pagination. 

--- a/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.h
+++ b/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.h
@@ -68,7 +68,7 @@
 
 /**
  The total number of public rooms matching `searchPattern`.
- It is accurate only if 'moreThanRoomsCount' is NO.
+ It is accurate only if 'searchResultsCountIsLimited' is NO.
  */
 @property (nonatomic, readonly) NSUInteger searchResultsCount;
 

--- a/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.m
+++ b/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.m
@@ -165,6 +165,11 @@ static NSString *const kNSFWKeyword = @"nsfw";
     }
 }
 
+- (NSUInteger)roomsCount
+{
+    return rooms.count;
+}
+
 - (NSIndexPath*)cellIndexPathWithRoomId:(NSString*)roomId andMatrixSession:(MXSession*)matrixSession
 {
     NSIndexPath *indexPath = nil;
@@ -217,8 +222,8 @@ static NSString *const kNSFWKeyword = @"nsfw";
     // Reset all pagination vars
     [rooms removeAllObjects];
     nextBatch = nil;
-    _roomsCount = 0;
-    _moreThanRoomsCount = NO;
+    _searchResultsCount = 0;
+    _searchResultsCountIsLimited = NO;
     _hasReachedPaginationEnd = NO;
 }
 
@@ -264,14 +269,14 @@ static NSString *const kNSFWKeyword = @"nsfw";
             if (!self->_searchPattern)
             {
                 // When there is no search, we can use totalRoomCountEstimate returned by the server
-                self->_roomsCount = publicRoomsResponse.totalRoomCountEstimate;
-                self->_moreThanRoomsCount = NO;
+                self->_searchResultsCount = publicRoomsResponse.totalRoomCountEstimate;
+                self->_searchResultsCountIsLimited = NO;
             }
             else
             {
                 // Else we can only display something like ">20 matching rooms"
-                self->_roomsCount = self->rooms.count;
-                self->_moreThanRoomsCount = publicRoomsResponse.nextBatch ? YES : NO;
+                self->_searchResultsCount = self->rooms.count;
+                self->_searchResultsCountIsLimited = publicRoomsResponse.nextBatch ? YES : NO;
             }
 
             // Detect pagination end


### PR DESCRIPTION
Fixes #4537. Note: this is only happening in `ShowDirectoryViewController` (the one accessed via the #+ button).

Renamed the following for more obvious explanation (open to better suggestions):
`moreThanRoomsCount` → `searchResultsCountIsLimited`
`roomsCount` → `searchResultsCount`

Implemented a new `roomsCount` to be the number of rooms that have actually been fetched (again, open to better name suggestions).