### PR TITLE
Handle jpeg and png UTType properly

### DIFF
--- a/RiotShareExtension/Sources/ShareExtensionShareItemProvider.swift
+++ b/RiotShareExtension/Sources/ShareExtensionShareItemProvider.swift
@@ -27,7 +27,9 @@ private class ShareExtensionItem: ShareItemProtocol {
     }
     
     var type: ShareItemType {
-        if itemProvider.hasItemConformingToTypeIdentifier(MXKUTI.image.rawValue) {
+        if itemProvider.hasItemConformingToTypeIdentifier(MXKUTI.image.rawValue)
+            || itemProvider.hasItemConformingToTypeIdentifier(MXKUTI.jpeg.rawValue)
+            || itemProvider.hasItemConformingToTypeIdentifier(MXKUTI.png.rawValue) {
             return .image
         } else if itemProvider.hasItemConformingToTypeIdentifier(MXKUTI.video.rawValue) {
             return .video

--- a/changelog.d/3636.bugfix
+++ b/changelog.d/3636.bugfix
@@ -1,0 +1,1 @@
+Share: Handle jpeg and png UTType properly


### PR DESCRIPTION
Fixes #3636 

This adds a check on png/jpeg UTType with the same priority as kUTTypeImage (which already worked properly when sharing with UIImage). 
Reproducing issue should work with any app sharing an image file URL rather than an UIImage.

Screenshot of the receiving web app, first message is without this fix : 
![image](https://user-images.githubusercontent.com/80891108/152558185-0ac0e65f-7556-4e8f-b4e7-dde04c9dcb60.png)