### PR TITLE
Disable the default analytics configurations for forks.

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -156,20 +156,35 @@ final class BuildSettings: NSObject {
     static let roomsAllowToJoinPublicRooms: Bool = true
     
     // MARK: - Analytics
-    #if DEBUG
-    /// Host to use for PostHog analytics during development. Set to nil to disable analytics in debug builds.
-    static let analyticsHost: String? = "https://posthog-poc.lab.element.dev"
-    /// Public key for submitting analytics during development. Set to nil to disable analytics in debug builds.
-    static let analyticsKey: String? = "rs-pJjsYJTuAkXJfhaMmPUNBhWliDyTKLOOxike6ck8"
-    #else
-    /// Host to use for PostHog analytics. Set to nil to disable analytics.
-    static let analyticsHost: String? = "https://posthog.hss.element.io"
-    /// Public key for submitting analytics. Set to nil to disable analytics.
-    static let analyticsKey: String? = "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO"
-    #endif
     
-    /// The URL to open with more information about analytics terms.
-    static let analyticsTermsURL = URL(string: "https://element.io/cookie-policy")!
+    /// A type that represents how to set up the analytics module in the app.
+    ///
+    /// **Note:** Analytics are disabled by default for forks.
+    /// If you are maintaining a fork, set custom configurations.
+    struct AnalyticsConfiguration {
+        /// Whether or not analytics should be enabled.
+        let isEnabled: Bool
+        /// The host to use for PostHog analytics.
+        let host: String
+        /// The public key for submitting analytics.
+        let apiKey: String
+        /// The URL to open with more information about analytics terms.
+        let termsURL: URL
+    }
+    
+    #if DEBUG
+    /// The configuration to use for analytics during development. Set `isEnabled` to false to disable analytics in debug builds.
+    static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: BuildSettings.baseBundleIdentifier.starts(with: "im.vector.app"),
+                                                               host: "https://posthog-poc.lab.element.dev",
+                                                               apiKey: "rs-pJjsYJTuAkXJfhaMmPUNBhWliDyTKLOOxike6ck8",
+                                                               termsURL: URL(string: "https://element.io/cookie-policy")!)
+    #else
+    /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
+    static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: BuildSettings.baseBundleIdentifier.starts(with: "im.vector.app"),
+                                                               host: "https://posthog.hss.element.io",
+                                                               apiKey: "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
+                                                               termsURL: URL(string: "https://element.io/cookie-policy")!)
+    #endif
     
     
     // MARK: - Bug report

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -50,8 +50,8 @@ import AnalyticsEvents
     
     /// Whether to show the user the analytics opt in prompt.
     var shouldShowAnalyticsPrompt: Bool {
-        // Only show the prompt once, and when analytics are configured in BuildSettings.
-        !RiotSettings.shared.hasSeenAnalyticsPrompt && PHGPostHogConfiguration.standard != nil
+        // Only show the prompt once, and when analytics are enabled in BuildSettings.
+        !RiotSettings.shared.hasSeenAnalyticsPrompt && BuildSettings.analyticsConfiguration.isEnabled
     }
     
     /// Indicates whether the user previously accepted Matomo analytics and should be shown the upgrade prompt.

--- a/Riot/Modules/Analytics/PHGPostHogConfiguration.swift
+++ b/Riot/Modules/Analytics/PHGPostHogConfiguration.swift
@@ -18,11 +18,12 @@ import PostHog
 
 extension PHGPostHogConfiguration {
     static var standard: PHGPostHogConfiguration? {
-        guard let apiKey = BuildSettings.analyticsKey, let host = BuildSettings.analyticsHost else { return nil }
+        let analyticsConfiguration = BuildSettings.analyticsConfiguration
+        guard analyticsConfiguration.isEnabled else { return nil }
         
-        let configuration = PHGPostHogConfiguration(apiKey: apiKey, host: host)
-        configuration.shouldSendDeviceID = false
+        let postHogConfiguration = PHGPostHogConfiguration(apiKey: analyticsConfiguration.apiKey, host: analyticsConfiguration.host)
+        postHogConfiguration.shouldSendDeviceID = false
         
-        return configuration
+        return postHogConfiguration
     }
 }

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
@@ -57,7 +57,7 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
             promptType = .newUser
         }
         
-        let viewModel = AnalyticsPromptViewModel(promptType: promptType, strings: strings, termsURL: BuildSettings.analyticsTermsURL)
+        let viewModel = AnalyticsPromptViewModel(promptType: promptType, strings: strings, termsURL: BuildSettings.analyticsConfiguration.termsURL)
         
         let view = AnalyticsPrompt(viewModel: viewModel.context)
         _analyticsPromptViewModel = viewModel

--- a/changelog.d/5687.misc
+++ b/changelog.d/5687.misc
@@ -1,0 +1,1 @@
+Disable the default analytics configurations for forks.


### PR DESCRIPTION
Adds an `AnalyticsConfiguration` to contain all settings in a single object.

I've nested this inside of `BuildSettings` to avoid needing to add it to every target that contains `BuildSettings` as that seemed more sensible to me, but happy to change this if not.

Fixes #5687 