### PR TITLE
Call transfer selection should put the other person on hold.

### DIFF
--- a/Riot/Modules/Call/CallViewController.m
+++ b/Riot/Modules/Call/CallViewController.m
@@ -645,8 +645,8 @@ CallAudioRouteMenuViewDelegate>
 {
     CallTransferMainViewController *controller = [CallTransferMainViewController instantiateWithSession:self.mainSession ignoredUserIds:@[self.peer.userId]];
     controller.delegate = self;
-    
     UINavigationController *navController = [[RiotNavigationController alloc] initWithRootViewController:controller];
+    [self.mxCall hold:YES];
     [self presentViewController:navController animated:YES completion:nil];
 }
 
@@ -732,6 +732,7 @@ CallAudioRouteMenuViewDelegate>
 
 - (void)callTransferMainViewControllerDidCancel:(CallTransferMainViewController *)viewController
 {
+    [self.mxCall hold:NO];
     [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/changelog.d/5451.bugfix
+++ b/changelog.d/5451.bugfix
@@ -1,0 +1,1 @@
+Selecting Transfer in a call should immediately put the the other person on hold until the call connects or the Transfer is cancelled.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5451