### PR TITLE
Ignore badge updates for virtual rooms.

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -154,9 +154,6 @@ final class BuildSettings: NSObject {
     }
     static let stunServerFallbackUrlString: String? = "stun:turn.matrix.org"
     
-    // For use in conjunction with virtual rooms. Events from virtual rooms should not be reflected in badge count for unread messages.
-    static let ignoreBadgeUpdatesForVirtualRooms = true
-    
     // MARK: -  Public rooms Directory
     #warning("Unused build setting: should this be implemented in ShowDirectory?")
     static let publicRoomsAllowServerChange: Bool = true

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -154,6 +154,8 @@ final class BuildSettings: NSObject {
     }
     static let stunServerFallbackUrlString: String? = "stun:turn.matrix.org"
     
+    // For use in conjunction with virtual rooms. Events from virtual rooms should not be reflected in badge count for unread messages.
+    static let ignoreBadgeUpdatesForVirtualRooms = true
     
     // MARK: -  Public rooms Directory
     #warning("Unused build setting: should this be implemented in ShowDirectory?")

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -337,7 +337,6 @@ class NotificationService: UNNotificationServiceExtension {
                                         self.sendReadReceipt(forEvent: event)
                                         ignoreBadgeUpdate = true
                                     }
-                                    self.sendVoipPush(forEvent: event)
                                     self.validateNotificationContentAndComplete(
                                         notificationTitle: notificationTitle,
                                         notificationBody: notificationBody,
@@ -350,6 +349,7 @@ class NotificationService: UNNotificationServiceExtension {
                                         onComplete: onComplete
                                     )
                                 }
