### PR TITLE
Scroll to the bottom of timeline automatically

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -215,6 +215,11 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
 @property (nonatomic, readwrite) RoomDisplayConfiguration *displayConfiguration;
 @property (nonatomic) AnalyticsScreenTimer *screenTimer;
 
+// When layout of the screen changes (e.g. height), we no longer know whether
+// to autoscroll to the bottom again or not. Instead we need to capture the
+// scroll state just before the layout change, and restore it after the layout.
+@property (nonatomic) BOOL shouldScrollToBottomAfterLayout;
+
 @end
 
 @implementation RoomViewController
@@ -650,6 +655,11 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     [self.screenTimer stop];
 }
 
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];
+    self.shouldScrollToBottomAfterLayout = self.isBubblesTableScrollViewAtTheBottom;
+}
+
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
@@ -715,9 +725,10 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
         self.edgesForExtendedLayout = UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight;
     }
     
-    //  stay at the bottom if already was
-    if (self.isBubblesTableScrollViewAtTheBottom)
+    // re-scroll to the bottom, if at bottom before the most recent layout
+    if (self.shouldScrollToBottomAfterLayout)
     {
+        self.shouldScrollToBottomAfterLayout = NO;
         [self scrollBubblesTableViewToBottomAnimated:NO];
     }
     

--- a/changelog.d/4524.bugfix
+++ b/changelog.d/4524.bugfix
@@ -1,0 +1,1 @@
+Timeline: automatically scroll timeline to the bottom when opening a room or rotating device.


### PR DESCRIPTION
Fixes #4524 

The `isBubblesTableScrollViewAtTheBottom` method was being used in `viewDidLayoutSubviews` to determine, whether to scroll to the bottom-most bubble. The issue is however that `viewDidLayoutSubviews` may change the size of the view, making `isBubblesTableScrollViewAtTheBottom` give the wrong result.

To solve this we need to capture the value of `isBubblesTableScrollViewAtTheBottom` during `viewWillLayout` and use that value in `viewDidLayoutSubviews`