### PR TITLE
Add a simple screen SwiftUI template.

### DIFF
--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Coordinator/TemplateSimpleScreenCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Coordinator/TemplateSimpleScreenCoordinator.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct TemplateSimpleScreenCoordinatorParameters {
+    let promptType: TemplateSimpleScreenPromptType
+}
+
+final class TemplateSimpleScreenCoordinator: Coordinator, Presentable {
+    
+    // MARK: - Properties
+    
+    // MARK: Private
+    
+    private let parameters: TemplateSimpleScreenCoordinatorParameters
+    private let templateSimpleScreenHostingController: UIViewController
+    private var templateSimpleScreenViewModel: TemplateSimpleScreenViewModelProtocol
+    
+    // MARK: Public
+
+    // Must be used only internally
+    var childCoordinators: [Coordinator] = []
+    var completion: ((TemplateSimpleScreenViewModelResult) -> Void)?
+    
+    // MARK: - Setup
+    
+    @available(iOS 14.0, *)
+    init(parameters: TemplateSimpleScreenCoordinatorParameters) {
+        self.parameters = parameters
+        
+        let viewModel = TemplateSimpleScreenViewModel(promptType: parameters.promptType)
+        let view = TemplateSimpleScreen(viewModel: viewModel.context)
+        templateSimpleScreenViewModel = viewModel
+        templateSimpleScreenHostingController = VectorHostingController(rootView: view)
+    }
+    
+    // MARK: - Public
+    func start() {
+        MXLog.debug("[TemplateSimpleScreenCoordinator] did start.")
+        templateSimpleScreenViewModel.completion = { [weak self] result in
+            MXLog.debug("[TemplateSimpleScreenCoordinator] TemplateSimpleScreenViewModel did complete with result: \(result).")
+            guard let self = self else { return }
+            self.completion?(result)
+        }
+    }
+    
+    func toPresentable() -> UIViewController {
+        return self.templateSimpleScreenHostingController
+    }
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/MockTemplateSimpleScreenScreenState.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/MockTemplateSimpleScreenScreenState.swift
@@ -1,0 +1,57 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import SwiftUI
+
+/// Using an enum for the screen allows you define the different state cases with
+/// the relevant associated data for each case.
+@available(iOS 14.0, *)
+enum MockTemplateSimpleScreenScreenState: MockScreenState, CaseIterable {
+    // A case for each state you want to represent
+    // with specific, minimal associated data that will allow you
+    // mock that screen.
+    case promptType(TemplateSimpleScreenPromptType)
+    
+    /// The associated screen
+    var screenType: Any.Type {
+        TemplateSimpleScreen.self
+    }
+    
+    /// A list of screen state definitions
+    static var allCases: [MockTemplateSimpleScreenScreenState] {
+        // Each of the presence statuses
+        TemplateSimpleScreenPromptType.allCases.map(MockTemplateSimpleScreenScreenState.promptType)
+    }
+    
+    /// Generate the view struct for the screen state.
+    var screenView: ([Any], AnyView)  {
+        let promptType: TemplateSimpleScreenPromptType
+        switch self {
+        case .promptType(let type):
+            promptType = type
+        }
+        let viewModel = TemplateSimpleScreenViewModel(promptType: promptType)
+        
+        // can simulate service and viewModel actions here if needs be.
+        
+        return (
+            [promptType, viewModel],
+            AnyView(TemplateSimpleScreen(viewModel: viewModel.context)
+                .addDependency(MockAvatarService.example))
+        )
+    }
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenModels.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenModels.swift
@@ -1,0 +1,71 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+// MARK: - Coordinator
+
+enum TemplateSimpleScreenPromptType {
+    case regular
+    case upgrade
+}
+
+extension TemplateSimpleScreenPromptType: Identifiable, CaseIterable {
+    var id: Self { self }
+    
+    var title: String {
+        switch self {
+        case .regular:
+            return "Enable this feature?"
+        case .upgrade:
+            return "Upgrade this feature?"
+        }
+    }
+    
+    var imageName: String {
+        switch self {
+        case .regular:
+            return "person.circle"
+        case .upgrade:
+            return "arrowshape.zigzag.forward"
+        }
+    }
+}
+
+// MARK: View model
+
+enum TemplateSimpleScreenStateAction {
+    case viewAction(TemplateSimpleScreenViewAction)
+}
+
+enum TemplateSimpleScreenViewModelResult {
+    case accept
+    case cancel
+}
+
+// MARK: View
+
+struct TemplateSimpleScreenViewState: BindableState {
+    var promptType: TemplateSimpleScreenPromptType
+    var count: Int
+}
+
+enum TemplateSimpleScreenViewAction {
+    case incrementCount
+    case decrementCount
+    case accept
+    case cancel
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenModels.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenModels.swift
@@ -29,18 +29,18 @@ extension TemplateSimpleScreenPromptType: Identifiable, CaseIterable {
     var title: String {
         switch self {
         case .regular:
-            return "Enable this feature?"
+            return VectorL10n.roomCreationMakePublicPromptTitle
         case .upgrade:
-            return "Upgrade this feature?"
+            return VectorL10n.roomDetailsHistorySectionPromptTitle
         }
     }
     
-    var imageName: String {
+    var image: ImageAsset {
         switch self {
         case .regular:
-            return "person.circle"
+            return Asset.Images.appSymbol
         case .upgrade:
-            return "arrowshape.zigzag.forward"
+            return Asset.Images.keyVerificationSuccessShield
         }
     }
 }

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModel.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModel.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+@available(iOS 14, *)
+typealias TemplateSimpleScreenViewModelType = StateStoreViewModel<TemplateSimpleScreenViewState,
+                                                                 TemplateSimpleScreenStateAction,
+                                                                 TemplateSimpleScreenViewAction>
+@available(iOS 14, *)
+class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, TemplateSimpleScreenViewModelProtocol {
+
+    // MARK: - Properties
+
+    // MARK: Private
+
+    // MARK: Public
+
+    var completion: ((TemplateSimpleScreenViewModelResult) -> Void)?
+
+    // MARK: - Setup
+
+    init(promptType: TemplateSimpleScreenPromptType, initialCount: Int = 0) {
+        super.init(initialViewState: TemplateSimpleScreenViewState(promptType: promptType, count: 0))
+    }
+
+    // MARK: - Public
+
+    override func process(viewAction: TemplateSimpleScreenViewAction) {
+        switch viewAction {
+        case .accept:
+            accept()
+        case .cancel:
+            cancel()
+        case .incrementCount, .decrementCount:
+            dispatch(action: .viewAction(viewAction))
+        }
+    }
+
+    override class func reducer(state: inout TemplateSimpleScreenViewState, action: TemplateSimpleScreenStateAction) {
+        switch action {
+        case .viewAction(let viewAction):
+            switch viewAction {
+            case .incrementCount:
+                state.count += 1
+            case .decrementCount:
+                state.count -= 1
+            case .accept, .cancel:
+                break
+            }
+        }
+        UILog.debug("[TemplateSimpleScreenViewModel] reducer with action \(action) produced state: \(state)")
+    }
+
+    private func accept() {
+        completion?(.accept)
+    }
+
+    private func cancel() {
+        completion?(.cancel)
+    }
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModel.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModel.swift
@@ -18,8 +18,8 @@ import SwiftUI
 
 @available(iOS 14, *)
 typealias TemplateSimpleScreenViewModelType = StateStoreViewModel<TemplateSimpleScreenViewState,
-                                                                 TemplateSimpleScreenStateAction,
-                                                                 TemplateSimpleScreenViewAction>
+                                                                  TemplateSimpleScreenStateAction,
+                                                                  TemplateSimpleScreenViewAction>
 @available(iOS 14, *)
 class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, TemplateSimpleScreenViewModelProtocol {
 
@@ -42,9 +42,9 @@ class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, Template
     override func process(viewAction: TemplateSimpleScreenViewAction) {
         switch viewAction {
         case .accept:
-            accept()
+            completion?(.accept)
         case .cancel:
-            cancel()
+            completion?(.cancel)
         case .incrementCount, .decrementCount:
             dispatch(action: .viewAction(viewAction))
         }
@@ -63,13 +63,5 @@ class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, Template
             }
         }
         UILog.debug("[TemplateSimpleScreenViewModel] reducer with action \(action) produced state: \(state)")
-    }
-
-    private func accept() {
-        completion?(.accept)
-    }
-
-    private func cancel() {
-        completion?(.cancel)
     }
 }

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModelProtocol.swift
@@ -16,19 +16,9 @@
 
 import Foundation
 
-/// The static list of mocked screens in RiotSwiftUI
-@available(iOS 14.0, *)
-enum MockAppScreens {
-    static let appScreens: [MockScreenState.Type] = [
-        MockLocationSharingScreenState.self,
-        MockAnalyticsPromptScreenState.self,
-        MockUserSuggestionScreenState.self,
-        MockPollEditFormScreenState.self,
-        MockTimelinePollScreenState.self,
-        MockTemplateSimpleScreenScreenState.self,
-        MockTemplateUserProfileScreenState.self,
-        MockTemplateRoomListScreenState.self,
-        MockTemplateRoomChatScreenState.self
-    ]
+protocol TemplateSimpleScreenViewModelProtocol {
+    
+    var completion: ((TemplateSimpleScreenViewModelResult) -> Void)? { get set }
+    @available(iOS 14, *)
+    var context: TemplateSimpleScreenViewModelType.Context { get }
 }
-

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/UI/TemplateSimpleScreenUITests.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/UI/TemplateSimpleScreenUITests.swift
@@ -1,0 +1,45 @@
+//
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import RiotSwiftUI
+
+@available(iOS 14.0, *)
+class TemplateSimpleScreenUITests: MockScreenTest {
+
+    override class var screenType: MockScreenState.Type {
+        return MockTemplateSimpleScreenScreenState.self
+    }
+
+    override class func createTest() -> MockScreenTest {
+        return TemplateSimpleScreenUITests(selector: #selector(verifyTemplateSimpleScreenScreen))
+    }
+
+    func verifyTemplateSimpleScreenScreen() throws {
+        guard let screenState = screenState as? MockTemplateSimpleScreenScreenState else { fatalError("no screen") }
+        switch screenState {
+        case .promptType(let promptType):
+            verifyTemplateSimpleScreenPromptType(promptType: promptType)
+        }
+    }
+    
+    func verifyTemplateSimpleScreenPromptType(promptType: TemplateSimpleScreenPromptType) {
+        let title = app.staticTexts["title"]
+        XCTAssert(title.exists)
+        XCTAssertEqual(title.label, promptType.title)
+    }
+
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/Unit/TemplateSimpleScreenViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/Unit/TemplateSimpleScreenViewModelTests.swift
@@ -1,0 +1,49 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+@testable import RiotSwiftUI
+
+@available(iOS 14.0, *)
+class TemplateSimpleScreenViewModelTests: XCTestCase {
+    private enum Constants {
+        static let counterInitialValue = 0
+    }
+    
+    var viewModel: TemplateSimpleScreenViewModelProtocol!
+    var context: TemplateSimpleScreenViewModelType.Context!
+    
+    override func setUpWithError() throws {
+        viewModel = TemplateSimpleScreenViewModel(promptType: .regular, initialCount: Constants.counterInitialValue)
+        context = viewModel.context
+    }
+
+    func testInitialState() {
+        XCTAssertEqual(context.viewState.count, Constants.counterInitialValue)
+    }
+
+    func testCounter() throws {
+        context.send(viewAction: .incrementCount)
+        XCTAssertEqual(context.viewState.count, 1)
+        
+        context.send(viewAction: .incrementCount)
+        XCTAssertEqual(context.viewState.count, 2)
+        
+        context.send(viewAction: .decrementCount)
+        XCTAssertEqual(context.viewState.count, 1)
+    }
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/View/TemplateSimpleScreen.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/View/TemplateSimpleScreen.swift
@@ -1,0 +1,111 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+@available(iOS 14.0, *)
+struct TemplateSimpleScreen: View {
+
+    // MARK: - Properties
+    
+    // MARK: Private
+    
+    @Environment(\.theme) private var theme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    
+    private var horizontalPadding: CGFloat {
+        horizontalSizeClass == .regular ? 50 : 16
+    }
+    
+    // MARK: Public
+    
+    @ObservedObject var viewModel: TemplateSimpleScreenViewModel.Context
+    
+    /// The main content of the view to be shown in a scroll view.
+    var mainContent: some View {
+        VStack(spacing: 36) {
+            Text(viewModel.viewState.promptType.title)
+                .font(theme.fonts.title1B)
+                .foregroundColor(theme.colors.primaryContent)
+                .accessibilityIdentifier("title")
+            
+            Image(systemName: viewModel.viewState.promptType.imageName)
+                .resizable()
+                .scaledToFit()
+                .frame(width:100)
+                .foregroundColor(theme.colors.accent)
+            
+            HStack{
+                Text("Counter: \(viewModel.viewState.count)")
+                    .foregroundColor(theme.colors.primaryContent)
+                
+                Button("-") {
+                    viewModel.send(viewAction: .decrementCount)
+                }
+                
+                Button("+") {
+                    viewModel.send(viewAction: .incrementCount)
+                }
+            }
+            .font(theme.fonts.title3)
+        }
+    }
+    
+    /// The action buttons shown at the bottom of the view.
+    var buttons: some View {
+        VStack {
+            Button { viewModel.send(viewAction: .accept) } label: {
+                Text("Accept")
+                    .font(theme.fonts.bodySB)
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+            
+            Button { viewModel.send(viewAction: .cancel) } label: {
+                Text("Cancel")
+                    .font(theme.fonts.body)
+                    .padding(.vertical, 12)
+            }
+        }
+    }
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                ScrollView(showsIndicators: false) {
+                    mainContent
+                        .padding(.top, 50)
+                        .padding(.horizontal, horizontalPadding)
+                }
+                
+                buttons
+                    .padding(.horizontal, horizontalPadding)
+                    .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
+            }
+        }
+        .background(theme.colors.background.ignoresSafeArea())
+        .accentColor(theme.colors.accent)
+    }
+}
+
+// MARK: - Previews
+
+@available(iOS 14.0, *)
+struct TemplateSimpleScreen_Previews: PreviewProvider {
+    static let stateRenderer = MockTemplateSimpleScreenScreenState.stateRenderer
+    static var previews: some View {
+        stateRenderer.screenGroup()
+    }
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/View/TemplateSimpleScreen.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/View/TemplateSimpleScreen.swift
@@ -34,6 +34,26 @@ struct TemplateSimpleScreen: View {
     
     @ObservedObject var viewModel: TemplateSimpleScreenViewModel.Context
     
+    // MARK: Views
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                ScrollView(showsIndicators: false) {
+                    mainContent
+                        .padding(.top, 50)
+                        .padding(.horizontal, horizontalPadding)
+                }
+                
+                buttons
+                    .padding(.horizontal, horizontalPadding)
+                    .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
+            }
+        }
+        .background(theme.colors.background.ignoresSafeArea())
+        .accentColor(theme.colors.accent)
+    }
+    
     /// The main content of the view to be shown in a scroll view.
     var mainContent: some View {
         VStack(spacing: 36) {
@@ -42,7 +62,7 @@ struct TemplateSimpleScreen: View {
                 .foregroundColor(theme.colors.primaryContent)
                 .accessibilityIdentifier("title")
             
-            Image(systemName: viewModel.viewState.promptType.imageName)
+            Image(viewModel.viewState.promptType.image.name)
                 .resizable()
                 .scaledToFit()
                 .frame(width:100)
@@ -79,24 +99,6 @@ struct TemplateSimpleScreen: View {
                     .padding(.vertical, 12)
             }
         }
-    }
-    
-    var body: some View {
-        GeometryReader { geometry in
-            VStack {
-                ScrollView(showsIndicators: false) {
-                    mainContent
-                        .padding(.top, 50)
-                        .padding(.horizontal, horizontalPadding)
-                }
-                
-                buttons
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
-            }
-        }
-        .background(theme.colors.background.ignoresSafeArea())
-        .accentColor(theme.colors.accent)
     }
 }
 

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfile.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfile.swift
@@ -30,7 +30,6 @@ struct TemplateUserProfile: View {
     @ObservedObject var viewModel: TemplateUserProfileViewModel.Context
     
     var body: some View {
-        EmptyView()
         VStack {
             TemplateUserProfileHeader(
                 avatar: viewModel.viewState.avatar,

--- a/Tools/Templates/createSwiftUISimpleScreen.sh
+++ b/Tools/Templates/createSwiftUISimpleScreen.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ ! $# -eq 2 ]; then
+    echo "Usage: ./createSwiftUISimpleScreen.sh Folder MyScreenName"
+    exit 1
+fi
+
+MODULE_DIR="../../RiotSwiftUI/Modules"
+OUTPUT_DIR=$MODULE_DIR/$1
+SCREEN_NAME=$2
+SCREEN_VAR_NAME=`echo $SCREEN_NAME | awk '{ print tolower(substr($0, 1, 1)) substr($0, 2) }'`
+TEMPLATE_DIR=$MODULE_DIR/Template/SimpleScreenExample/
+if [ -e $OUTPUT_DIR ]; then
+    echo "Error: Folder ${OUTPUT_DIR} already exists"
+    exit 1
+fi
+
+echo "Create folder ${OUTPUT_DIR}"
+
+mkdir -p $OUTPUT_DIR
+cp -R $TEMPLATE_DIR $OUTPUT_DIR/
+
+cd $OUTPUT_DIR
+for file in $(find * -type f -print)
+do
+  echo "Building ${file/TemplateSimpleScreen/$SCREEN_NAME}..."
+  perl -p -i -e "s/TemplateSimpleScreen/"$SCREEN_NAME"/g" $file
+  perl -p -i -e "s/templateSimpleScreen/"$SCREEN_VAR_NAME"/g" $file
+
+  mv ${file} ${file/TemplateSimpleScreen/$SCREEN_NAME}
+done

--- a/changelog.d/5349.misc
+++ b/changelog.d/5349.misc
@@ -1,0 +1,1 @@
+Add a simple screen SwiftUI template.


### PR DESCRIPTION
The template is generated from the single screen template, with the service removed, but the reducer left in place for some basic state management. Fixes #5349.