### PR TITLE
Fix image and video thumbnail masks on cell reuse.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changes to be released in next version
  * Use different title for scan button for self verification (#4525).
  * it's easy for the back button to trigger a leftpanel reveal (#4438).
  * Show / hide reset button in secrets recovery screen (#4546).
+ * Timeline: Fix incorrect crop of media thumbnails.
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -1039,10 +1039,21 @@ const CGFloat kTypingCellHeight = 24;
 
 - (void)applyMaskToAttachmentViewOfBubbleCell:(MXKRoomBubbleTableViewCell *)cell
 {
-    if (cell.attachmentView && !cell.attachmentView.layer.mask)
+    if (cell.attachmentView)
     {
         UIBezierPath *myClippingPath = [UIBezierPath bezierPathWithRoundedRect:cell.attachmentView.bounds cornerRadius:6];
-        CAShapeLayer *mask = [CAShapeLayer layer];
+        CAShapeLayer *mask;
+        
+        // check for an existing mask in case the cell is being reused, otherwise create a new one
+        if ([cell.attachmentView.layer.mask isKindOfClass:[CAShapeLayer class]])
+        {
+            mask = (CAShapeLayer*)cell.attachmentView.layer.mask;
+        }
+        else
+        {
+            mask = [CAShapeLayer layer];
+        }
+        
         mask.path = myClippingPath.CGPath;
         cell.attachmentView.layer.mask = mask;
     }

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -1041,21 +1041,8 @@ const CGFloat kTypingCellHeight = 24;
 {
     if (cell.attachmentView)
     {
-        UIBezierPath *myClippingPath = [UIBezierPath bezierPathWithRoundedRect:cell.attachmentView.bounds cornerRadius:6];
-        CAShapeLayer *mask;
-        
-        // check for an existing mask in case the cell is being reused, otherwise create a new one
-        if ([cell.attachmentView.layer.mask isKindOfClass:[CAShapeLayer class]])
-        {
-            mask = (CAShapeLayer*)cell.attachmentView.layer.mask;
-        }
-        else
-        {
-            mask = [CAShapeLayer layer];
-        }
-        
-        mask.path = myClippingPath.CGPath;
-        cell.attachmentView.layer.mask = mask;
+        cell.attachmentView.layer.cornerRadius = 6;
+        cell.attachmentView.layer.masksToBounds = YES;
     }
 }
 


### PR DESCRIPTION
Fixes #4552.

Deliberated whether to fix this here or in `MXKRoomBubbleTableViewCell`'s `prepareForReuse`. Decided it's probably better here as otherwise it would alter the cells of other users of MatrixKit when they had their own custom masks.