### PR TITLE
Fix tab bar title localisation

### DIFF
--- a/Riot/Modules/Communities/GroupsViewController.m
+++ b/Riot/Modules/Communities/GroupsViewController.m
@@ -21,7 +21,7 @@
 
 #import "GeneratedInterface-Swift.h"
 
-@interface GroupsViewController ()
+@interface GroupsViewController () <MasterTabBarItemDisplayProtocol>
 {
     // Tell whether a groups refresh is pending (suspended during editing mode).
     BOOL isRefreshPending;
@@ -224,8 +224,6 @@
         [self scrollToTop:YES];
         
     }];
-    
-    [AppDelegate theDelegate].masterTabBarController.navigationItem.title = [VectorL10n titleGroups];
     [AppDelegate theDelegate].masterTabBarController.tabBar.tintColor = ThemeService.shared.theme.tintColor;        
 }
 
@@ -642,6 +640,13 @@
 - (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar
 {
     [self.groupsSearchBar setShowsCancelButton:NO animated:NO];
+}
+
+#pragma mark - MasterTabBarItemDisplayProtocol
+
+- (NSString *)masterTabBarItemTitle
+{
+    return [VectorL10n titleGroups];
 }
 
 @end

--- a/Riot/Modules/Favorites/FavouritesViewController.m
+++ b/Riot/Modules/Favorites/FavouritesViewController.m
@@ -19,7 +19,7 @@
 #import "RecentsDataSource.h"
 #import "GeneratedInterface-Swift.h"
 
-@interface FavouritesViewController ()
+@interface FavouritesViewController () <MasterTabBarItemDisplayProtocol>
 {    
     RecentsDataSource *recentsDataSource;
 }
@@ -62,8 +62,6 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    [AppDelegate theDelegate].masterTabBarController.navigationItem.title = [VectorL10n titleFavourites];
     [AppDelegate theDelegate].masterTabBarController.tabBar.tintColor = ThemeService.shared.theme.tintColor;
     
     if (recentsDataSource)
@@ -161,6 +159,13 @@
     {
         return AssetImages.favouritesEmptyScreenArtwork.image;
     }
+}
+
+#pragma mark - MasterTabBarItemDisplayProtocol
+
+- (NSString *)masterTabBarItemTitle
+{
+    return [VectorL10n titleFavourites];
 }
 
 @end

--- a/Riot/Modules/Home/HomeViewController.m
+++ b/Riot/Modules/Home/HomeViewController.m
@@ -103,8 +103,6 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    [AppDelegate theDelegate].masterTabBarController.navigationItem.title = [VectorL10n titleHome];
 
     [ThemeService.shared.theme applyStyleOnNavigationBar:[AppDelegate theDelegate].masterTabBarController.navigationController.navigationBar];
 

