### PR TITLE
Message bubbles: Fix edited text message `edited` link not working

### DIFF
--- a/Riot/Modules/Room/TimelineCells/BaseRoomCell/BaseRoomCell.swift
+++ b/Riot/Modules/Room/TimelineCells/BaseRoomCell/BaseRoomCell.swift
@@ -133,6 +133,7 @@ class BaseRoomCell: MXKRoomBubbleTableViewCell, BaseRoomCellProtocol {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        self.commonInit()
     }
     
     private func commonInit() {
@@ -179,6 +180,41 @@ class BaseRoomCell: MXKRoomBubbleTableViewCell, BaseRoomCellProtocol {
         if showEncryptionStatus {
             self.setupEncryptionStatusViewTapGestureRecognizer()
         }
+    }
+    
+    override func setupSenderNameLabel() {
+        
+        guard let userNameTouchMaskView = self.roomCellContentView?.userNameTouchMaskView else {
+            return
+        }
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onSenderNameTap(_:)))
+        tapGesture.numberOfTouchesRequired = 1
+        tapGesture.numberOfTapsRequired = 1
+        tapGesture.delegate = self
+
+        userNameTouchMaskView.addGestureRecognizer(tapGesture)
+    }
+    
+    override func setupAvatarView() {
+        
+        guard let avatarImageView = self.roomCellContentView?.avatarImageView else {
+            return
+        }
+        
+        avatarImageView.mediaFolder = kMXMediaManagerAvatarThumbnailFolder
+
+        // Listen to avatar tap
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onAvatarTap(_:)))
+        tapGesture.numberOfTouchesRequired = 1
+        tapGesture.numberOfTapsRequired = 1
+        tapGesture.delegate = self
+        avatarImageView.addGestureRecognizer(tapGesture)
+        avatarImageView.isUserInteractionEnabled = true
+
+        // Add a long gesture recognizer on avatar (in order to display for example the member details)
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(onLongPressGesture(_:)))
+        avatarImageView.addGestureRecognizer(longPress)
     }
     
     override class func defaultReuseIdentifier() -> String! {

--- a/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.h
+++ b/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.h
@@ -337,10 +337,31 @@ extern NSString *const kMXKRoomBubbleCellUrlItemInteraction;
  */
 - (void)setupViews;
 
+/// Setup sender name label if needed
+- (void)setupSenderNameLabel;
+
+/// Setup avatar view if needed
+- (void)setupAvatarView;
+
+/// Setup message text view if needed
+- (void)setupMessageTextView;
+
+/// Setup message text view long press gesture if needed
+- (void)setupMessageTextViewLongPressGesture;
+
 /// Add temporary subview to `tmpSubviews` property.
 - (void)addTemporarySubview:(UIView*)subview;
 
 /// Called when content view cell is tapped
 - (IBAction)onContentViewTap:(UITapGestureRecognizer*)sender;
+
+/// Called when sender name is tapped
+- (IBAction)onSenderNameTap:(UITapGestureRecognizer*)sender;
+
+/// Called when avatar view is tapped
+- (IBAction)onAvatarTap:(UITapGestureRecognizer*)sender;
+
+/// Called when a UI component is long pressed
+- (IBAction)onLongPressGesture:(UILongPressGestureRecognizer*)longPressGestureRecognizer;
 
 @end

--- a/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
+++ b/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
@@ -136,86 +136,11 @@ static BOOL _disableLongPressGestureOnEvent;
 
 - (void)setupViews
 {
-    if (self.userNameLabel)
-    {
-        // Listen to name tap
-        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onSenderNameTap:)];
-        [tapGesture setNumberOfTouchesRequired:1];
-        [tapGesture setNumberOfTapsRequired:1];
-        [tapGesture setDelegate:self];
-        
-        if (self.userNameTapGestureMaskView)
-        {
-            [self.userNameTapGestureMaskView addGestureRecognizer:tapGesture];
-        }
-        else
-        {
-            [self.userNameLabel addGestureRecognizer:tapGesture];
-            self.userNameLabel.userInteractionEnabled = YES;
-        }
-    }
+    [self setupSenderNameLabel];
     
