### PR TITLE
Enable home activity indicator

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -228,7 +228,7 @@ final class BuildSettings: NSObject {
     /// Whether a screen uses legacy local activity indicators or improved app-wide indicators
     static var useAppUserIndicators: Bool {
         #if DEBUG
-        return false
+        return true
         #else
         return false
         #endif

--- a/Riot/Modules/Common/ActivityPresenters/ToastUserIndicatorPresenter.swift
+++ b/Riot/Modules/Common/ActivityPresenters/ToastUserIndicatorPresenter.swift
@@ -43,8 +43,8 @@ class ToastUserIndicatorPresenter: UserIndicatorPresentable {
         view.translatesAutoresizingMaskIntoConstraints = false
         navigationController.view.addSubview(view)
         NSLayoutConstraint.activate([
-            view.centerXAnchor.constraint(equalTo: navigationController.navigationBar.centerXAnchor),
-            view.topAnchor.constraint(equalTo: navigationController.navigationBar.bottomAnchor)
+            view.centerXAnchor.constraint(equalTo: navigationController.view.centerXAnchor),
+            view.topAnchor.constraint(equalTo: navigationController.navigationBar.safeAreaLayoutGuide.bottomAnchor)
         ])
         
         view.alpha = 0

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -314,6 +314,8 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         [[NSNotificationCenter defaultCenter] removeObserver:kMXNotificationCenterDidUpdateRulesObserver];
         kMXNotificationCenterDidUpdateRulesObserver = nil;
     }
+    
+    [self stopActivityIndicator];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Riot/Modules/Common/Toasts/RoundedToastView.swift
+++ b/Riot/Modules/Common/Toasts/RoundedToastView.swift
@@ -19,13 +19,18 @@ import UIKit
 import DesignKit
 
 class RoundedToastView: UIView, Themable {
+    private struct ShadowStyle {
+        let offset: CGSize
+        let radius: CGFloat
+        let opacity: Float
+    }
+    
     private struct Constants {
         static let padding = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
         static let activityIndicatorScale = CGFloat(0.75)
         static let imageViewSize = CGFloat(15)
-        static let shadowOffset = CGSize(width: 0, height: 4)
-        static let shadowRadius = CGFloat(12)
-        static let shadowOpacity = Float(0.1)
+        static let lightShadow = ShadowStyle(offset: .init(width: 0, height: 4), radius: 12, opacity: 0.1)
+        static let darkShadow = ShadowStyle(offset: .init(width: 0, height: 4), radius: 4, opacity: 0.2)
     }
     
     private lazy var activityIndicator: UIActivityIndicatorView = {
@@ -68,7 +73,6 @@ class RoundedToastView: UIView, Themable {
     }
 
     private func setup(viewState: ToastViewState) {
-        setupLayer()
         setupStackView()
         stackView.addArrangedSubview(toastView(for: viewState.style))
         stackView.addArrangedSubview(label)
@@ -86,13 +90,6 @@ class RoundedToastView: UIView, Themable {
         ])
     }
     
-    private func setupLayer() {
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOffset = Constants.shadowOffset
-        layer.shadowRadius = Constants.shadowRadius
-        layer.shadowOpacity = Constants.shadowOpacity
-    }
-    
     override func layoutSubviews() {
         super.layoutSubviews()
         layer.cornerRadius = layer.frame.height / 2
@@ -103,6 +100,12 @@ class RoundedToastView: UIView, Themable {
         stackView.arrangedSubviews.first?.tintColor = theme.colors.primaryContent
         label.font = theme.fonts.subheadline
         label.textColor = theme.colors.primaryContent
+        
+        let shadowStyle = theme.identifier == ThemeIdentifier.dark.rawValue ? Constants.darkShadow : Constants.lightShadow
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOffset = shadowStyle.offset
+        layer.shadowRadius = shadowStyle.radius
+        layer.shadowOpacity = shadowStyle.opacity
     }
     
     private func toastView(for style: ToastViewState.Style) -> UIView {

--- a/Riot/Modules/Common/Toasts/RoundedToastView.swift
+++ b/Riot/Modules/Common/Toasts/RoundedToastView.swift
@@ -49,6 +49,7 @@ class RoundedToastView: UIView, Themable {
     private let stackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
+        stack.alignment = .center
         stack.spacing = 5
         return stack
     }()

--- a/changelog.d/5663.change
+++ b/changelog.d/5663.change
@@ -1,0 +1,1 @@
+Enable activity indicators on the home screen


### PR DESCRIPTION
Resolves #5663 

| iPhone 8 portrait | iPhone 8 landscape |
|------------------|---------------------|
| ![Simulator Screen Shot - iPhone 8 - 2022-02-22 at 11 49 10](https://user-images.githubusercontent.com/3922159/155129171-d9e4d95c-d525-4fa1-bfb1-555fc03a2443.png) | ![Simulator Screen Shot - iPhone 8 - 2022-02-22 at 11 49 12](https://user-images.githubusercontent.com/3922159/155129175-001886fc-0c01-4ca4-b249-10effe65c997.png) |

| iPhone 13 dark 1 | iPhone 13 dark 2 |
|------------------|------------------|
| ![Simulator Screen Shot - iPhone 13 - 2022-02-22 at 11 51 03](https://user-images.githubusercontent.com/3922159/155129319-a36a6ebc-10c1-4207-92b0-3e13109687b7.png) | ![Simulator Screen Shot - iPhone 13 - 2022-02-22 at 11 51 06](https://user-images.githubusercontent.com/3922159/155129323-16a82d61-67d7-4a49-97d6-b798a9f864e7.png) |


| iPhone 13 landscape dark 1 | iPhone 13 landscape dark 2 |
|-----------------------------|----------------------------|
| ![Simulator Screen Shot - iPhone 13 - 2022-02-22 at 11 51 10](https://user-images.githubusercontent.com/3922159/155129416-13c63534-00e5-4098-bfcc-1aeb0422af50.png) | ![Simulator Screen Shot - iPhone 13 - 2022-02-22 at 11 51 12](https://user-images.githubusercontent.com/3922159/155129421-5f98e393-8a69-45fc-90fb-76cb09e28509.png) |

| iPad portrait | iPad landscape |
|-------------|-----------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-02-22 at 11 54 45](https://user-images.githubusercontent.com/3922159/155129528-1bde8ee1-69e6-4d4b-90bd-e62c2d3a64b2.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-02-22 at 11 54 47](https://user-images.githubusercontent.com/3922159/155129530-3e22713c-1986-4958-b068-8c5721e72ca1.png) |

