### PR TITLE
Update RoomDataSource init finalization to fix peeking case

### DIFF
--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -119,7 +119,7 @@ const CGFloat kTypingCellHeight = 24;
 
     // Sadly, we need to make sure we have fetched all room members from the HS
     // to be able to display read receipts
-    if (![self.mxSession.store hasLoadedAllRoomMembersForRoom:self.roomId])
+    if (!self.isPeeking && ![self.mxSession.store hasLoadedAllRoomMembersForRoom:self.roomId])
     {
         [self.room members:^(MXRoomMembers *roomMembers) {
             MXLogDebug(@"[MXKRoomDataSource] finalizeRoomDataSource: All room members have been retrieved");


### PR DESCRIPTION
During a bug investigation, we found that the FileStore may be corrupted with peeking feature (when previewing a room), but not joining the room after previewing it.

To avoid this on peeking rooms, I excluded to fetch all room members from RoomDataSource when isPeeking is set to YES.

A second part is on MatrixSDK, [here](https://github.com/matrix-org/matrix-ios-sdk/pull/1373).