-    if (self.pictureView)
-    {
-        self.pictureView.mediaFolder = kMXMediaManagerAvatarThumbnailFolder;
-        
-        // Listen to avatar tap
-        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onAvatarTap:)];
-        [tapGesture setNumberOfTouchesRequired:1];
-        [tapGesture setNumberOfTapsRequired:1];
-        [tapGesture setDelegate:self];
-        [self.pictureView addGestureRecognizer:tapGesture];
-        self.pictureView.userInteractionEnabled = YES;
-        
-        // Add a long gesture recognizer on avatar (in order to display for example the member details)
-        UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
-        [self.pictureView addGestureRecognizer:longPress];
-    }
+    [self setupAvatarView];
     
-    if (self.messageTextView)
-    {
-        // Listen to textView tap
-        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onMessageTap:)];
-        [tapGesture setNumberOfTouchesRequired:1];
-        [tapGesture setNumberOfTapsRequired:1];
-        [tapGesture setDelegate:self];
-        [self.messageTextView addGestureRecognizer:tapGesture];
-        self.messageTextView.userInteractionEnabled = YES;
-
-        // Recognise and make tappable phone numbers, address, etc.
-        self.messageTextView.dataDetectorTypes = UIDataDetectorTypeAll;
-
-        // Listen to link click
-        self.messageTextView.delegate = self;
-        
-        if (_disableLongPressGestureOnEvent == NO)
-        {
-            // Add a long gesture recognizer on text view (in order to display for example the event details)
-            UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
-            longPress.delegate = self;
-            
-            // MXKMessageTextView does not catch touches outside of links. Add a background view to handle long touch.
-            if ([self.messageTextView isKindOfClass:[MXKMessageTextView class]])
-            {
-                UIView *messageTextBackgroundView = [[UIView alloc] initWithFrame:self.messageTextView.frame];
-                messageTextBackgroundView.backgroundColor = [UIColor clearColor];
-                [self.contentView insertSubview:messageTextBackgroundView belowSubview:self.messageTextView];
-                messageTextBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
-                [messageTextBackgroundView.leftAnchor constraintEqualToAnchor:self.messageTextView.leftAnchor].active = YES;
-                [messageTextBackgroundView.rightAnchor constraintEqualToAnchor:self.messageTextView.rightAnchor].active = YES;
-                [messageTextBackgroundView.topAnchor constraintEqualToAnchor:self.messageTextView.topAnchor].active = YES;
-                [messageTextBackgroundView.bottomAnchor constraintEqualToAnchor:self.messageTextView.bottomAnchor].active = YES;
-                
-                [messageTextBackgroundView addGestureRecognizer:longPress];
-                
-                self.messageTextBackgroundView = messageTextBackgroundView;
-            }
-            else
-            {
-                [self.messageTextView addGestureRecognizer:longPress];
-            }
-        }
-    }
+    [self setupMessageTextView];
     
     if (self.playIconView)
     {
@@ -248,6 +173,107 @@ static BOOL _disableLongPressGestureOnEvent;
     }
     
     [self setupConstraintsConstantDefaultValues];
