### PR TITLE
Move call to validateSyncLocalContactsState into MatrixKit.

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1843,13 +1843,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
             [self checkLocalPrivateKeysInSession:mxSession];
             
             [self.pushNotificationService checkPushKitPushersInSession:mxSession];
-            
-            // Validate the availability of local contact sync for any changes to the
-            // authorization of contacts access that may have occurred since the last launch.
-            if (BuildSettings.allowLocalContactsAccess)
-            {
-                [MXKContactManager.sharedManager validateSyncLocalContactsState];
-            }
         }
         else if (mxSession.state == MXSessionStateClosed)
         {

--- a/changelog.d/4989.bugfix
+++ b/changelog.d/4989.bugfix
@@ -1,0 +1,1 @@
+Contacts Sync: Move call to validateSyncLocalContactsState into MatrixKit.


### PR DESCRIPTION
Fixes #4989. The call to `validateSyncLocalContactsState` is now handled by MatrixKit in https://github.com/matrix-org/matrix-ios-kit/pull/931.