### PR TITLE
Room ordering: Prioritize pinned rooms in all room lists

### DIFF
--- a/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
+++ b/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
@@ -146,17 +146,11 @@ public class RecentsListService: NSObject, RecentsListServiceProtocol {
     private let multicastDelegate: MXMulticastDelegate<RecentsListServiceDelegate> = MXMulticastDelegate()
     // swiftlint:enable weak_delegate
     
-    private var sortOptions: MXRoomListDataSortOptions {
-        switch mode {
-        case .home:
-            let pinMissed = RiotSettings.shared.pinRoomsWithMissedNotificationsOnHome
-            let pinUnread = RiotSettings.shared.pinRoomsWithUnreadMessagesOnHome
-            return MXRoomListDataSortOptions(missedNotificationsFirst: pinMissed,
-                                             unreadMessagesFirst: pinUnread)
-        default:
-            return MXRoomListDataSortOptions(missedNotificationsFirst: false,
-                                             unreadMessagesFirst: false)
-        }
+    private var sortOptions: MXRoomListDataSortOptions {        
+        let pinMissed = RiotSettings.shared.pinRoomsWithMissedNotificationsOnHome
+        let pinUnread = RiotSettings.shared.pinRoomsWithUnreadMessagesOnHome
+        return MXRoomListDataSortOptions(missedNotificationsFirst: pinMissed,
+                                         unreadMessagesFirst: pinUnread)        
     }
     
     //  MARK: - Public API

--- a/changelog.d/5132.bugfix
+++ b/changelog.d/5132.bugfix
@@ -1,0 +1,1 @@
+Room ordering: Prioritize pinned rooms in all room lists.


### PR DESCRIPTION
Part of https://github.com/vector-im/element-ios/issues/5132. Handle the case: 
> When "Pin rooms with missed notifications" and "Pin rooms with unread notifications" are on: Home, Favourites, People, and Rooms are ordered by Mentions, Unreads, Others (chronological inside each bucket)
