### PR TITLE
Space list loses responsiveness upon refresh

### DIFF
--- a/Riot/Modules/Spaces/SpaceList/SpaceListViewController.storyboard
+++ b/Riot/Modules/Spaces/SpaceList/SpaceListViewController.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spaces" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQD-at-CDq">
-                                <rect key="frame" x="16" y="44" width="382" height="21"/>
+                                <rect key="frame" x="16" y="44" width="56.5" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -31,20 +31,25 @@
                                     <outlet property="delegate" destination="V8j-Lb-PgC" id="Dlq-3U-wxg"/>
                                 </connections>
                             </tableView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="uRD-bG-wFr">
+                                <rect key="frame" x="80.5" y="44.5" width="20" height="20"/>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="bFg-jh-JZB"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="uRD-bG-wFr" firstAttribute="centerY" secondItem="VQD-at-CDq" secondAttribute="centerY" id="2wK-5R-ksc"/>
                             <constraint firstItem="fr1-tf-eDV" firstAttribute="top" secondItem="VQD-at-CDq" secondAttribute="bottom" constant="16" id="Cgt-Qc-Jro"/>
                             <constraint firstAttribute="trailing" secondItem="fr1-tf-eDV" secondAttribute="trailing" id="F07-Ge-xr5"/>
                             <constraint firstAttribute="bottomMargin" secondItem="fr1-tf-eDV" secondAttribute="bottom" id="FfH-sZ-enc"/>
-                            <constraint firstItem="bFg-jh-JZB" firstAttribute="trailing" secondItem="VQD-at-CDq" secondAttribute="trailing" constant="16" id="Pg7-ae-av6"/>
                             <constraint firstItem="fr1-tf-eDV" firstAttribute="leading" secondItem="EL9-GA-lwo" secondAttribute="leading" id="dPV-AP-ody"/>
                             <constraint firstItem="VQD-at-CDq" firstAttribute="top" secondItem="bFg-jh-JZB" secondAttribute="top" id="g1M-rQ-73b"/>
+                            <constraint firstItem="uRD-bG-wFr" firstAttribute="leading" secondItem="VQD-at-CDq" secondAttribute="trailing" constant="8" symbolic="YES" id="tD6-fY-fcw"/>
                             <constraint firstItem="VQD-at-CDq" firstAttribute="leading" secondItem="bFg-jh-JZB" secondAttribute="leading" constant="16" id="zLQ-Xc-Vqj"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="activityIndicator" destination="uRD-bG-wFr" id="Qtb-LH-a9A"/>
                         <outlet property="tableView" destination="fr1-tf-eDV" id="QLT-hP-wCg"/>
                         <outlet property="titleLabel" destination="VQD-at-CDq" id="Sgc-OZ-Ntb"/>
                     </connections>

--- a/Riot/Modules/Spaces/SpaceList/SpaceListViewController.swift
+++ b/Riot/Modules/Spaces/SpaceList/SpaceListViewController.swift
@@ -32,13 +32,13 @@ final class SpaceListViewController: UIViewController {
 
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     
     // MARK: Private
 
     private var viewModel: SpaceListViewModelType!
     private var theme: Theme!
     private var errorPresenter: MXKErrorPresentation!
-    private var activityPresenter: ActivityIndicatorPresenter!
     
     private var sections: [SpaceListSection] = []
 
@@ -59,7 +59,6 @@ final class SpaceListViewController: UIViewController {
         // Do any additional setup after loading the view.
         
         self.setupViews()
-        self.activityPresenter = ActivityIndicatorPresenter()
         self.errorPresenter = MXKErrorAlertPresentation()
         
         self.registerThemeServiceDidChangeThemeNotification()
@@ -86,6 +85,8 @@ final class SpaceListViewController: UIViewController {
         
         self.titleLabel.textColor = theme.colors.primaryContent
         self.titleLabel.font = theme.fonts.bodySB
+        
+        self.activityIndicator.color = theme.colors.secondaryContent
     }
     
     private func registerThemeServiceDidChangeThemeNotification() {
@@ -124,14 +125,11 @@ final class SpaceListViewController: UIViewController {
     }
     
     private func renderLoading() {
-        self.activityPresenter.presentActivityIndicator(on: self.view, animated: true)
-        if let selectedRow = self.tableView.indexPathForSelectedRow {
-            self.tableView.deselectRow(at: selectedRow, animated: true)
-        }
+        self.activityIndicator.startAnimating()
     }
     
     private func renderLoaded(sections: [SpaceListSection]) {
-        self.activityPresenter.removeCurrentActivityIndicator(animated: true)
+        self.activityIndicator.stopAnimating()
         self.sections = sections
         self.tableView.reloadData()
     }
@@ -141,7 +139,6 @@ final class SpaceListViewController: UIViewController {
     }
     
     private func render(error: Error) {
-        self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
     }
 }


### PR DESCRIPTION
fix #5323

@niquewoodhouse we are using a indicator presenter and each time the list is refreshed this presenter is shown then hidden animated. The refresh of the list itself takes long (some few ms) but it takes 300ms to show the indicator and 300ms to hide it. So the space list loses its responsiveness for at least 600ms.

To solve this issue I would rather use an activity indicator alongside the View title:

![ezgif-5-ca18384e03](https://user-images.githubusercontent.com/15386762/152204394-0cda6a0e-1848-46a2-a3a5-394de4fc8d90.gif)

