### PR TITLE
Refresh RecentsListService when switching modes.

### DIFF
--- a/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
+++ b/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
@@ -20,7 +20,12 @@ import Foundation
 public class RecentsListService: NSObject, RecentsListServiceProtocol {
     
     private weak var session: MXSession?
-    public private(set) var mode: RecentsDataSourceMode
+    public private(set) var mode: RecentsDataSourceMode {
+        didSet {
+            refresh()
+        }
+    }
+    
     public private(set) var query: String?
     public private(set) var space: MXSpace?
     

--- a/Riot/Modules/Common/Recents/Service/Mock/MockRoomSummary.swift
+++ b/Riot/Modules/Common/Recents/Service/Mock/MockRoomSummary.swift
@@ -60,6 +60,18 @@ public class MockRoomSummary: NSObject, MXRoomSummaryProtocol {
     
     public var highlightCount: UInt = 0
     
+    public var hasAnyUnread: Bool {
+        return localUnreadEventCount > 0
+    }
+    
+    public var hasAnyNotification: Bool {
+        return notificationCount > 0
+    }
+    
+    public var hasAnyHighlight: Bool {
+        return highlightCount > 0
+    }
+    
     public var isDirect: Bool {
         return isTyped(.direct)
     }

--- a/changelog.d/5105.bugfix
+++ b/changelog.d/5105.bugfix
@@ -1,0 +1,1 @@
+Fix room ordering when switching between Home and People/Rooms/Favourites.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5105.

The filtering was perfectly fine, however it wasn't being updated when switching modes, so would be incorrect until a sync response that modified a room summary (I think there was more to it than just that) came in.