### PR TITLE
Fixes #4748 - Fixed cached callbacks race condition

### DIFF
--- a/changelog.d/4748.bugfix
+++ b/changelog.d/4748.bugfix
@@ -1,0 +1,1 @@
+Fixed cached callbacks race condition, serialized all async operations, properly cleaning up callbacks on failure.


### PR DESCRIPTION
Switched to using a serial OperationQueue that waits on a semaphore for all async operations to finish before continuing to the next enqueued task.
Fixed CompletionCallbackKeys not being genereated properly when encountering failures.