### PR TITLE
Delay access to local contacts until they're needed for display

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changes to be released in next version
  * Rooms Tab: Remove the directory section (#4521).
  * Notifications: Show decrypted content is enabled by default (#4519).
  * People Tab: Remove the local contacts section (#4523).
+ * Contacts: Delay access to local contacts until they're needed for display (#4616).
 
 🐛 Bugfix
  * Room: Fixed mentioning users from room info member details (#4583)

--- a/Riot/Modules/Contacts/ContactsTableViewController.m
+++ b/Riot/Modules/Contacts/ContactsTableViewController.m
@@ -246,7 +246,7 @@
             {
                 [MXKAppSettings standardAppSettings].syncLocalContactsPermissionRequested = YES;
                 
-                [MXKContactManager requestUserConfirmationForLocalContactsSyncInViewController:self.presentedViewController completionHandler:^(BOOL granted) {
+                [MXKContactManager requestUserConfirmationForLocalContactsSyncInViewController:self completionHandler:^(BOOL granted) {
                     
                     if (granted)
                     {

--- a/Riot/Modules/Contacts/ContactsTableViewController.m
+++ b/Riot/Modules/Contacts/ContactsTableViewController.m
@@ -84,9 +84,6 @@
         [[[self class] nib] instantiateWithOwner:self options:nil];
     }
     
-    // Load the local contacts for display
-    [self refreshLocalContacts];
-    
     // Finalize table view configuration
     self.contactsTableView.delegate = self;
     self.contactsTableView.dataSource = contactsDataSource; // Note: dataSource may be nil here
@@ -175,6 +172,15 @@
     }];
     
     [self refreshContactsTable];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    
+    // Load the local contacts for display.
+    // In viewDidAppear as it may trigger a request for contacts access.
+    [self refreshLocalContacts];
 }
 
 - (void)viewWillDisappear:(BOOL)animated


### PR DESCRIPTION
This is a simple first pass at #4616 by moving `LegacyAppDelegate.refreshLocalContacts` into `ContactsTableViewController`. This way, local contacts won't get loaded until they are about to be displayed. This technically fixes the contacts part of #4484 too, although there is additional work to complete for that issue around the appearance of behaviour of the request.

Depends on https://github.com/matrix-org/matrix-ios-sdk/pull/1172