### PR TITLE
Ensure the last bubble component has a link before loading the preview.

### DIFF
--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -1076,7 +1076,7 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
 {
     // Get the last bubble component as that contains the link.
     MXKRoomBubbleComponent *lastComponent = bubbleComponents.lastObject;
-    if (!lastComponent)
+    if (!lastComponent || !lastComponent.link)
     {
         return;
     }

--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -254,6 +254,14 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
     return attributedTextMessage;
 }
 
+- (BOOL)hasLink
+{
+    // Only check the last bubble component as -addEvent:andRoomState: will break up
+    // the data that way, to always show a URL preview at the bottom of the cell.
+    MXKRoomBubbleComponent *lastComponent = bubbleComponents.lastObject;
+    return (lastComponent && lastComponent.link);
+}
+
 - (BOOL)hasNoDisplay
 {
     if (self.tag == RoomBubbleCellDataTagKeyVerificationNoDisplay)

--- a/changelog.d/4823.bugfix
+++ b/changelog.d/4823.bugfix
@@ -1,0 +1,1 @@
+RoomBubbleCellData: Fix crash when creating a URL preview when the link didn't end up in the last bubble component.


### PR DESCRIPTION
Fixes #4823.