### PR TITLE
Use a different green spinner during onboarding

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2410,6 +2410,12 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         
         MXLogDebug(@"[AppDelegate] handleAppState: isLaunching: %@", isLaunching ? @"YES" : @"NO");
         
+        if (self.masterTabBarController.isOnboardingInProgress)
+        {
+            MXLogDebug(@"[AppDelegate] handleAppState: Skipping LaunchLoadingView due to Onboarding.");
+            return;
+        }
+        
         if (isLaunching)
         {
             MXLogDebug(@"[AppDelegate] handleAppState: LaunchLoadingView");

--- a/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
@@ -18,9 +18,21 @@
 
 import Foundation
 
+struct AuthenticationCoordinatorParameters {
+    let navigationRouter: NavigationRouterType
+}
+
+enum AuthenticationCoordinatorResult {
+    /// The user has authenticated but key verification is yet to happen. The session value is
+    /// for a fresh session that still needs to load, sync etc before being ready.
+    case didLogin(MXSession)
+    /// All of the required authentication steps including key verification is complete.
+    case didComplete(MXKAuthenticationType)
+}
+
 /// `AuthenticationCoordinatorProtocol` is a protocol describing a Coordinator that handle's the authentication navigation flow.
 protocol AuthenticationCoordinatorProtocol: Coordinator, Presentable {
-    var completion: ((MXKAuthenticationType) -> Void)? { get set }
+    var completion: ((AuthenticationCoordinatorResult) -> Void)? { get set }
     
     /// Update the screen to display registration or login.
     func update(authenticationType: MXKAuthenticationType)

--- a/Riot/Modules/Authentication/AuthenticationViewController.h
+++ b/Riot/Modules/Authentication/AuthenticationViewController.h
@@ -62,6 +62,8 @@
 
 @protocol AuthenticationViewControllerDelegate <NSObject>
 
-- (void)authenticationViewControllerDidDismiss:(AuthenticationViewController *)authenticationViewController;
+- (void)authenticationViewController:(AuthenticationViewController *)authenticationViewController
+                 didLoginWithSession:(MXSession *)session
+                         andPassword:(NSString *)password;
 
 @end;

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -28,7 +28,7 @@
 
 static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 
-@interface AuthenticationViewController () <AuthFallBackViewControllerDelegate, KeyVerificationCoordinatorBridgePresenterDelegate, SetPinCoordinatorBridgePresenterDelegate,
+@interface AuthenticationViewController () <AuthFallBackViewControllerDelegate, SetPinCoordinatorBridgePresenterDelegate,
     SocialLoginListViewDelegate,
     SSOAuthenticationPresenterDelegate
 >
@@ -63,7 +63,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 }
 
 @property (nonatomic, readonly) BOOL isIdentityServerConfigured;
-@property (nonatomic, strong) KeyVerificationCoordinatorBridgePresenter *keyVerificationCoordinatorBridgePresenter;
 @property (nonatomic, strong) SetPinCoordinatorBridgePresenter *setPinCoordinatorBridgePresenter;
 @property (nonatomic, strong) KeyboardAvoider *keyboardAvoider;
 
@@ -77,8 +76,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 
 // Current SSO transaction id used to identify and validate the SSO authentication callback
 @property (nonatomic, strong) NSString *ssoCallbackTxnId;
-
-@property (nonatomic, strong) CrossSigningService *crossSigningService;
 
 @property (nonatomic, getter = isFirstViewAppearing) BOOL firstViewAppearing;
 
@@ -118,7 +115,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
     
     _firstViewAppearing = YES;
     
-    self.crossSigningService = [CrossSigningService new];
     self.errorPresenter = [MXKErrorAlertPresentation new];
 }
 
@@ -318,11 +314,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
     {
         self.firstViewAppearing = NO;
     }
-    
-    if (self.keyVerificationCoordinatorBridgePresenter)
-    {
-        return;
-    }        
 
     // Verify that the app does not show the authentication screen whereas
     // the user has already logged in.
@@ -379,7 +370,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
     [self.authenticationActivityIndicator removeObserver:self forKeyPath:@"hidden"];
 
     autoDiscovery = nil;
-    _keyVerificationCoordinatorBridgePresenter = nil;
     _keyboardAvoider = nil;
 }
 
@@ -554,30 +544,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
             // The right bar button is used to return to login.
             self.navigationItem.rightBarButtonItem.title = [VectorL10n cancel];
         }
