### PR TITLE
Expose room cells to voiceover on Home tab.

### DIFF
--- a/Riot/Modules/Home/Views/AccessibleCollectionView.swift
+++ b/Riot/Modules/Home/Views/AccessibleCollectionView.swift
@@ -1,0 +1,37 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+/// A collection view that returns an accessibility element count equal to the number of
+/// items in its first section. This allows voiceover user to swipe through the entire collection.
+class AccessibleCollectionView: UICollectionView {
+    private var numberOfItemsInFirstSection = 0
+    
+    override func accessibilityElementCount() -> Int {
+        return numberOfItemsInFirstSection
+    }
+    
+    override func numberOfItems(inSection section: Int) -> Int {
+        let numberOfItems = super.numberOfItems(inSection: section)
+        
+        if section == 0 {
+            numberOfItemsInFirstSection = numberOfItems
+        }
+        
+        return numberOfItems
+    }
+}

--- a/Riot/Modules/Home/Views/RoomCollectionViewCell.m
+++ b/Riot/Modules/Home/Views/RoomCollectionViewCell.m
@@ -52,6 +52,8 @@
     [path closePath]; // arrow top side
     arrowMaskLayer.path = path.CGPath;
     self.editionArrowView.layer.mask = arrowMaskLayer;
+    
+    self.isAccessibilityElement = YES;
 }
 
 - (void)customizeCollectionViewCellRendering
@@ -86,6 +88,8 @@
         self.roomTitle1.hidden = YES;
         self.roomTitle2.hidden = YES;
         
+        NSMutableString *accessibilityLabel = [self.roomTitle.text mutableCopy];
+        
         // Check whether the room display name is an alias to keep visible the HS.
         if ([MXTools isMatrixRoomAlias:roomCellData.roomDisplayname])
         {
@@ -97,6 +101,7 @@
                 self.roomTitle1.text = [roomCellData.roomDisplayname substringToIndex:range.location + 1];
                 self.roomTitle2.hidden = NO;
                 self.roomTitle2.text = [roomCellData.roomDisplayname substringFromIndex:range.location + 1];
+                accessibilityLabel = [[NSString stringWithFormat:@"%@, %@", self.roomTitle1.text, self.roomTitle2.text] mutableCopy];
             }
         }
         
@@ -118,6 +123,10 @@
                 self.badgeLabel.hidden = NO;
                 self.badgeLabel.badgeColor = roomCellData.highlightCount ? ThemeService.shared.theme.noticeColor : ThemeService.shared.theme.noticeSecondaryColor;
                 self.badgeLabel.text = roomCellData.notificationCountStringValue;
+                
+                NSUInteger count = roomCellData.notificationCount;
+                NSString *newMessagesLabel = count == 1 ? [VectorL10n roomNewMessageNotification:count] : [VectorL10n roomNewMessagesNotification:count];
+                [accessibilityLabel appendFormat:@", %@", newMessagesLabel];
             }
             
             // Use bold font for the room title
@@ -129,6 +138,8 @@
             self.roomTitle.font = self.roomTitle1.font = self.roomTitle2.font = [UIFont systemFontOfSize:13 weight:UIFontWeightMedium];
             
         }
+        
+        self.accessibilityLabel = accessibilityLabel;
         
         [self.roomAvatar vc_setRoomAvatarImageWith:roomCellData.avatarUrl
                                             roomId:roomCellData.roomIdentifier

--- a/Riot/Modules/Home/Views/TableViewCellWithCollectionView.m
+++ b/Riot/Modules/Home/Views/TableViewCellWithCollectionView.m
@@ -30,6 +30,11 @@ static CGFloat const kEditionViewCornerRadius = 10.0;
     self.editionViewBottomConstraint.constant = 0;
     
     self.editionView.layer.masksToBounds = YES;
+    
+    // Hide both the cell and its collection view from voiceover.
+    // Instead we expose the individual cells as accessibility elements.
+    self.isAccessibilityElement = NO;
+    self.collectionView.isAccessibilityElement = NO;
 }
 
 - (void)customizeTableViewCellRendering

--- a/Riot/Modules/Home/Views/TableViewCellWithCollectionView.xib
+++ b/Riot/Modules/Home/Views/TableViewCellWithCollectionView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="600" height="181"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="iXt-1Y-bEu">
+                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="iXt-1Y-bEu" customClass="AccessibleCollectionView" customModule="Riot" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="116"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="zZI-Za-2q1">
@@ -83,7 +83,7 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="f0O-Nh-XqH" firstAttribute="centerX" secondItem="MbR-Oe-6k1" secondAttribute="centerX" id="0NZ-qp-2Nk"/>
                             <constraint firstItem="cgb-3x-9qQ" firstAttribute="centerX" secondItem="uG0-u6-BBj" secondAttribute="centerX" id="2xF-Df-927"/>
@@ -155,5 +155,8 @@
         <image name="room_action_leave" width="24" height="24"/>
         <image name="room_action_notification" width="24" height="24"/>
         <image name="room_action_priority_low" width="24" height="24"/>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/changelog.d/1433.bugfix
+++ b/changelog.d/1433.bugfix
@@ -1,0 +1,1 @@
+Home Tab: Initial support for navigating through the room lists using voiceover.


### PR DESCRIPTION
First step at improving voiceover support on the Home tab (#1433). The collection view cells are now set as accessibility elements with an appropriate label and the table view cells and collection views are all hidden.

It is by no means perfect whilst swiping through the cells, particularly when the data source paginates more rooms, but it at least feels somewhat usable now.

Next steps for future PRs
- Allow 2-finger swipes between sections.
- Add the + button as an element.
- Tidy up labels for section headers.

![IMG_719CC8560556-1](https://user-images.githubusercontent.com/6060466/154794579-251a9c16-d444-47c8-a6ab-a85439027fa6.jpeg)

