### PR TITLE
Standardise casing of identity server and integration manager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,7 @@ Improvements:
 
  * Room Notification Settings: Ability to change between "All Messages", "Mentions and Keywords" and "None". Not yet exposed in Element UI. (#4458).
  * Add support for sending slow motion videos (#4483).
+ * Standardise casing of identity server and integration manager (#4559).
 
 🐛 Bugfix
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -513,7 +513,7 @@ Tap the + to start adding people.";
 "settings_calls_stun_server_fallback_description" = "Allow fallback call assist server %@ when your homeserver does not offer one (your IP address would be shared during a call).";
 
 "settings_integrations_allow_button" = "Manage integrations";
-"settings_integrations_allow_description" = "Use an Integration Manager (%@) to manage bots, bridges, widgets and sticker packs.\n\nIntegration Managers receive configuration data, and can modify widgets, send room invites and set power levels on your behalf.";
+"settings_integrations_allow_description" = "Use an integration manager (%@) to manage bots, bridges, widgets and sticker packs.\n\nIntegration managers receive configuration data, and can modify widgets, send room invites and set power levels on your behalf.";
 
 "settings_ui_language" = "Language";
 "settings_ui_theme" = "Theme";
@@ -595,7 +595,7 @@ Tap the + to start adding people.";
 "settings_devices_description" = "A session's public name is visible to people you communicate with";
 
 "settings_discovery_no_identity_server" = "You are not currently using an identity server. To be discoverable by existing contacts you known, add one.";
-"settings_discovery_terms_not_signed" = "Agree to the Identity Server (%@) Terms of Service to allow yourself to be discoverable by email address or phone number.";
+"settings_discovery_terms_not_signed" = "Agree to the identity server (%@) Terms of Service to allow yourself to be discoverable by email address or phone number.";
 "settings_discovery_three_pids_management_information_part1" = "Manage which email addresses or phone numbers other users can use to discover you and use to invite you to rooms. Add or remove email addresses or phone numbers from this list in ";
 "settings_discovery_three_pids_management_information_part2" = "User Settings";
 "settings_discovery_three_pids_management_information_part3" = ".";
@@ -668,7 +668,7 @@ Tap the + to start adding people.";
 "authenticated_session_flow_not_supported" = "This app does not support the authentication mechanism on your homeserver.";
 
 // Identity server settings
-"identity_server_settings_title" = "Identity Server";
+"identity_server_settings_title" = "Identity server";
 
 "identity_server_settings_description" = "You are currently using %@ to discover and be discoverable by existing contacts you know.";
 "identity_server_settings_no_is_description" = "You are not currently using an identity server. To discover and be discoverable by existing contacts, add one above.";
@@ -959,7 +959,7 @@ Tap the + to start adding people.";
 "widget_integration_missing_room_id" = "Missing room_id in request.";
 "widget_integration_missing_user_id" = "Missing user_id in request.";
 "widget_integration_room_not_visible" = "Room %@ is not visible.";
-"widget_integration_manager_disabled" = "You need to enable Integration Manager in settings";
+"widget_integration_manager_disabled" = "You need to enable integration manager in settings";
 
 // Widget Picker
 "widget_picker_title" = "Integrations";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1590,7 +1590,7 @@ internal enum VectorL10n {
   internal static var identityServerSettingsPlaceHolder: String { 
     return VectorL10n.tr("Vector", "identity_server_settings_place_holder") 
   }
-  /// Identity Server
+  /// Identity server
   internal static var identityServerSettingsTitle: String { 
     return VectorL10n.tr("Vector", "identity_server_settings_title") 
   }
@@ -4150,7 +4150,7 @@ internal enum VectorL10n {
   internal static var settingsDiscoverySettings: String { 
     return VectorL10n.tr("Vector", "settings_discovery_settings") 
   }
-  /// Agree to the Identity Server (%@) Terms of Service to allow yourself to be discoverable by email address or phone number.
+  /// Agree to the identity server (%@) Terms of Service to allow yourself to be discoverable by email address or phone number.
   internal static func settingsDiscoveryTermsNotSigned(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "settings_discovery_terms_not_signed", p1)
   }

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4270,7 +4270,7 @@ internal enum VectorL10n {
   internal static var settingsIntegrationsAllowButton: String { 
     return VectorL10n.tr("Vector", "settings_integrations_allow_button") 
   }
-  /// Use an Integration Manager (%@) to manage bots, bridges, widgets and sticker packs.\n\nIntegration Managers receive configuration data, and can modify widgets, send room invites and set power levels on your behalf.
+  /// Use an integration manager (%@) to manage bots, bridges, widgets and sticker packs.\n\nIntegration managers receive configuration data, and can modify widgets, send room invites and set power levels on your behalf.
   internal static func settingsIntegrationsAllowDescription(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "settings_integrations_allow_description", p1)
   }
@@ -4930,7 +4930,7 @@ internal enum VectorL10n {
   internal static var widgetIntegrationFailedToSendRequest: String { 
     return VectorL10n.tr("Vector", "widget_integration_failed_to_send_request") 
   }
-  /// You need to enable Integration Manager in settings
+  /// You need to enable integration manager in settings
   internal static var widgetIntegrationManagerDisabled: String { 
     return VectorL10n.tr("Vector", "widget_integration_manager_disabled") 
   }

--- a/Riot/Managers/Widgets/WidgetManager.m
+++ b/Riot/Managers/Widgets/WidgetManager.m
@@ -262,7 +262,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     WidgetManagerConfig *config = [self configForUser:userId];
     if (!config.hasUrls)
     {
-        MXLogDebug(@"[WidgetManager] createJitsiWidgetInRoom: Error: no Integrations Manager API URL for user %@", userId);
+        MXLogDebug(@"[WidgetManager] createJitsiWidgetInRoom: Error: no integration manager API URL for user %@", userId);
         failure(self.errorForNonConfiguredIntegrationManager);
         return nil;
     }
@@ -574,7 +574,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     WidgetManagerConfig *config = [self configForUser:userId];
     if (!config.hasUrls)
     {
-        MXLogDebug(@"[WidgetManager] registerForScalarToken: Error: no Integrations Manager API URL for user %@", mxSession.myUser.userId);
+        MXLogDebug(@"[WidgetManager] registerForScalarToken: Error: no integration manager API URL for user %@", mxSession.myUser.userId);
         failure(self.errorForNonConfiguredIntegrationManager);
         return nil;
     }
@@ -654,7 +654,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     WidgetManagerConfig *config = [self configForUser:userId];
     if (!config.hasUrls)
     {
-        MXLogDebug(@"[WidgetManager] validateScalarToken: Error: no Integrations Manager API URL for user %@", mxSession.myUser.userId);
+        MXLogDebug(@"[WidgetManager] validateScalarToken: Error: no integration manager API URL for user %@", mxSession.myUser.userId);
         failure(self.errorForNonConfiguredIntegrationManager);
         return nil;
     }

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1164,7 +1164,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         return YES;
     }
     
-    // Manage email validation link from Identity Server v1 or v2
+    // Manage email validation link from identity server v1 or v2
     else if ([webURL.path isEqualToString:validateEmailSubmitTokenAPIPathV1]
              || [webURL.path isEqualToString:validateEmailSubmitTokenAPIPathV2])
     {

--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -294,7 +294,7 @@
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kjJ-Tb-SIW">
                                                             <rect key="frame" x="0.0" y="70" width="375" height="70"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Identity Server:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5CT-Ht-Z3v">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Identity server:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5CT-Ht-Z3v">
                                                                     <rect key="frame" x="18" y="8" width="339" height="20"/>
                                                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCISLabel"/>
                                                                     <constraints>

--- a/Riot/Modules/Settings/IdentityServer/SettingsIdentityServerViewController.storyboard
+++ b/Riot/Modules/Settings/IdentityServer/SettingsIdentityServerViewController.storyboard
@@ -28,7 +28,7 @@
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0W7-LW-UNr">
                                                         <rect key="frame" x="0.0" y="40" width="375" height="51"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Identity Server" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g0a-45-iRa">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Identity server" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g0a-45-iRa">
                                                                 <rect key="frame" x="20" y="16" width="100" height="19"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <nil key="textColor"/>

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -4195,7 +4195,7 @@ TableViewSectionsDelegate>
 }
 
 
-#pragma mark - Identity Server updates
+#pragma mark - Identity server updates
 
 - (void)registerAccountDataDidChangeIdentityServerNotification
 {
@@ -4289,7 +4289,7 @@ TableViewSectionsDelegate>
 }
 
 
-#pragma mark - Identity Server
+#pragma mark - Identity server
 
 - (void)showIdentityServerSettingsScreen
 {


### PR DESCRIPTION
This PR standardises the spelling and casing of the following terms, across the codebase, as per #2655:

- homeserver
- identity server
- integration manager

While the issue mentions only user-visible text, this PR changes all instances of the terms, regardless of whether they're user-visible or not. I think there's value in standardising these terms even in non-user-visible text, so I went ahead and applied the changes to all text.

For reference, here's the script I used to find candidates for replacement: https://gist.github.com/psrpinto/b3787bae212d5d99649b517e2efd4dce

The same work has been done on element-web, in vector-im/element-web#17980