### PR TITLE
Add concurrency to GitHub workflows to auto-cancel older runs.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,6 +17,11 @@ jobs:
   build:
     name: Build
     runs-on: macos-11
+    
+    # Only allow a single run of this workflow on each branch (cancel older runs automatically)
+    concurrency:
+      group: build-${{ github.head_ref }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,9 +18,10 @@ jobs:
     name: Build
     runs-on: macos-11
     
-    # Only allow a single run of this workflow on each branch (cancel older runs automatically)
     concurrency:
-      group: build-${{ github.head_ref }}
+      # When running on develop, use the sha to allow all runs of this workflow to run concurrently.
+      # Otherwise only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: ${{ github.ref == 'refs/heads/develop' && format('build-develop-{0}', github.sha) || format('build-{0}', github.ref) }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,6 +17,11 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-11
+    
+    # Only allow a single run of this workflow on each branch (cancel older runs automatically)
+    concurrency:
+      group: tests-${{ github.head_ref }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,9 +18,10 @@ jobs:
     name: Tests
     runs-on: macos-11
     
-    # Only allow a single run of this workflow on each branch (cancel older runs automatically)
     concurrency:
-      group: tests-${{ github.head_ref }}
+      # When running on develop, use the sha to allow all runs of this workflow to run concurrently.
+      # Otherwise only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: ${{ github.ref == 'refs/heads/develop' && format('tests-develop-{0}', github.sha) || format('tests-{0}', github.ref) }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -17,9 +17,10 @@ jobs:
     name: Release
     runs-on: macos-11
     
-    # Only allow a single run of this workflow on each branch (cancel older runs automatically)
     concurrency:
-      group: alpha-${{ github.head_ref }}
+      # When running on develop, use the sha to allow all runs of this workflow to run concurrently.
+      # Otherwise only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: ${{ github.ref == 'refs/heads/develop' && format('alpha-develop-{0}', github.sha) || format('alpha-{0}', github.ref) }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -16,6 +16,11 @@ jobs:
   build:
     name: Release
     runs-on: macos-11
+    
+    # Only allow a single run of this workflow on each branch (cancel older runs automatically)
+    concurrency:
+      group: alpha-${{ github.head_ref }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v2

--- a/changelog.d/5039.build
+++ b/changelog.d/5039.build
@@ -1,0 +1,1 @@
+Add concurrency to the GitHub workflows to auto-cancel older runs of each action.

--- a/changelog.d/5039.build
+++ b/changelog.d/5039.build
@@ -1,1 +1,1 @@
-Add concurrency to the GitHub workflows to auto-cancel older runs of each action.
+Add concurrency to the GitHub workflows to auto-cancel older runs of each action for PRs.


### PR DESCRIPTION
This limits GitHub actions to only allow each workflow to have a single concurrent run per branch. The result is that pushing new changes to a PR will automatically cancel older runs, freeing up more CI instances for us to use.

**Caveat:** The same effect will happen on `develop` too, so if 2 PRs are merged within a short time of each other, only the newer one would have CI results. I'm not sure if this is desirable behaviour or not?