### PR TITLE
Fix for images sometimes being sent unencrypted in an encrypted room.

### DIFF
--- a/Riot/Modules/Room/MXKRoomViewController.h
+++ b/Riot/Modules/Room/MXKRoomViewController.h
@@ -438,11 +438,12 @@ typedef NS_ENUM(NSUInteger, MXKRoomViewControllerJoinRoomResult) {
 - (void)setBubbleTableViewContentOffset:(CGPoint)contentOffset animated:(BOOL)animated;
 
 /**
- Handle typing notification.
+ Sends a typing notification with the specified timeout.
  
  @param typing Flag indicating whether the user is typing or not.
+ @param notificationTimeoutMS The length of time the typing notification is valid for
  */
-- (void)handleTypingNotification:(BOOL)typing;
+- (void)sendTypingNotification:(BOOL)typing timeout:(NSUInteger)notificationTimeoutMS;
 
 
 /**

--- a/Riot/Modules/Room/MXKRoomViewController.h
+++ b/Riot/Modules/Room/MXKRoomViewController.h
@@ -444,4 +444,10 @@ typedef NS_ENUM(NSUInteger, MXKRoomViewControllerJoinRoomResult) {
  */
 - (void)handleTypingNotification:(BOOL)typing;
 
+
+/**
+ Share encryption keys in this room.
+ */
+- (void)shareEncryptionKeys;
+
 @end

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -3299,7 +3299,7 @@
         roomDataSource.partialTextMessage = inputToolbarView.textMessage;
     }
     
-    [self handleTypingNotification:typing];
+    [self handleTypingState:typing];
 }
 
 - (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView heightDidChanged:(CGFloat)height completion:(void (^)(BOOL finished))completion
@@ -3420,7 +3420,7 @@
 }
 # pragma mark - Typing notification
 
-- (void)handleTypingNotification:(BOOL)typing
+- (void)handleTypingState:(BOOL)typing
 {
     NSUInteger notificationTimeoutMS = -1;
     if (typing)
@@ -3482,6 +3482,11 @@
         lastTypingDate = nil;
     }
     
+    [self sendTypingNotification:typing timeout:notificationTimeoutMS];
+}
+
+- (void)sendTypingNotification:(BOOL)typing timeout:(NSUInteger)notificationTimeoutMS
+{
     MXWeakify(self);
     
     // Send typing notification to server
@@ -3512,7 +3517,7 @@
     // Check whether a new typing event has been observed
     BOOL typing = (lastTypingDate != nil);
     // Post a new typing notification
-    [self handleTypingNotification:typing];
+    [self handleTypingState:typing];
 }
 
 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4564,6 +4564,15 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     [self.userSuggestionCoordinator processTextMessage:toolbarView.textMessage];
 }
 
+- (void)roomInputToolbarViewDidOpenActionMenu:(MXKRoomInputToolbarView*)toolbarView
+{
+    // Consider opening the action menu as beginning to type and share encryption keys if requested.
+    if ([MXKAppSettings standardAppSettings].outboundGroupSessionKeyPreSharingStrategy == MXKKeyPreSharingWhenTyping)
+    {
+        [self shareEncryptionKeys];
+    }
+}
+
 #pragma mark - MXKRoomMemberDetailsViewControllerDelegate
 
 - (void)roomMemberDetailsViewController:(MXKRoomMemberDetailsViewController *)roomMemberDetailsViewController startChatWithMemberId:(NSString *)matrixId completion:(void (^)(void))completion

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.h
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.h
@@ -47,6 +47,13 @@ typedef enum : NSUInteger
  */
 - (void)roomInputToolbarViewDidChangeTextMessage:(MXKRoomInputToolbarView*)toolbarView;
 
+/**
+ Inform the delegate that the action menu was opened.
+ 
+ @param toolbarView the room input toolbar view
+ */
+- (void)roomInputToolbarViewDidOpenActionMenu:(MXKRoomInputToolbarView*)toolbarView;
+
 @end
 
 /**

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -429,6 +429,7 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
         if (_actionMenuOpened) {
             self.actionsBar.hidden = NO;
             [self.actionsBar animateWithShowIn:_actionMenuOpened completion:nil];
+            [self.delegate roomInputToolbarViewDidOpenActionMenu:self];
         }
         else
         {

--- a/Riot/Modules/Threads/Thread/ThreadViewController.swift
+++ b/Riot/Modules/Threads/Thread/ThreadViewController.swift
@@ -70,8 +70,8 @@ class ThreadViewController: RoomViewController {
         super.onButtonPressed(sender)
     }
     
-    override func handleTypingNotification(_ typing: Bool) {
-        //  no-op
+    override func sendTypingNotification(_ typing: Bool, timeout notificationTimeoutMS: UInt) {
+        // no-op
     }
 
     private func showThreadActions() {

--- a/changelog.d/5564.bugfix
+++ b/changelog.d/5564.bugfix
@@ -1,0 +1,1 @@
+Fix for images sometimes being sent unencrypted inside an encrypted room.


### PR DESCRIPTION
Following on from https://github.com/matrix-org/matrix-ios-sdk/pull/1358 it is possible in 1.8.0 TF for the [query](https://github.com/matrix-org/matrix-ios-sdk/blob/7be07981c3f2932b0205797f234982ca32da7dff/MatrixSDK/Crypto/Data/Store/MXRealmCryptoStore/MXRealmCryptoStore.m#L819) to a room's encryption algorithm to occur before that algorithm has been stored in the realm when sending an image. When sending a text message the algorithm gets stored when `shareEncryptionKeys` is called before a typing notification is created.

This PR mimics the same behaviour by calling `shareEncryptionKeys` when the composer's action menu is displayed as none of those events send typing notifications. That said, I think some deeper thought needs to go into the timing of all of this if we are going to rely on using the realm for encryption status.