### PR TITLE
Fix crash from potentially calling removeObserver multiple times.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changes to be released in next version
  * Room: Fixed mentioning users from room info member details (#4583)
  * Settings: Disabled autocorrection when entering an identity server (#4593).
  * Room Notification Settings: Fix Crash when opening the new Room Notification Settings Screen (Not yet released) (#4599).
+ * AuthenticationViewController: Fix crash on authentication if an intermediate view was presented (#4606).
 
 ⚠️ API Changes
  * 

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -382,6 +382,8 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
         [[NSNotificationCenter defaultCenter] removeObserver:universalLinkDidChangeNotificationObserver];
         universalLinkDidChangeNotificationObserver = nil;
     }
+    
+    [self.authenticationActivityIndicator removeObserver:self forKeyPath:@"hidden"];
 
     autoDiscovery = nil;
     _keyVerificationCoordinatorBridgePresenter = nil;

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -354,8 +354,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 {
     [_keyboardAvoider stopAvoiding];
     
-    [self.authenticationActivityIndicator removeObserver:self forKeyPath:@"hidden"];
-    
     [super viewDidDisappear:animated];
 }
 


### PR DESCRIPTION
Fixes #4606.

Remove the observer in `destroy` rather than `viewDidDisappear` so it only occurs once.