+}
+
+- (void)setupSenderNameLabel
+{
+    if (!self.userNameLabel)
+    {
+        return;
+    }
+    
+    // Listen to name tap
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onSenderNameTap:)];
+    [tapGesture setNumberOfTouchesRequired:1];
+    [tapGesture setNumberOfTapsRequired:1];
+    [tapGesture setDelegate:self];
+    
+    if (self.userNameTapGestureMaskView)
+    {
+        [self.userNameTapGestureMaskView addGestureRecognizer:tapGesture];
+    }
+    else
+    {
+        [self.userNameLabel addGestureRecognizer:tapGesture];
+        self.userNameLabel.userInteractionEnabled = YES;
+    }
+}
+
+- (void)setupAvatarView
+{
+    if (!self.pictureView)
+    {
+        return;
+    }
+    
+    self.pictureView.mediaFolder = kMXMediaManagerAvatarThumbnailFolder;
+    
+    // Listen to avatar tap
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onAvatarTap:)];
+    [tapGesture setNumberOfTouchesRequired:1];
+    [tapGesture setNumberOfTapsRequired:1];
+    [tapGesture setDelegate:self];
+    [self.pictureView addGestureRecognizer:tapGesture];
+    self.pictureView.userInteractionEnabled = YES;
+    
+    // Add a long gesture recognizer on avatar (in order to display for example the member details)
+    UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
+    [self.pictureView addGestureRecognizer:longPress];
+}
+
+- (void)setupMessageTextView
+{
+    if (!self.messageTextView)
+    {
+        return;
+    }
+    
+    // Listen to textView tap
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onMessageTap:)];
+    [tapGesture setNumberOfTouchesRequired:1];
+    [tapGesture setNumberOfTapsRequired:1];
+    [tapGesture setDelegate:self];
+    [self.messageTextView addGestureRecognizer:tapGesture];
+    self.messageTextView.userInteractionEnabled = YES;
+    
+    // Recognise and make tappable phone numbers, address, etc.
+    self.messageTextView.dataDetectorTypes = UIDataDetectorTypeAll;
+    
+    // Listen to link click
+    self.messageTextView.delegate = self;
+    
+    [self setupMessageTextViewLongPressGesture];
+}
+
+- (void)setupMessageTextViewLongPressGesture
+{
+    if (_disableLongPressGestureOnEvent == NO)
+    {
+        // Add a long gesture recognizer on text view (in order to display for example the event details)
+        UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
+        longPress.delegate = self;
+        
+        // MXKMessageTextView does not catch touches outside of links. Add a background view to handle long touch.
+        if ([self.messageTextView isKindOfClass:[MXKMessageTextView class]])
+        {
+            UIView *messageTextBackgroundView = [[UIView alloc] initWithFrame:self.messageTextView.frame];
+            messageTextBackgroundView.backgroundColor = [UIColor clearColor];
+            [self.contentView insertSubview:messageTextBackgroundView belowSubview:self.messageTextView];
+            messageTextBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+            [messageTextBackgroundView.leftAnchor constraintEqualToAnchor:self.messageTextView.leftAnchor].active = YES;
+            [messageTextBackgroundView.rightAnchor constraintEqualToAnchor:self.messageTextView.rightAnchor].active = YES;
+            [messageTextBackgroundView.topAnchor constraintEqualToAnchor:self.messageTextView.topAnchor].active = YES;
+            [messageTextBackgroundView.bottomAnchor constraintEqualToAnchor:self.messageTextView.bottomAnchor].active = YES;
+            
+            [messageTextBackgroundView addGestureRecognizer:longPress];
+            
+            self.messageTextBackgroundView = messageTextBackgroundView;
+        }
+        else
+        {
+            [self.messageTextView addGestureRecognizer:longPress];
+        }
+    }
 }
 
 - (void)customizeTableViewCellRendering

