### PR TITLE
Fix generated avatar colours not matching Element Web.

### DIFF
--- a/Riot/Categories/MXKImageView.swift
+++ b/Riot/Categories/MXKImageView.swift
@@ -17,9 +17,9 @@
 import Foundation
 
 extension MXKImageView {
-    @objc func vc_setRoomAvatarImage(with url: String?, displayName: String, mediaManager: MXMediaManager) {
+    @objc func vc_setRoomAvatarImage(with url: String?, roomId: String, displayName: String, mediaManager: MXMediaManager) {
         // Use the display name to prepare the default avatar image.
-        let avatarImage = AvatarGenerator.generateAvatar(forText: displayName)
+        let avatarImage = AvatarGenerator.generateAvatar(forMatrixItem: roomId, withDisplayName: displayName)
 
         if let avatarUrl = url {
             self.enableInMemoryCache = true

--- a/Riot/Categories/MXRoomSummary+Riot.m
+++ b/Riot/Categories/MXRoomSummary+Riot.m
@@ -19,32 +19,20 @@
 
 #import "AvatarGenerator.h"
 
+#ifdef IS_SHARE_EXTENSION
+#import "RiotShareExtension-Swift.h"
+#else
+#import "Riot-Swift.h"
+#endif
+
 @implementation MXRoomSummary (Riot)
 
 - (void)setRoomAvatarImageIn:(MXKImageView*)mxkImageView
 {
-    // Use the room display name to prepare the default avatar image.
-    NSString *avatarDisplayName = self.displayname;
-    UIImage* avatarImage = [AvatarGenerator generateAvatarForMatrixItem:self.roomId withDisplayName:avatarDisplayName];
-    
-    if (self.avatar)
-    {
-        mxkImageView.enableInMemoryCache = YES;
-        
-        [mxkImageView setImageURI:self.avatar
-                         withType:nil
-              andImageOrientation:UIImageOrientationUp
-                    toFitViewSize:mxkImageView.frame.size
-                       withMethod:MXThumbnailingMethodCrop
-                     previewImage:avatarImage
-                     mediaManager:self.mxSession.mediaManager];
-    }
-    else
-    {
-        mxkImageView.image = avatarImage;
-    }
-    
-    mxkImageView.contentMode = UIViewContentModeScaleAspectFill;
+    [mxkImageView vc_setRoomAvatarImageWith:self.avatar
+                                     roomId:self.roomId
+                                displayName:self.displayname
+                               mediaManager:self.mxSession.mediaManager];
 }
 
 - (RoomEncryptionTrustLevel)roomEncryptionTrustLevel

--- a/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
+++ b/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
@@ -126,11 +126,17 @@
 
         if (roomCellData.spaceChildInfo)
         {
-            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.spaceChildInfo.avatarUrl displayName:roomCellData.spaceChildInfo.displayName mediaManager:roomCellData.recentsDataSource.mxSession.mediaManager];
+            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.spaceChildInfo.avatarUrl
+                                                roomId:roomCellData.spaceChildInfo.childRoomId
+                                           displayName:roomCellData.spaceChildInfo.displayName
+                                          mediaManager:roomCellData.recentsDataSource.mxSession.mediaManager];
         }
         else
         {
-            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.roomSummary.avatar displayName:roomCellData.roomSummary.displayname mediaManager:roomCellData.roomSummary.mxSession.mediaManager];
+            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.roomSummary.avatar
+                                                roomId:roomCellData.roomSummary.roomId
+                                           displayName:roomCellData.roomSummary.displayname
+                                          mediaManager:roomCellData.roomSummary.mxSession.mediaManager];
         }
     }
     else

--- a/Riot/Modules/Home/Views/RoomCollectionViewCell.m
+++ b/Riot/Modules/Home/Views/RoomCollectionViewCell.m
@@ -132,11 +132,17 @@
         
         if (roomCellData.roomSummary)
         {
-            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.roomSummary.avatar displayName:roomCellData.roomSummary.displayname mediaManager:roomCellData.roomSummary.mxSession.mediaManager];
+            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.roomSummary.avatar
+                                                roomId:roomCellData.roomSummary.roomId
+                                           displayName:roomCellData.roomSummary.displayname
+                                          mediaManager:roomCellData.roomSummary.mxSession.mediaManager];
         }
         else
         {
-            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.spaceChildInfo.avatarUrl displayName:roomCellData.spaceChildInfo.displayName mediaManager:roomCellData.recentsDataSource.mxSession.mediaManager];
+            [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.spaceChildInfo.avatarUrl
+                                                roomId:roomCellData.spaceChildInfo.childRoomId
+                                           displayName:roomCellData.spaceChildInfo.displayName
+                                          mediaManager:roomCellData.recentsDataSource.mxSession.mediaManager];
         }
     }
 }

--- a/RiotShareExtension/SupportingFiles/RiotShareExtension-Bridging-Header.h
+++ b/RiotShareExtension/SupportingFiles/RiotShareExtension-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "ThemeService.h"
+#import "AvatarGenerator.h"

--- a/RiotShareExtension/target.yml
+++ b/RiotShareExtension/target.yml
@@ -43,6 +43,7 @@ targets:
     - path: ../Riot/Utils/AvatarGenerator.m
     - path: ../Config/BuildSettings.swift
     - path: ../Riot/Categories/Character.swift
+    - path: ../Riot/Categories/MXKImageView.swift
     - path: ../Riot/Categories/MXRoom+Riot.m
     - path: ../Config/Configurable.swift
     - path: ../Config/CommonConfiguration.swift

--- a/changelog.d/4978.bugfix
+++ b/changelog.d/4978.bugfix
@@ -1,0 +1,1 @@
+Room Lists: Fix generated avatar colours not matching Element Web.


### PR DESCRIPTION
Fixes #4978 so that colours are consistent across iOS and Web.

Note: The cause is that rooms generate their colour from the room ID, whereas spaces are doing it from the display name.