### PR TITLE
Fix Element Alpha on iOS 15.

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Release
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2

--- a/changelog.d/4937.build
+++ b/changelog.d/4937.build
@@ -1,0 +1,1 @@
+Element Alpha: Build on macOS 11 to fix iOS 15 installation error.


### PR DESCRIPTION
iOS 15 requires AdHoc and Enterprise builds to be signed with a newer code signature format which is applied automatically by signing with macOS 11. [Apple Docs](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format).

Fixes #4937.