### PR TITLE
Revert change to UnifiedSearchRecentsDataSource

### DIFF
--- a/Riot/Modules/GlobalSearch/DataSources/UnifiedSearchRecentsDataSource.m
+++ b/Riot/Modules/GlobalSearch/DataSources/UnifiedSearchRecentsDataSource.m
@@ -35,6 +35,18 @@
 
 @implementation UnifiedSearchRecentsDataSource
 
+- (instancetype)initWithMatrixSession:(MXSession *)mxSession recentsListService:(id<RecentsListServiceProtocol>)recentsListService
+{
+    self = [super initWithMatrixSession:mxSession recentsListService:recentsListService];
+    if (self)
+    {
+        searchedRoomIdOrAliasSection = -1;
+        
+        _hideRecents = NO;
+    }
+    return self;
+}
+
 #pragma mark -
 
 - (void)setPublicRoomsDirectoryDataSource:(PublicRoomsDirectoryDataSource *)publicRoomsDirectoryDataSource

--- a/changelog.d/5672.bugfix
+++ b/changelog.d/5672.bugfix
@@ -1,0 +1,1 @@
+Unified Search: Fix a bug where the room directory wasn't working.


### PR DESCRIPTION
Reverts a change to `UnifiedSearchRecentsDataSource ` that removed the `init` due to a "Implementing unavailable method" warning. This PR adds it back and renames it to `initWithMatrixSession:recentsListService:`.

Whilst the `init` it was marked as unavailable, it seemingly was being used by the available init.