-    }
-}
-
-- (void)presentCompleteSecurityWithSession:(MXSession*)session
-{
-    KeyVerificationCoordinatorBridgePresenter *keyVerificationCoordinatorBridgePresenter = [[KeyVerificationCoordinatorBridgePresenter alloc] initWithSession:session];
-    keyVerificationCoordinatorBridgePresenter.delegate = self;
-    
-    [keyVerificationCoordinatorBridgePresenter presentCompleteSecurityFrom:self isNewSignIn:YES animated:YES];
-    
-    self.keyVerificationCoordinatorBridgePresenter = keyVerificationCoordinatorBridgePresenter;
-}
-
-- (void)dismiss
-{
-    self.userInteractionEnabled = YES;
-    [self.authenticationActivityIndicator stopAnimating];
-    
-    // Dismiss (key verification) on successful login
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
-    
-    if (self.authVCDelegate)
-    {
-        [self.authVCDelegate authenticationViewControllerDidDismiss:self];
     }
 }
 
@@ -1377,119 +1343,8 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
         }];
     }
     
-    // Wait for session change to present complete security screen if needed
-    [self registerSessionStateChangeNotificationForSession:session];
-}
-
-- (void)registerSessionStateChangeNotificationForSession:(MXSession*)session
-{
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionStateDidChangeNotification:) name:kMXSessionStateDidChangeNotification object:session];
-}
-
-- (void)unregisterSessionStateChangeNotification
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXSessionStateDidChangeNotification object:nil];
-}
-                                  
-- (void)sessionStateDidChangeNotification:(NSNotification*)notification
-{
-    MXSession *session = (MXSession*)notification.object;
-
-    if (session.state == MXSessionStateStoreDataReady)
-    {
-        if (session.crypto.crossSigning)
-        {
-            // Do not make key share requests while the "Complete security" is not complete.
-            // If the device is self-verified, the SDK will restore the existing key backup.
-            // Then, it  will re-enable outgoing key share requests
-            [session.crypto setOutgoingKeyRequestsEnabled:NO onComplete:nil];
-        }
-    }
-    else if (session.state == MXSessionStateRunning)
-    {
-        [self unregisterSessionStateChangeNotification];
-        
-        if (session.crypto.crossSigning)
-        {
-            [session.crypto.crossSigning refreshStateWithSuccess:^(BOOL stateUpdated) {
-
-                MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: crossSigning.state: %@", @(session.crypto.crossSigning.state));
-
-                switch (session.crypto.crossSigning.state)
-                {
-                    case MXCrossSigningStateNotBootstrapped:
-                    {
-                        // TODO: This is still not sure we want to disable the automatic cross-signing bootstrap
-                        // if the admin disabled e2e by default.
-                        // Do like riot-web for the moment
-                        if ([session vc_homeserverConfiguration].isE2EEByDefaultEnabled)
-                        {
-                            // Bootstrap cross-signing on user's account
-                            // We do it for both registration and new login as long as cross-signing does not exist yet
-                            if (self.authInputsView.password.length)
-                            {
-                                MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Bootstrap with password");
-                                
-                                [session.crypto.crossSigning setupWithPassword:self.authInputsView.password success:^{
-                                    MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Bootstrap succeeded");
-                                    [self dismiss];
-                                } failure:^(NSError * _Nonnull error) {
-                                    MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Bootstrap failed. Error: %@", error);
-                                    [session.crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];
-                                    [self dismiss];
-                                }];
-                            }
-                            else
-                            {
-                                // Try to setup cross-signing without authentication parameters in case if a grace period is enabled
-                                [self.crossSigningService setupCrossSigningWithoutAuthenticationFor:session success:^{
-                                    MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Bootstrap succeeded without credentials");
-                                    [self dismiss];
-                                } failure:^(NSError * _Nonnull error) {
-                                    MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Do not know how to bootstrap cross-signing. Skip it.");
-                                    [session.crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];
-                                    [self dismiss];
-                                }];
-                            }
-                        }
-                        else
-                        {
-                            [session.crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];
-                            [self dismiss];
-                        }
-                        break;
-                    }
-                    case MXCrossSigningStateCrossSigningExists:
-                    {
-                        MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Complete security");
-                        
-                        // Ask the user to verify this session
-                        self.userInteractionEnabled = YES;
-                        [self.authenticationActivityIndicator stopAnimating];
-                        
-                        [self presentCompleteSecurityWithSession:session];
-                        break;
-                    }
-                        
-                    default:
-                        MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Nothing to do");
-                        
-                        [session.crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];
-                        [self dismiss];
-                        break;
-                }
-                
-            } failure:^(NSError * _Nonnull error) {
-                MXLogDebug(@"[AuthenticationVC] sessionStateDidChange: Fail to refresh crypto state with error: %@", error);
-                [session.crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];
-                [self dismiss];
-            }];
-        }
-        else
-        {
-            [self dismiss];
-        }
-    }
+    // Ask the coordinator to show the loading spinner whilst waiting.
+    [self.authVCDelegate authenticationViewController:self didLoginWithSession:session andPassword:self.authInputsView.password];
 }
 
 #pragma mark - MXKAuthInputsViewDelegate
