### PR TITLE
Only run build CI on develop.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,6 @@ on:
   # Triggers the workflow on any pull request and push to develop
   push:
     branches: [ develop ]
-  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,11 +17,7 @@ jobs:
     name: Build
     runs-on: macos-11
     
-    concurrency:
-      # When running on develop, use the sha to allow all runs of this workflow to run concurrently.
-      # Otherwise only allow a single run of this workflow on each branch, automatically cancelling older runs.
-      group: ${{ github.ref == 'refs/heads/develop' && format('build-develop-{0}', github.sha) || format('build-{0}', github.ref) }}
-      cancel-in-progress: true
+    # Concurrency group not needed as this workflow only runs on develop which we always want to test.
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -18,9 +18,8 @@ jobs:
     runs-on: macos-11
     
     concurrency:
-      # When running on develop, use the sha to allow all runs of this workflow to run concurrently.
-      # Otherwise only allow a single run of this workflow on each branch, automatically cancelling older runs.
-      group: ${{ github.ref == 'refs/heads/develop' && format('alpha-develop-{0}', github.sha) || format('alpha-{0}', github.ref) }}
+      # Only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: alpha-${{ github.head_ref }}
       cancel-in-progress: true
 
     steps:

--- a/changelog.d/pr-5112.build
+++ b/changelog.d/pr-5112.build
@@ -1,0 +1,1 @@
+Only run Build CI on develop, as it is already covered by Tests and Alpha.


### PR DESCRIPTION
Following on from #5101, only run the build CI on `develop` as the Tests & Alpha should be enough for PRs. I've also reverted the concurrency group for the Alpha build as it only runs on develop so doesn't need the check for when it is run on develop.