### PR TITLE
Fix voip calls after singout/signin

### DIFF
--- a/Riot/Managers/PushNotification/PushNotificationService.m
+++ b/Riot/Managers/PushNotification/PushNotificationService.m
@@ -269,7 +269,7 @@ Matrix session observer used to detect new opened sessions.
     NSData* token = [_pushRegistry pushTokenForType:PKPushTypeVoIP];
     if (token) {
         // If the token is available, store it. This can happen if you sign out and back in.
-        // i.e We are registered, but we have cleared it form the the store on logout and the
+        // i.e We are registered, but we have cleared it from the the store on logout and the
         // _pushRegistry lives through signin/signout as PushNotificationService is a singleton
         // on app delegate.
         _pushNotificationStore.pushKitToken = token;

--- a/Riot/Managers/PushNotification/PushNotificationService.m
+++ b/Riot/Managers/PushNotification/PushNotificationService.m
@@ -266,6 +266,15 @@ Matrix session observer used to detect new opened sessions.
 - (void)configurePushKit
 {
     MXLogDebug(@"[PushNotificationService] configurePushKit")
+    NSData* token = [_pushRegistry pushTokenForType:PKPushTypeVoIP];
+    if (token) {
+        // If the token is available, store it. This can happen if you sign out and back in.
+        // i.e We are registered, but we have cleared it form the the store on logout and the
+        // _pushRegistry lives through signin/signout as PushNotificationService is a singleton
+        // on app delegate.
+        _pushNotificationStore.pushKitToken = token;
+        MXLogDebug(@"[PushNotificationService] configurePushKit: Restored pushKit token")
+    }
     
     _pushRegistry.delegate = self;
     _pushRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -67,6 +67,7 @@ class NotificationService: UNNotificationServiceExtension {
     private var pushNotificationStore: PushNotificationStore = PushNotificationStore()
     private let localAuthenticationService = LocalAuthenticationService(pinCodePreferences: .shared)
     
+    private let backgroundServiceInitQueue = DispatchQueue(label: "backgroundServiceInitQueue")
     //  MARK: - Method Overrides
     
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
@@ -169,14 +170,16 @@ class NotificationService: UNNotificationServiceExtension {
         MXKAccountManager.shared()?.forceReloadAccounts()
         self.userAccount = MXKAccountManager.shared()?.activeAccounts.first
         if let userAccount = userAccount {
-            if NotificationService.backgroundSyncService?.credentials != userAccount.mxCredentials {
-                MXLog.debug("[NotificationService] setup: MXBackgroundSyncService init: BEFORE")
-                self.logMemory()
-                NotificationService.backgroundSyncService = MXBackgroundSyncService(withCredentials: userAccount.mxCredentials)
-                MXLog.debug("[NotificationService] setup: MXBackgroundSyncService init: AFTER")
-                self.logMemory()
+            backgroundServiceInitQueue.sync {
+                if NotificationService.backgroundSyncService?.credentials != userAccount.mxCredentials {
+                    MXLog.debug("[NotificationService] setup: MXBackgroundSyncService init: BEFORE")
+                    self.logMemory()
+                    NotificationService.backgroundSyncService = MXBackgroundSyncService(withCredentials: userAccount.mxCredentials)
+                    MXLog.debug("[NotificationService] setup: MXBackgroundSyncService init: AFTER")
+                    self.logMemory()
+                }
+                completion()
             }
-            completion()
         } else {
             MXLog.debug("[NotificationService] setup: No active accounts")
             fallbackToBestAttemptContent(forEventId: eventId)

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -66,8 +66,7 @@ class NotificationService: UNNotificationServiceExtension {
     }()
     private var pushNotificationStore: PushNotificationStore = PushNotificationStore()
     private let localAuthenticationService = LocalAuthenticationService(pinCodePreferences: .shared)
-    
-    private let backgroundServiceInitQueue = DispatchQueue(label: "backgroundServiceInitQueue")
+    private static let backgroundServiceInitQueue = DispatchQueue(label: "io.element.NotificationService.backgroundServiceInitQueue")
     //  MARK: - Method Overrides
     
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
@@ -170,7 +169,7 @@ class NotificationService: UNNotificationServiceExtension {
         MXKAccountManager.shared()?.forceReloadAccounts()
         self.userAccount = MXKAccountManager.shared()?.activeAccounts.first
         if let userAccount = userAccount {
-            backgroundServiceInitQueue.sync {
+            Self.backgroundServiceInitQueue.sync {
                 if NotificationService.backgroundSyncService?.credentials != userAccount.mxCredentials {
                     MXLog.debug("[NotificationService] setup: MXBackgroundSyncService init: BEFORE")
                     self.logMemory()

--- a/changelog.d/5199.bugfix
+++ b/changelog.d/5199.bugfix
@@ -1,0 +1,1 @@
+Fix bug where VoIP calls would not connect reliably after signout/signin.


### PR DESCRIPTION
The issue arrives here when the notification share extension is first initialised.
For calls, you can get multiple notifications close together (room join, call invite).

I think a few changes will be required to fix this issue fully.

What this updates:
- `MXBackgroundSyncService` init deletes/creates realm stores, if you have two separate notifications initialising this service at the same time realm can crash.
- Restores the callKit push token when configuring callKit after signout/signin.

Fixes #5199