@@ -1619,24 +1474,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 
     // And show custom servers
     [self setCustomServerFieldsVisible:YES];
-}
-
-#pragma mark - KeyVerificationCoordinatorBridgePresenterDelegate
-
-- (void)keyVerificationCoordinatorBridgePresenterDelegateDidComplete:(KeyVerificationCoordinatorBridgePresenter * _Nonnull)coordinatorBridgePresenter otherUserId:(NSString * _Nonnull)otherUserId otherDeviceId:(NSString * _Nonnull)otherDeviceId
-{
-    MXCrypto *crypto = coordinatorBridgePresenter.session.crypto;
-    if (!crypto.backup.hasPrivateKeyInCryptoStore || !crypto.backup.enabled)
-    {
-        MXLogDebug(@"[AuthenticationVC][MXKeyVerification] requestAllPrivateKeys: Request key backup private keys");
-        [crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];
-    }
-    [self dismiss];
-}
-
-- (void)keyVerificationCoordinatorBridgePresenterDelegateDidCancel:(KeyVerificationCoordinatorBridgePresenter * _Nonnull)coordinatorBridgePresenter
-{
-    [self dismiss];
 }
 
 #pragma mark - SetPinCoordinatorBridgePresenterDelegate

--- a/Riot/Modules/LaunchLoading/LaunchLoadingViewController.swift
+++ b/Riot/Modules/LaunchLoading/LaunchLoadingViewController.swift
@@ -1,0 +1,38 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+import Reusable
+
+class LaunchLoadingViewController: UIViewController, Reusable {
+    
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    
+    init() {
+        super.init(nibName: "LaunchLoadingViewController", bundle: nil)
+        
+        let launchLoadingView = LaunchLoadingView.instantiate()
+        launchLoadingView.update(theme: ThemeService.shared().theme)
+        view.vc_addSubViewMatchingParent(launchLoadingView)
+        
+        // The launch time isn't profiled for analytics as it's presentation length
+        // will be artificially changed based on other views in the flow.
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+}

--- a/Riot/Modules/LaunchLoading/LaunchLoadingViewController.xib
+++ b/Riot/Modules/LaunchLoading/LaunchLoadingViewController.xib
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LaunchLoadingViewController" customModule="Riot" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="25f-lP-cnO" id="Qdu-wY-5s0"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="25f-lP-cnO">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <viewLayoutGuide key="safeArea" id="FXc-bE-Yxp"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <point key="canvasLocation" x="192" y="-103"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -119,9 +119,9 @@
     
     self.delegate = self;
     
-    _isOnboardingInProgress = NO;
+    self.isOnboardingInProgress = NO;
     
-    // Note: UITabBarViewController shoud not be embed in a UINavigationController (https://github.com/vector-im/riot-ios/issues/3086)
+    // Note: UITabBarViewController should not be embed in a UINavigationController (https://github.com/vector-im/riot-ios/issues/3086)
     [self vc_removeBackTitle];
     
     [self setupTitleView];
@@ -520,7 +520,7 @@
         [self.onboardingCoordinatorBridgePresenter dismissWithAnimated:YES completion:nil];
         self.onboardingCoordinatorBridgePresenter = nil;
         
-        self.isOnboardingInProgress = NO;
+        self.isOnboardingInProgress = NO;   // Must be set before calling didCompleteAuthentication
         [self.masterTabBarDelegate masterTabBarControllerDidCompleteAuthentication:self];
     };
     

--- a/changelog.d/5621.change
+++ b/changelog.d/5621.change
@@ -1,0 +1,1 @@
+Onboarding: Use a different green spinner during onboarding and use the one presented by the LegacyAppDelegate only when logged in.


### PR DESCRIPTION
This will allow other screens to be presented during onboarding without having the spinner thrown on top of them. Additionally moves key verification out of a bridge presenter in AuthenticationVC and into the AuthenticationCoordinator.

I may end up moving both the spinner and the key verification the `OnboardingCoordinator` instead of the `AuthenticationCoordinator`, but this seems like a decent sized PR for now and fixes a couple of potential issues with the spinner presentation that would be great to get into the next release.

Fixes #5621.