+                                self.sendVoipPush(forEvent: event)
                                 return
                             } else {
                                 MXLog.debug("[NotificationService] notificationContent: Do not attempt to send a VoIP push, there is not enough time to process it.")
@@ -537,13 +537,13 @@ class NotificationService: UNNotificationServiceExtension {
         var validatedNotificationBody: String? = notificationBody
         var validatedNotificationTitle: String? = notificationTitle
         if self.localAuthenticationService.isProtectionSet {
-            MXLog.debug("[NotificationService] notificationContentForEvent: Resetting title and body because app protection is set")
+            MXLog.debug("[NotificationService] validateNotificationContentAndComplete: Resetting title and body because app protection is set")
             validatedNotificationBody = NSString.localizedUserNotificationString(forKey: "MESSAGE_PROTECTED", arguments: [])
             validatedNotificationTitle = nil
         }
         
-        guard notificationBody != nil else {
-            MXLog.debug("[NotificationService] notificationContentForEvent: notificationBody is nil")
+        guard validatedNotificationBody != nil else {
+            MXLog.debug("[NotificationService] validateNotificationContentAndComplete: notificationBody is nil")
             onComplete(nil, false)
             return
         }
@@ -556,7 +556,7 @@ class NotificationService: UNNotificationServiceExtension {
                                                            pushRule: pushRule,
                                                            additionalInfo: additionalUserInfo)
         
-        MXLog.debug("[NotificationService] notificationContentForEvent: Calling onComplete.")
+        MXLog.debug("[NotificationService] validateNotificationContentAndComplete: Calling onComplete.")
         onComplete(notificationContent, ignoreBadgeUpdate)
     }
     

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -726,20 +726,20 @@ class NotificationService: UNNotificationServiceExtension {
     
     private func sendReadReceipt(forEvent event: MXEvent) {
         guard let mxRestClient = mxRestClient else {
-            MXLog.error("[NotificationService] sendVoipReadReceipt: Missing mxRestClient for read receipt request.")
+            MXLog.error("[NotificationService] sendReadReceipt: Missing mxRestClient for read receipt request.")
             return
         }
         guard let eventId = event.eventId,
               let roomId = event.roomId else {
-            MXLog.error("[NotificationService] sendVoipReadReceipt: Event information missing for read receipt request.")
+            MXLog.error("[NotificationService] sendReadReceipt: Event information missing for read receipt request.")
             return
         }
         
         mxRestClient.sendReadReceipt(toRoom: roomId, forEvent: eventId) { response in
             if response.isSuccess {
-                MXLog.debug("[NotificationService] sendVoipReadReceipt: Read receipt send successfully.")
+                MXLog.debug("[NotificationService] sendReadReceipt: Read receipt send successfully.")
             } else if let error = response.error {
-                MXLog.error("[NotificationService] sendVoipReadReceipt: Read receipt send failed with error \(error).")
+                MXLog.error("[NotificationService] sendReadReceipt: Read receipt send failed with error \(error).")
             }
         }
     }

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -53,6 +53,12 @@ class NotificationService: UNNotificationServiceExtension {
     private lazy var configuration: Configurable = {
         return CommonConfiguration()
     }()
+    private lazy var mxRestClient: MXRestClient? = {
+        guard let userAccount = userAccount else {
+            return nil
+        }
+        return MXRestClient(credentials: userAccount.mxCredentials, unrecognizedCertificateHandler: nil)
+    }()
     private static var isLoggerInitialized: Bool = false
     private lazy var pushGatewayRestClient: MXPushGatewayRestClient = {
         let url = URL(string: BuildSettings.serverConfigSygnalAPIUrlString)!
@@ -222,7 +228,7 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
         
-        self.notificationContent(forEvent: event, forAccount: userAccount) { (notificationContent) in
+        self.notificationContent(forEvent: event, forAccount: userAccount) { (notificationContent, ignoreBadgeUpdate) in
             var isUnwantedNotification = false
             
             // Modify the notification content here...
@@ -238,6 +244,10 @@ class NotificationService: UNNotificationServiceExtension {
                 //  this is an unwanted notification, mark as to be deleted when app is foregrounded again OR a new push came
                 content.categoryIdentifier = Constants.toBeRemovedNotificationCategoryIdentifier
                 isUnwantedNotification = true
+            }
+            
+            if ignoreBadgeUpdate {
+                content.badge = nil
             }
             
             if self.ongoingVoIPPushRequests[event.eventId] == true {
@@ -279,10 +289,10 @@ class NotificationService: UNNotificationServiceExtension {
         MXLog.debug("--------------------------------------------------------------------------------")
     }
     
-    private func notificationContent(forEvent event: MXEvent, forAccount account: MXKAccount, onComplete: @escaping (UNNotificationContent?) -> Void) {
+    private func notificationContent(forEvent event: MXEvent, forAccount account: MXKAccount, onComplete: @escaping (UNNotificationContent?, Bool) -> Void) {
         guard let content = event.content, content.count > 0 else {
             MXLog.debug("[NotificationService] notificationContentForEvent: empty event content")
-            onComplete(nil)
+            onComplete(nil, false)
             return
         }
         
@@ -298,7 +308,7 @@ class NotificationService: UNNotificationServiceExtension {
                     var notificationTitle: String?
                     var notificationBody: String?
                     var additionalUserInfo: [AnyHashable: Any]?
-                    
+                    var ignoreBadgeUpdate = false
                     var threadIdentifier: String? = roomId
                     let currentUserId = account.mxCredentials.userId
                     let roomDisplayName = roomSummary?.displayname
@@ -322,6 +332,10 @@ class NotificationService: UNNotificationServiceExtension {
                             if let callInviteContent = MXCallInviteEventContent(fromJSON: event.content),
                                callInviteContent.lifetime > event.age,
                                (callInviteContent.lifetime - event.age) > UInt(NSE.Constants.timeNeededToSendVoIPPushes * MSEC_PER_SEC) {
+                                if BuildSettings.ignoreBadgeUpdatesForVirtualRooms {
+                                    self.sendReadReceipt(forEvent: event)
+                                    ignoreBadgeUpdate = true
+                                }
                                 self.sendVoipPush(forEvent: event)
                             } else {
                                 MXLog.debug("[NotificationService] notificationContent: Do not attempt to send a VoIP push, there is not enough time to process it.")
@@ -351,7 +365,7 @@ class NotificationService: UNNotificationServiceExtension {
                                     #warning("In practice, this only hides the notification's content. An empty notification may be less useful in this instance?")
                                     // Ignore this notif.
                                     MXLog.debug("[NotificationService] notificationContentForEvent: Ignore non highlighted notif in mentions only room")
-                                    onComplete(nil)
+                                    onComplete(nil, false)
                                     return
                                 }
                             }
@@ -483,7 +497,7 @@ class NotificationService: UNNotificationServiceExtension {
                     
                     guard notificationBody != nil else {
                         MXLog.debug("[NotificationService] notificationContentForEvent: notificationBody is nil")
-                        onComplete(nil)
+                        onComplete(nil, false)
                         return
                     }
                     
@@ -496,10 +510,10 @@ class NotificationService: UNNotificationServiceExtension {
                                                                        additionalInfo: additionalUserInfo)
                     
                     MXLog.debug("[NotificationService] notificationContentForEvent: Calling onComplete.")
-                    onComplete(notificationContent)
+                    onComplete(notificationContent, ignoreBadgeUpdate)
                 case .failure(let error):
                     MXLog.debug("[NotificationService] notificationContentForEvent: error: \(error)")
-                    onComplete(nil)
+                    onComplete(nil, false)
             }
         })
     }
@@ -710,4 +724,23 @@ class NotificationService: UNNotificationServiceExtension {
         }
     }
     
+    private func sendReadReceipt(forEvent event: MXEvent) {
+        guard let mxRestClient = mxRestClient else {
+            MXLog.error("[NotificationService] sendVoipReadReceipt: Missing mxRestClient for read receipt request.")
+            return
+        }
+        guard let eventId = event.eventId,
+              let roomId = event.roomId else {
+            MXLog.error("[NotificationService] sendVoipReadReceipt: Event information missing for read receipt request.")
+            return
+        }
+        
+        mxRestClient.sendReadReceipt(toRoom: roomId, forEvent: eventId) { response in
+            if response.isSuccess {
+                MXLog.debug("[NotificationService] sendVoipReadReceipt: Read receipt send successfully.")
+            } else if let error = response.error {
+                MXLog.error("[NotificationService] sendVoipReadReceipt: Read receipt send failed with error \(error).")
+            }
+        }
+    }
 }

--- a/changelog.d/5155.bugfix
+++ b/changelog.d/5155.bugfix
@@ -1,0 +1,1 @@
+Add BuildSetting to ignore badge updates from virtual rooms.

--- a/changelog.d/5155.bugfix
+++ b/changelog.d/5155.bugfix
@@ -1,1 +1,1 @@
-Add BuildSetting to ignore badge updates from virtual rooms.
+Ignore badge updates from virtual rooms.


### PR DESCRIPTION
Fixes #5155 

We clear the `content.badge` for the voip notification(leaving the badge the same) from the virtual room and we also send the read receipt so that the server value for the badge is also correct for subsequent notifications.