### PR TITLE
Remeber keyboard language for room

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2030,6 +2030,11 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     roomInputView.actionsBar.actionItems = actionItems;
 }
 
+- (NSString *)textInputContextIdentifier
+{
+    return self.roomDataSource.roomId;
+}
+
 - (void)roomInputToolbarViewPresentStickerPicker
 {
     // Search for the sticker picker widget in the user account

--- a/changelog.d/5067.feature
+++ b/changelog.d/5067.feature
@@ -1,0 +1,1 @@
+Remember keyboard layout per room and restore it when opening the room again.


### PR DESCRIPTION
This adds a `textInputContextIdentifier` to the RoomViewController to save the current language per room.


### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