--- a/Riot/Modules/Home/VersionCheck/HomeViewControllerWithBannerWrapperViewController.swift
+++ b/Riot/Modules/Home/VersionCheck/HomeViewControllerWithBannerWrapperViewController.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKViewControllerActivityHandling, BannerPresentationProtocol {
+class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKViewControllerActivityHandling, BannerPresentationProtocol, MasterTabBarItemDisplayProtocol {
     
     @objc let homeViewController: HomeViewController
     private var bannerContainerView: UIView!
@@ -106,5 +106,11 @@ class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKVi
 
     func stopActivityIndicator() {
         homeViewController.stopActivityIndicator()
+    }
+    
+    // MARK: - MasterTabBarItemDisplayProtocol
+    
+    var masterTabBarItemTitle: String {
+        return VectorL10n.titleHome
     }
 }

--- a/Riot/Modules/People/PeopleViewController.m
+++ b/Riot/Modules/People/PeopleViewController.m
@@ -26,7 +26,7 @@
 
 #import "GeneratedInterface-Swift.h"
 
-@interface PeopleViewController () <SpaceMembersCoordinatorBridgePresenterDelegate>
+@interface PeopleViewController () <SpaceMembersCoordinatorBridgePresenterDelegate, MasterTabBarItemDisplayProtocol>
 {
     NSInteger          directRoomsSectionNumber;
     RecentsDataSource *recentsDataSource;
@@ -83,8 +83,6 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    [AppDelegate theDelegate].masterTabBarController.navigationItem.title = [VectorL10n titlePeople];
     [AppDelegate theDelegate].masterTabBarController.tabBar.tintColor = ThemeService.shared.theme.tintColor;
     
     if ([self.dataSource isKindOfClass:RecentsDataSource.class])
@@ -192,6 +190,13 @@
     [coordinatorBridgePresenter dismissWithAnimated:YES completion:^{
         self.spaceMembersCoordinatorBridgePresenter = nil;
     }];
+}
+
+#pragma mark - MasterTabBarItemDisplayProtocol
+
+- (NSString *)masterTabBarItemTitle
+{
+    return [VectorL10n titlePeople];
 }
 
 @end

--- a/Riot/Modules/Rooms/RoomsViewController.m
+++ b/Riot/Modules/Rooms/RoomsViewController.m
@@ -20,7 +20,7 @@
 
 #import "GeneratedInterface-Swift.h"
 
-@interface RoomsViewController ()
+@interface RoomsViewController () <MasterTabBarItemDisplayProtocol>
 {
     RecentsDataSource *recentsDataSource;
 }
@@ -66,8 +66,6 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    [AppDelegate theDelegate].masterTabBarController.navigationItem.title = [VectorL10n titleRooms];
     [AppDelegate theDelegate].masterTabBarController.tabBar.tintColor = ThemeService.shared.theme.tintColor;
     
     if ([self.dataSource isKindOfClass:RecentsDataSource.class])
@@ -163,6 +161,13 @@
     {
         return AssetImages.roomsEmptyScreenArtwork.image;
     }
+}
+
+#pragma mark - MasterTabBarItemDisplayProtocol
+
+- (NSString *)masterTabBarItemTitle
+{
+    return [VectorL10n titleRooms];
 }
 
 @end

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -316,7 +316,7 @@
         }
     }
     
-    titleView.titleLabel.text = self.selectedViewController.accessibilityLabel;
+    titleView.titleLabel.text = [self getTitleForItemViewController:self.selectedViewController];
     
     // Need to be called in case of the controllers have been replaced
     [self.selectedViewController viewDidAppear:NO];
@@ -336,6 +336,8 @@
 {
     NSInteger index = [self indexOfTabItemWithTag:tabBarIndex];
     self.selectedIndex = index;
+    
+    titleView.titleLabel.text = [self getTitleForItemViewController:self.selectedViewController];
 }
 
 #pragma mark -
@@ -825,6 +827,17 @@
     self.navigationController.navigationBar.hidden = hidden;
 }
 
+- (NSString*)getTitleForItemViewController:(UIViewController*)itemViewController
+{
+    if ([itemViewController conformsToProtocol:@protocol(MasterTabBarItemDisplayProtocol)])
+    {
+        UIViewController<MasterTabBarItemDisplayProtocol> *masterTabBarItem = (UIViewController<MasterTabBarItemDisplayProtocol>*)itemViewController;
+        return masterTabBarItem.masterTabBarItemTitle;
+    }
+        
+    return nil;
+}
+
 #pragma mark -
 
 - (void)refreshTabBarBadges
@@ -1115,7 +1128,7 @@
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController
 {
-    titleView.titleLabel.text = viewController.accessibilityLabel;
+    titleView.titleLabel.text = [self getTitleForItemViewController:viewController];
 }
 
 @end

--- a/Riot/Modules/TabBar/MasterTabBarItemDisplayProtocol.swift
+++ b/Riot/Modules/TabBar/MasterTabBarItemDisplayProtocol.swift
@@ -1,0 +1,21 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@objc protocol MasterTabBarItemDisplayProtocol {
+    var masterTabBarItemTitle: String { get }
+}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5489

It appearsd we do not sue the VC title as setting the title causes text to display on the tabs, which we don't want. Creating a protocol to be a bit more explicit rather thatn the current approach of using the accessibilityLabel.