### PR TITLE
Handle session states better

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1377,6 +1377,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                                 event = eventFromServer;
                                 dispatch_group_leave(eventDispatchGroup);
                             } failure:^(NSError *error) {
+                                MXLogError(@"[LegacyAppDelegate] handleUniversalLinkWithParameters: event fetch failed: %@", error);
                                 dispatch_group_leave(eventDispatchGroup);
                             }];
                         }

--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -1020,7 +1020,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
                 }
             }
             
-            MXLogDebug(@"[MXKAccount] Pause is delayed at the end of sync (current state %tu)", mxSession.state);
+            MXLogDebug(@"[MXKAccount] Pause is delayed at the end of sync (current state %@)", [MXTools readableSessionState: mxSession.state]);
             isPauseRequested = YES;
         }
     }
@@ -1032,7 +1032,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
     
     if (mxSession)
     {
-        MXLogVerbose(@"[MXKAccount] resume with session state: %tu", mxSession.state);
+        MXLogVerbose(@"[MXKAccount] resume with session state: %@", [MXTools readableSessionState:mxSession.state]);
         
         [self cancelBackgroundSync];
         
@@ -1891,7 +1891,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
         }
         else
         {
-            MXLogDebug(@"[MXKAccount] cannot start background Sync (invalid state %tu)", mxSession.state);
+            MXLogDebug(@"[MXKAccount] cannot start background Sync (invalid state %@)", [MXTools readableSessionState:mxSession.state]);
             failure([NSError errorWithDomain:kMXKAccountErrorDomain code:0 userInfo:nil]);
         }
     }

--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -1754,6 +1754,7 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
                     
                     dispatch_group_leave(dispatchGroup);
                 } failure:^(NSError *error) {
+                    MXLogError(@"[MXKAccount] onDateTimeFormatUpdate: event fetch failed: %@", error);
                     dispatch_group_leave(dispatchGroup);
                 }];
             }

--- a/changelog.d/5426.bugfix
+++ b/changelog.d/5426.bugfix
@@ -1,0 +1,1 @@
+MXKAccount: Gracefully pause the session.


### PR DESCRIPTION
- Uses readable session states when logging for missed places.
- Adds some error logs around `event/(null)` requests.
- Updates in `MXKAccount` to gracefully pause the session on certain states.

Fixes #5426 and requires https://github.com/matrix-org/matrix-ios-sdk/pull/1359