### PR TITLE
Green spinner hidden too early

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2335,11 +2335,11 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                 case MXSessionStateClosed:
                 case MXSessionStateInitialised:
                 case MXSessionStateBackgroundSyncInProgress:
-                case MXSessionStateProcessingBackgroundSyncCache:
                     self.roomListDataReady = NO;
                     isLaunching = YES;
                     break;
                 case MXSessionStateStoreDataReady:
+                case MXSessionStateProcessingBackgroundSyncCache:
                 case MXSessionStateSyncInProgress:
                     // Stay in launching during the first server sync if the store is empty.
                     isLaunching = (mainSession.rooms.count == 0 && launchAnimationContainerView);

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2335,6 +2335,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                 case MXSessionStateClosed:
                 case MXSessionStateInitialised:
                 case MXSessionStateBackgroundSyncInProgress:
+                case MXSessionStateProcessingBackgroundSyncCache:
                     self.roomListDataReady = NO;
                     isLaunching = YES;
                     break;

--- a/changelog.d/5472.bugfix
+++ b/changelog.d/5472.bugfix
@@ -1,0 +1,1 @@
+Green launch spinner is sometimes dismissed too early causing the incorrect onboarding screen to be displayed.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5472
The green spinner should not hide for `MXSessionStateProcessingBackgroundSyncCache`.