### PR TITLE
Exclude all items from iCloud backup

### DIFF
--- a/Riot/Managers/URLPreviews/Core Data/URLPreviewStore.swift
+++ b/Riot/Managers/URLPreviews/Core Data/URLPreviewStore.swift
@@ -61,6 +61,14 @@ class URLPreviewStore {
             if let error = error {
                 MXLog.error("[URLPreviewStore] Core Data container error: \(error.localizedDescription)")
             }
+            
+            if let url = storeDescription.url {
+                do {
+                    try FileManager.default.excludeItemFromBackup(at: url)
+                } catch {
+                    MXLog.error("[URLPreviewStore] Cannot exclude Core Data from backup: \(error.localizedDescription)")
+                }
+            }
         }
     }
     

--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import Intents
+import MatrixSDK
 
 #if DEBUG
 import FLEX
@@ -79,6 +80,7 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
     func start() {
         self.setupLogger()
         self.setupTheme()
+        self.excludeAllItemsFromBackup()
         
         // Setup navigation router store
         _ = NavigationRouterStore.shared
@@ -127,6 +129,17 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
 
             ThemePublisher.shared.republish(themeIdPublisher: themeIdPublisher)
         }
+    }
+    
+    private func excludeAllItemsFromBackup() {
+        let manager = FileManager.default
+        
+        // Individual files and directories created by the application or SDK are excluded case-by-case,
+        // but sometimes the lifecycle of a file is not directly controlled by the app (e.g. plists for
+        // UserDefaults). For that reason the app will always exclude all top-level directories as well
+        // as individual files.
+        manager.excludeAllUserDirectoriesFromBackup()
+        manager.excludeAllAppGroupDirectoriesFromBackup()
     }
     
     private func showAuthentication() {

--- a/Riot/Modules/MatrixKit/Models/Contact/MXKContactManager.m
+++ b/Riot/Modules/MatrixKit/Models/Contact/MXKContactManager.m
@@ -1873,6 +1873,10 @@ static NSString *contactsBookInfoFile = @"contactsV2";
     if (error == nil)
     {
         [cipher writeToFile:[self dataFilePathForComponent:fileName] atomically:YES];
+        [[NSFileManager defaultManager] excludeItemFromBackupAt:[NSURL fileURLWithPath:fileName] error:&error];
+        if (error) {
+            MXLogDebug(@"[MXKContactManager] Cannot exclude item from backup %@", error.localizedDescription);
+        }
     }
     else
     {

--- a/Riot/Modules/MatrixKit/Models/MXKAppSettings.m
+++ b/Riot/Modules/MatrixKit/Models/MXKAppSettings.m
@@ -19,6 +19,7 @@
 #import "MXKAppSettings.h"
 
 #import "MXKTools.h"
+@import MatrixSDK;
 
 
 // get ISO country name
@@ -66,11 +67,10 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
 {
     NSString *cacheFolder;
 
-    // Check for a potential application group id
-    NSString *applicationGroupIdentifier = [MXSDKOptions sharedInstance].applicationGroupIdentifier;
-    if (applicationGroupIdentifier)
+    // Check for a potential application group container
+    NSURL *sharedContainerURL = [[NSFileManager defaultManager] applicationGroupContainerURL];
+    if (sharedContainerURL)
     {
-        NSURL *sharedContainerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:applicationGroupIdentifier];
         cacheFolder = [sharedContainerURL path];
     }
     else
@@ -86,7 +86,7 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
     if (cacheFolder && ![[NSFileManager defaultManager] fileExistsAtPath:cacheFolder])
     {
         NSError *error;
-        [[NSFileManager defaultManager] createDirectoryAtPath:cacheFolder withIntermediateDirectories:YES attributes:nil error:&error];
+        [[NSFileManager defaultManager] createDirectoryExcludedFromBackupAtPath:cacheFolder error:&error];
         if (error)
         {
             MXLogDebug(@"[MXKAppSettings] cacheFolder: Error: Cannot create MatrixKit folder at %@. Error: %@", cacheFolder, error);

--- a/changelog.d/5498.change
+++ b/changelog.d/5498.change
@@ -1,0 +1,1 @@
+Exclude all files and directories from iCloud and iTunes backup


### PR DESCRIPTION
Fixes #5498 

Application-side changes corresponding to [SDK changes](https://github.com/matrix-org/matrix-ios-sdk/pull/1361). This means excluding some application-specific files (e.g. Core Data), as well as triggering a blanket exclusion of all top-level directories on app start. Note that if this is the first time a user has installed the app, some folders created after app start and not explicitly excluded will be backed up to iCloud. Once the app is relaunched, the newly created folders will not be excluded as well and removed from the backup.
