### PR TITLE
Fix crash uploading video ipad

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2172,6 +2172,8 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
             [MXSDKOptions sharedInstance].videoConversionPresetName = presetName;
             [roomInputToolbarView sendSelectedVideoAsset:videoAsset isPhotoLibraryAsset:isPhotoLibraryAsset];
         }];
+        compressionPrompt.popoverPresentationController.sourceView = roomInputToolbarView.attachMediaButton;
+        compressionPrompt.popoverPresentationController.sourceRect = roomInputToolbarView.attachMediaButton.bounds;
         
         [self presentViewController:compressionPrompt animated:YES completion:nil];
     }

--- a/changelog.d/5399.bugfix
+++ b/changelog.d/5399.bugfix
@@ -1,0 +1,1 @@
+Fix crash when uploading a video on iPad when "Confirm size when sending" is enabled in settings.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5399

iPads show popovers rather than alert views and you need to specify the source of the popover so that it knows how to position/orientate itself.