### PR TITLE
Reduce grace period to report decryption failure

### DIFF
--- a/Riot/Modules/Analytics/DecryptionFailureTracker.m
+++ b/Riot/Modules/Analytics/DecryptionFailureTracker.m
@@ -19,11 +19,11 @@
 
 
 // Call `checkFailures` every `CHECK_INTERVAL`
-#define CHECK_INTERVAL 5
+#define CHECK_INTERVAL 2
 
 // Give events a chance to be decrypted by waiting `GRACE_PERIOD` before counting
 // and reporting them as failures
-#define GRACE_PERIOD 60
+#define GRACE_PERIOD 4
 
 // E2E failures analytics category.
 NSString *const kDecryptionFailureTrackerAnalyticsCategory = @"e2e.failure";

--- a/changelog.d/5345.change
+++ b/changelog.d/5345.change
@@ -1,0 +1,1 @@
+Reduce grace period to report decryption failure


### PR DESCRIPTION
A quick update to reduce the grace period for decryption from 60s to 4s (that would already be super annoying for a user)
