### PR TITLE
Voice message additions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes to be released in next version
  * Settings: The notifications toggle no longer detects the system's "Deliver Quietly" configuration as disabled (#2368).
  * Settings: Adds a link to open the Settings app to quickly configure app notifications.
  * VoIP: Text & icon changes on call tiles (#4642).
+ * Voice messages: Stop recording and go into locked mode when the application becomes inactive (#4656)
+ * Voice messages: Allow voice message playback control from the iOS lock screen and control center (#4655)
 
 🐛 Bugfix
  * 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1691,3 +1691,4 @@ Tap the + to start adding people.";
 "voice_message_release_to_send" = "Hold to record, release to send";
 "voice_message_remaining_recording_time" = "%@s left";
 "voice_message_stop_locked_mode_recording" = "Tap on your recording to stop or listen";
+"voice_message_lock_screen_placeholder" = "Voice message";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4898,6 +4898,10 @@ internal enum VectorL10n {
   internal static var voice: String { 
     return VectorL10n.tr("Vector", "voice") 
   }
+  /// Voice message
+  internal static var voiceMessageLockScreenPlaceholder: String { 
+    return VectorL10n.tr("Vector", "voice_message_lock_screen_placeholder") 
+  }
   /// Hold to record, release to send
   internal static var voiceMessageReleaseToSend: String { 
     return VectorL10n.tr("Vector", "voice_message_release_to_send") 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -998,6 +998,8 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     }
     
     [self refreshRoomInputToolbar];
+    
+    [VoiceMessageMediaServiceProvider.sharedProvider setCurrentRoomSummary:dataSource.room.summary];
 }
 
 - (void)onRoomDataSourceReady

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioPlayer.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioPlayer.swift
@@ -45,6 +45,7 @@ class VoiceMessageAudioPlayer: NSObject {
     private let delegateContainer = DelegateContainer()
     
     private(set) var url: URL?
+    private(set) var displayName: String?
     
     var isPlaying: Bool {
         guard let audioPlayer = audioPlayer else {
@@ -68,12 +69,13 @@ class VoiceMessageAudioPlayer: NSObject {
         removeObservers()
     }
     
-    func loadContentFromURL(_ url: URL) {
+    func loadContentFromURL(_ url: URL, displayName: String? = nil) {
         if self.url == url {
             return
         }
         
         self.url = url
+        self.displayName = displayName
         
         removeObservers()
         

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
@@ -88,6 +88,8 @@ public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, 
         NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .themeServiceDidChangeTheme, object: nil)
         updateTheme()
         
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        
         updateUI()
     }
     
@@ -310,6 +312,10 @@ public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, 
     
     @objc private func updateTheme() {
         _voiceMessageToolbarView.update(theme: themeService.theme)
+    }
+    
+    @objc private func applicationWillResignActive() {
+        finishRecording()
     }
     
     @objc private func handleDisplayLinkTick() {

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
@@ -249,7 +249,7 @@ import MediaPlayer
         }
         
         let nowPlayingInfoCenter = MPNowPlayingInfoCenter.default()
-        nowPlayingInfoCenter.nowPlayingInfo = [MPMediaItemPropertyTitle: audioPlayer.displayName ?? "Voice message",
+        nowPlayingInfoCenter.nowPlayingInfo = [MPMediaItemPropertyTitle: audioPlayer.displayName ?? VectorL10n.voiceMessageLockScreenPlaceholder,
                                                MPMediaItemPropertyArtist: currentRoomSummary?.displayname as Any,
                                                MPMediaItemPropertyArtwork: artwork,
                                                MPMediaItemPropertyPlaybackDuration: audioPlayer.duration as Any,

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
@@ -15,20 +15,44 @@
 //
 
 import Foundation
+import MediaPlayer
 
 @objc public class VoiceMessageMediaServiceProvider: NSObject, VoiceMessageAudioPlayerDelegate, VoiceMessageAudioRecorderDelegate {
+    
+    private enum Constants {
+        static let roomAvatarImageSize: CGFloat = 100.0
+        static let roomAvatarFontSize: CGFloat = 40.0
+    }
     
     private let audioPlayers: NSMapTable<NSString, VoiceMessageAudioPlayer>
     private let audioRecorders: NSHashTable<VoiceMessageAudioRecorder>
     
-    // Retain currently playing audio player so it doesn't stop playing on timeline cell reusage
+    private var displayLink: CADisplayLink!
+    
+    // Retain currently playing audio player so it doesn't stop playing on timeline cell reuse
     private var currentlyPlayingAudioPlayer: VoiceMessageAudioPlayer?
     
     @objc public static let sharedProvider = VoiceMessageMediaServiceProvider()
     
+    private var roomAvatar: UIImage?
+    @objc public var currentRoomSummary: MXRoomSummary? {
+        didSet {
+            roomAvatar = AvatarGenerator.generateAvatar(forMatrixItem: currentRoomSummary?.roomId,
+                                                        withDisplayName: currentRoomSummary?.displayname,
+                                                        size: Constants.roomAvatarImageSize,
+                                                        andFontSize: Constants.roomAvatarFontSize)
+        }
+    }
+    
     private override init() {
         audioPlayers = NSMapTable<NSString, VoiceMessageAudioPlayer>(valueOptions: .weakMemory)
         audioRecorders = NSHashTable<VoiceMessageAudioRecorder>(options: .weakMemory)
+        
+        super.init()
+        
+        displayLink = CADisplayLink(target: WeakTarget(self, selector: #selector(handleDisplayLinkTick)), selector: WeakTarget.triggerSelector)
+        displayLink.isPaused = true
+        displayLink.add(to: .current, forMode: .common)
     }
     
     @objc func audioPlayerForIdentifier(_ identifier: String) -> VoiceMessageAudioPlayer {
@@ -57,12 +81,21 @@ import Foundation
     
     func audioPlayerDidStartPlaying(_ audioPlayer: VoiceMessageAudioPlayer) {
         currentlyPlayingAudioPlayer = audioPlayer
+        setUpRemoteCommandCenter()
         stopAllServicesExcept(audioPlayer)
     }
     
     func audioPlayerDidStopPlaying(_ audioPlayer: VoiceMessageAudioPlayer) {
         if currentlyPlayingAudioPlayer == audioPlayer {
             currentlyPlayingAudioPlayer = nil
+            tearDownRemoteCommandCenter()
+        }
+    }
+    
+    func audioPlayerDidFinishPlaying(_ audioPlayer: VoiceMessageAudioPlayer) {
+        if currentlyPlayingAudioPlayer == audioPlayer {
+            currentlyPlayingAudioPlayer = nil
+            tearDownRemoteCommandCenter()
         }
     }
     
@@ -95,5 +128,91 @@ import Foundation
             audioPlayer.stop()
             audioPlayer.unloadContent()
         }
+    }
+    
+    @objc private func handleDisplayLinkTick() {
+        updateNowPlayingInfoCenter()
+    }
+    
+    private func setUpRemoteCommandCenter() {
+        displayLink.isPaused = false
+        
+        UIApplication.shared.beginReceivingRemoteControlEvents()
+        
+        let commandCenter = MPRemoteCommandCenter.shared()
+        
+        commandCenter.playCommand.isEnabled = true
+        commandCenter.playCommand.removeTarget(nil)
+        commandCenter.playCommand.addTarget { [weak self] event in
+            guard let audioPlayer = self?.currentlyPlayingAudioPlayer else {
+                return MPRemoteCommandHandlerStatus.commandFailed
+            }
+            
+            audioPlayer.play()
+            
+            return MPRemoteCommandHandlerStatus.success
+        }
+        
+        commandCenter.pauseCommand.isEnabled = true
+        commandCenter.pauseCommand.removeTarget(nil)
+        commandCenter.pauseCommand.addTarget { [weak self] event in
+            guard let audioPlayer = self?.currentlyPlayingAudioPlayer else {
+                return MPRemoteCommandHandlerStatus.commandFailed
+            }
+            
+            audioPlayer.pause()
+
+            return MPRemoteCommandHandlerStatus.success
+        }
+        
+        commandCenter.skipForwardCommand.isEnabled = true
+        commandCenter.skipForwardCommand.removeTarget(nil)
+        commandCenter.skipForwardCommand.addTarget { [weak self] event in
+            guard let audioPlayer = self?.currentlyPlayingAudioPlayer, let skipEvent = event as? MPSkipIntervalCommandEvent else {
+                return MPRemoteCommandHandlerStatus.commandFailed
+            }
+            
+            audioPlayer.seekToTime(audioPlayer.currentTime + skipEvent.interval)
+            
+            return MPRemoteCommandHandlerStatus.success
+        }
+        
+        commandCenter.skipBackwardCommand.isEnabled = true
+        commandCenter.skipBackwardCommand.removeTarget(nil)
+        commandCenter.skipBackwardCommand.addTarget { [weak self] event in
+            guard let audioPlayer = self?.currentlyPlayingAudioPlayer, let skipEvent = event as? MPSkipIntervalCommandEvent else {
+                return MPRemoteCommandHandlerStatus.commandFailed
+            }
+            
+            audioPlayer.seekToTime(audioPlayer.currentTime - skipEvent.interval)
+            
+            return MPRemoteCommandHandlerStatus.success
+        }
+    }
+    
+    private func tearDownRemoteCommandCenter() {
+        displayLink.isPaused = true
+        
+        UIApplication.shared.endReceivingRemoteControlEvents()
+        
+        let nowPlayingInfoCenter = MPNowPlayingInfoCenter.default()
+        nowPlayingInfoCenter.nowPlayingInfo = nil
+    }
+    
+    private func updateNowPlayingInfoCenter() {
+        guard let audioPlayer = currentlyPlayingAudioPlayer else {
+            return
+        }
+        
+        let artwork = MPMediaItemArtwork(boundsSize: .init(width: Constants.roomAvatarImageSize, height: Constants.roomAvatarImageSize)) { [weak self] size in
+            return self?.roomAvatar ?? UIImage()
+        }
+        
+        let nowPlayingInfoCenter = MPNowPlayingInfoCenter.default()
+        nowPlayingInfoCenter.nowPlayingInfo = [MPMediaItemPropertyTitle: audioPlayer.displayName ?? "Voice message",
+                                               MPMediaItemPropertyArtist: currentRoomSummary?.displayname as Any,
+                                               MPMediaItemPropertyArtwork: artwork,
+                                               MPMediaItemPropertyPlaybackDuration: audioPlayer.duration as Any,
+                                               MPNowPlayingInfoPropertyElapsedPlaybackTime: audioPlayer.currentTime as Any]
     }
 }

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessagePlaybackController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessagePlaybackController.swift
@@ -56,8 +56,7 @@ class VoiceMessagePlaybackController: VoiceMessageAudioPlayerDelegate, VoiceMess
     
     let playbackView: VoiceMessagePlaybackView
     
-    init(mediaServiceProvider: VoiceMessageMediaServiceProvider,
-         cacheManager: VoiceMessageAttachmentCacheManager) {
+    init(mediaServiceProvider: VoiceMessageMediaServiceProvider, cacheManager: VoiceMessageAttachmentCacheManager) {
         self.mediaServiceProvider = mediaServiceProvider
         self.cacheManager = cacheManager
         
@@ -93,7 +92,7 @@ class VoiceMessagePlaybackController: VoiceMessageAudioPlayerDelegate, VoiceMess
                 audioPlayer.play()
             }
         } else if let url = urlToLoad {
-            audioPlayer.loadContentFromURL(url)
+            audioPlayer.loadContentFromURL(url, displayName: attachment?.originalFileName)
             audioPlayer.play()
         }
     }
@@ -153,6 +152,7 @@ class VoiceMessagePlaybackController: VoiceMessageAudioPlayerDelegate, VoiceMess
                 details.progress = (audioPlayer.duration > 0.0 ? audioPlayer.currentTime / audioPlayer.duration : 0.0)
             }
         }
+        
         details.loading = self.loading
         
         playbackView.configureWithDetails(details)


### PR DESCRIPTION
#4655 - Allowing voice message playback to be controlled from the lock screen or the control center.
- Doing this in the `VoiceMessageMediaServiceProvider` so that it keeps working properly if the currently playing voice message (cell) gets scrolled off screen and deallocated.

#4656 - Stop recording voice message and go into locked mode when the application becomes inactive.