--- a/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
+++ b/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
@@ -247,32 +247,34 @@ static BOOL _disableLongPressGestureOnEvent;
 
 - (void)setupMessageTextViewLongPressGesture
 {
-    if (_disableLongPressGestureOnEvent == NO)
+    if (_disableLongPressGestureOnEvent)
     {
-        // Add a long gesture recognizer on text view (in order to display for example the event details)
-        UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
-        longPress.delegate = self;
+        return;
+    }
+    
+    // Add a long gesture recognizer on text view (in order to display for example the event details)
+    UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(onLongPressGesture:)];
+    longPress.delegate = self;
+    
+    // MXKMessageTextView does not catch touches outside of links. Add a background view to handle long touch.
+    if ([self.messageTextView isKindOfClass:[MXKMessageTextView class]])
+    {
+        UIView *messageTextBackgroundView = [[UIView alloc] initWithFrame:self.messageTextView.frame];
+        messageTextBackgroundView.backgroundColor = [UIColor clearColor];
+        [self.contentView insertSubview:messageTextBackgroundView belowSubview:self.messageTextView];
+        messageTextBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+        [messageTextBackgroundView.leftAnchor constraintEqualToAnchor:self.messageTextView.leftAnchor].active = YES;
+        [messageTextBackgroundView.rightAnchor constraintEqualToAnchor:self.messageTextView.rightAnchor].active = YES;
+        [messageTextBackgroundView.topAnchor constraintEqualToAnchor:self.messageTextView.topAnchor].active = YES;
+        [messageTextBackgroundView.bottomAnchor constraintEqualToAnchor:self.messageTextView.bottomAnchor].active = YES;
         
-        // MXKMessageTextView does not catch touches outside of links. Add a background view to handle long touch.
-        if ([self.messageTextView isKindOfClass:[MXKMessageTextView class]])
-        {
-            UIView *messageTextBackgroundView = [[UIView alloc] initWithFrame:self.messageTextView.frame];
-            messageTextBackgroundView.backgroundColor = [UIColor clearColor];
-            [self.contentView insertSubview:messageTextBackgroundView belowSubview:self.messageTextView];
-            messageTextBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
-            [messageTextBackgroundView.leftAnchor constraintEqualToAnchor:self.messageTextView.leftAnchor].active = YES;
-            [messageTextBackgroundView.rightAnchor constraintEqualToAnchor:self.messageTextView.rightAnchor].active = YES;
-            [messageTextBackgroundView.topAnchor constraintEqualToAnchor:self.messageTextView.topAnchor].active = YES;
-            [messageTextBackgroundView.bottomAnchor constraintEqualToAnchor:self.messageTextView.bottomAnchor].active = YES;
-            
-            [messageTextBackgroundView addGestureRecognizer:longPress];
-            
-            self.messageTextBackgroundView = messageTextBackgroundView;
-        }
-        else
-        {
-            [self.messageTextView addGestureRecognizer:longPress];
-        }
+        [messageTextBackgroundView addGestureRecognizer:longPress];
+        
+        self.messageTextBackgroundView = messageTextBackgroundView;
+    }
+    else
+    {
+        [self.messageTextView addGestureRecognizer:longPress];
     }
 }
 

--- a/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/TextMessage/Common/TextMessageBaseBubbleCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/TextMessage/Common/TextMessageBaseBubbleCell.swift
@@ -32,21 +32,23 @@ class TextMessageBaseBubbleCell: SizableBaseRoomCell, RoomCellURLPreviewDisplaya
     // MARK: - Overrides
     
     override func setupViews() {
-        super.setupViews()
         
         roomCellContentView?.backgroundColor = .clear
-        
-        guard let contentView = roomCellContentView?.innerContentView else {
-            return
-        }
         
         roomCellContentView?.innerContentViewBottomContraint.constant = BubbleRoomCellLayoutConstants.innerContentViewMargins.bottom
         
         let textMessageContentView = TextMessageBubbleCellContentView.instantiate()
                 
-        contentView.vc_addSubViewMatchingParent(textMessageContentView)
+        roomCellContentView?.innerContentView.vc_addSubViewMatchingParent(textMessageContentView)
         
         self.textMessageContentView = textMessageContentView
+        
+        // Setup messageTextView property first before running `setupMessageTextView` method
+        super.setupViews()
+    }
+    
+    override func setupMessageTextViewLongPressGesture() {
+        // Do nothing, otherwise default setup prevent link tap
     }
     
     override func update(theme: Theme) {

--- a/changelog.d/5553.bugfix
+++ b/changelog.d/5553.bugfix
@@ -1,0 +1,1 @@
+Message bubbles: Fix edited text message `edited` link not working.


### PR DESCRIPTION
Fix https://github.com/vector-im/element-ios/issues/5553

Also fix sender name label not tappable.