### PR TITLE
Track an analytics value of accept/decline of identity server terms.

### DIFF
--- a/Riot/Managers/Analytics/Analytics.h
+++ b/Riot/Managers/Analytics/Analytics.h
@@ -22,6 +22,10 @@
 // Metrics related to notifications
 FOUNDATION_EXPORT NSString *const AnalyticsNoficationsCategory;
 FOUNDATION_EXPORT NSString *const AnalyticsNoficationsTimeToDisplayContent;
+/**
+ The analytics value for accept/decline of the identity server's terms.
+ */
+FOUNDATION_EXPORT NSString *const AnalyticsContactsIdentityServerAccepted;
 
 
 /**

--- a/Riot/Managers/Analytics/Analytics.m
+++ b/Riot/Managers/Analytics/Analytics.m
@@ -21,6 +21,7 @@
 
 NSString *const AnalyticsNoficationsCategory = @"notifications";
 NSString *const AnalyticsNoficationsTimeToDisplayContent = @"timelineDisplay";
+NSString *const AnalyticsContactsIdentityServerAccepted = @"identityServerAccepted";
 
 
 // Duration data will be visible under the Piwik category called "Performance".

--- a/changelog.d/4955.change
+++ b/changelog.d/4955.change
@@ -1,0 +1,1 @@
+Service Terms: Track an analytics value on accept/decline of an identity server.


### PR DESCRIPTION
Fixes #4955, this PR adds an analytics value of accept/decline of the identity server's terms. Depends on https://github.com/matrix-org/matrix-ios-kit/pull/924.

In the context of this PR, a decline is being treated as dismissing without accepting, whether that's by tapping decline, cancel or swiping to dismiss.