### PR TITLE
Also display read receipts if users aren't room members

### DIFF
--- a/Riot/Modules/Room/TimelineDecorations/ReadReceipts/MXKReceiptSendersContainer.h
+++ b/Riot/Modules/Room/TimelineDecorations/ReadReceipts/MXKReceiptSendersContainer.h
@@ -71,6 +71,11 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
 @property (nonatomic, readonly) NSArray <MXRoomMember *> *roomMembers;
 
 /*
+ The array of the users that will have details displayed although they aren't a room member
+ */
+@property (nonatomic, readonly) NSArray <MXUser *> *nonRoomMembers;
+
+/*
  The placeholders of the room members that will be shown if the users don't have avatars
  */
 @property (nonatomic, readonly) NSArray <UIImage *> *placeholders;
@@ -93,7 +98,7 @@ typedef NS_ENUM(NSInteger, ReadReceiptsAlignment)
  @param placeHolders list of placeholders, one by room member. Used when url is nil, or during avatar download.
  @param alignment (see ReadReceiptsAlignment).
  */
-- (void)refreshReceiptSenders:(NSArray<MXRoomMember*>*)roomMembers withPlaceHolders:(NSArray<UIImage*>*)placeHolders andAlignment:(ReadReceiptsAlignment)alignment;
+- (void)refreshReceiptSenders:(NSArray<MXRoomMember*>*)roomMembers nonRoomMembersReceiptSenders: (NSArray<MXUser*>*)nonRoomMembers withPlaceHolders:(NSArray<UIImage*>*)placeHolders andAlignment:(ReadReceiptsAlignment)alignment;
 
 @end
 

--- a/changelog.d/5676.change
+++ b/changelog.d/5676.change
@@ -1,0 +1,1 @@
+Rooms: Display avatars for m.read events even if account who sent the read event is not a channel member


### PR DESCRIPTION
This fixes #5676 

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Looks exactly the same as other read avatars:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/783831/155365311-1ae02fd5-9af2-4227-8e2c-ef70a171f77c.png">

### Testing

- Create an (unencrypted) room with just you as a member
- Send a message to the room
- View the source of the message, copy out: `room_id`, `event_id`
- Copy a bearer token (i.e. by using chrome dev tools and inspecting requests)
- Create a m.read event from a different account that isn't a member of that room:

```
curl -X "POST" "https://matrix-client.matrix.org/_matrix/client/v3/rooms/<room_id>/receipt/m.read/<event_id>" \
     -H 'Authorization: Bearer <token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{}'
```

- See the event appearing in the client