### PR TITLE
Fix SwiftUI theme updates

### DIFF
--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -104,11 +104,14 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
     private func setupTheme() {
         ThemeService.shared().themeId = RiotSettings.shared.userInterfaceTheme
         if #available(iOS 14.0, *) {
-            guard let themeId = ThemeService.shared().themeIdentifier else {
+            // Set theme id from current theme.identifier, themeId can be nil.
+            if let themeId = ThemeIdentifier(rawValue: ThemeService.shared().theme.identifier) {
+                ThemePublisher.configure(themeId: themeId)
+            } else {
                 MXLog.error("[AppCoordinator] No theme id found to update ThemePublisher")
-                return
             }
-            ThemePublisher.configure(themeId: themeId)
+            
+            // Always republish theme change events
             let themeIdPublisher = NotificationCenter.default.publisher(for: Notification.Name.themeServiceDidChangeTheme)
                 .compactMap({ _ in ThemeService.shared().themeIdentifier })
                 .eraseToAnyPublisher()

--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -111,9 +111,9 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
                 MXLog.error("[AppCoordinator] No theme id found to update ThemePublisher")
             }
             
-            // Always republish theme change events
+            // Always republish theme change events, and again always getting the identifier from the theme.
             let themeIdPublisher = NotificationCenter.default.publisher(for: Notification.Name.themeServiceDidChangeTheme)
-                .compactMap({ _ in ThemeService.shared().themeIdentifier })
+                .compactMap({ _ in ThemeIdentifier(rawValue: ThemeService.shared().theme.identifier) })
                 .eraseToAnyPublisher()
 
             ThemePublisher.shared.republish(themeIdPublisher: themeIdPublisher)

--- a/changelog.d/4816.bugfix
+++ b/changelog.d/4816.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect theme being shown in the notification settings screens.


### PR DESCRIPTION
fixes #4816.

There was three problems here: 
- `themeId` from the service can be nil if there was nothing in `RiotSettings`, but a default theme still gets set. So we should get them theme id from the theme.
- We should also remove the guard and always listen for theme updates even if no theme id was found.
- Again when publishing theme updates we were getting the themeId from the service and not the current theme.