### PR TITLE
Prepare onboarding flow for personalisation screens.

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -361,6 +361,9 @@ final class BuildSettings: NSObject {
     // MARK: - Authentication Options
     static let authEnableRefreshTokens = false
     
+    // MARK: - Onboarding
+    static let onboardingShowAccountPersonalisation = false
+    
     // MARK: - Unified Search
     static let unifiedSearchScreenShowPublicDirectory = true
     

--- a/Riot/Assets/Images.xcassets/Onboarding/onboarding_congratulations_icon.imageset/Contents.json
+++ b/Riot/Assets/Images.xcassets/Onboarding/onboarding_congratulations_icon.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "user.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Riot/Assets/Images.xcassets/Onboarding/onboarding_congratulations_icon.imageset/user.svg
+++ b/Riot/Assets/Images.xcassets/Onboarding/onboarding_congratulations_icon.imageset/user.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 70 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M54.476,63.884C48.916,67.64 42.214,69.833 35,69.833C27.158,69.833 19.922,67.242 14.1,62.869C5.639,56.514 0.167,46.396 0.167,35C0.167,15.762 15.762,0.167 35,0.167C54.238,0.167 69.833,15.762 69.833,35C69.833,47.024 63.742,57.625 54.476,63.884ZM35,36.742C40.772,36.742 45.45,31.673 45.45,25.421C45.45,19.169 40.772,14.1 35,14.1C29.229,14.1 24.55,19.169 24.55,25.421C24.55,31.673 29.229,36.742 35,36.742ZM35,62.867C42.531,62.867 49.364,59.879 54.379,55.025C51.278,47.368 43.77,41.967 35,41.967C26.231,41.967 18.722,47.368 15.621,55.025C20.636,59.879 27.469,62.867 35,62.867Z" style="fill:white;"/>
+</svg>

--- a/Riot/Assets/en.lproj/Untranslated.strings
+++ b/Riot/Assets/en.lproj/Untranslated.strings
@@ -14,6 +14,10 @@
  limitations under the License.
  */
 
-/** General **/
+/** These strings will be ignored by Weblate. Useful for WIP **/
 
-"Untranslated test" = "Untranslated test";
+// MARK: Onboarding Personalisation WIP
+"onboarding_congratulations_title" = "Congratulations!";
+"onboarding_congratulations_message" = "Your account\n%@\nhas been created.";
+"onboarding_congratulations_personalise_button" = "Personalise profile";
+"onboarding_congratulations_home_button" = "Take me home";

--- a/Riot/Assets/en.lproj/Untranslated.strings
+++ b/Riot/Assets/en.lproj/Untranslated.strings
@@ -1,0 +1,19 @@
+/*
+ Copyright 2015 OpenMarket Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/** General **/
+
+"Untranslated test" = "Untranslated test";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -104,11 +104,6 @@
 "onboarding_use_case_existing_server_message" = "Looking to join an existing server?";
 "onboarding_use_case_existing_server_button" = "Connect to server";
 
-"onboarding_congratulations_title" = "Congratulations!";
-"onboarding_congratulations_message" = "Your account\n%@\nhas been created.";
-"onboarding_congratulations_personalise_button" = "Personalise profile";
-"onboarding_congratulations_home_button" = "Take me home";
-
 // Authentication
 "auth_login" = "Log in";
 "auth_register" = "Register";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -104,6 +104,11 @@
 "onboarding_use_case_existing_server_message" = "Looking to join an existing server?";
 "onboarding_use_case_existing_server_button" = "Connect to server";
 
+"onboarding_congratulations_title" = "Congratulations!";
+"onboarding_congratulations_message" = "Your account\n%@\nhas been created.";
+"onboarding_congratulations_personalise_button" = "Personalise profile";
+"onboarding_congratulations_home_button" = "Take me home";
+
 // Authentication
 "auth_login" = "Log in";
 "auth_register" = "Register";

--- a/Riot/Generated/Images.swift
+++ b/Riot/Generated/Images.swift
@@ -123,6 +123,7 @@ internal class Asset: NSObject {
     internal static let onboardingSplashScreenPage3Dark = ImageAsset(name: "OnboardingSplashScreenPage3Dark")
     internal static let onboardingSplashScreenPage4 = ImageAsset(name: "OnboardingSplashScreenPage4")
     internal static let onboardingSplashScreenPage4Dark = ImageAsset(name: "OnboardingSplashScreenPage4Dark")
+    internal static let onboardingCongratulationsIcon = ImageAsset(name: "onboarding_congratulations_icon")
     internal static let onboardingUseCaseCommunity = ImageAsset(name: "onboarding_use_case_community")
     internal static let onboardingUseCaseCommunityDark = ImageAsset(name: "onboarding_use_case_community_dark")
     internal static let onboardingUseCaseIcon = ImageAsset(name: "onboarding_use_case_icon")

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2407,22 +2407,6 @@ public class VectorL10n: NSObject {
   public static var on: String { 
     return VectorL10n.tr("Vector", "on") 
   }
-  /// Take me home
-  public static var onboardingCongratulationsHomeButton: String { 
-    return VectorL10n.tr("Vector", "onboarding_congratulations_home_button") 
-  }
-  /// Your account\n%@\nhas been created.
-  public static func onboardingCongratulationsMessage(_ p1: String) -> String {
-    return VectorL10n.tr("Vector", "onboarding_congratulations_message", p1)
-  }
-  /// Personalise profile
-  public static var onboardingCongratulationsPersonaliseButton: String { 
-    return VectorL10n.tr("Vector", "onboarding_congratulations_personalise_button") 
-  }
-  /// Congratulations!
-  public static var onboardingCongratulationsTitle: String { 
-    return VectorL10n.tr("Vector", "onboarding_congratulations_title") 
-  }
   /// I already have an account
   public static var onboardingSplashLoginButtonTitle: String { 
     return VectorL10n.tr("Vector", "onboarding_splash_login_button_title") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2407,6 +2407,22 @@ public class VectorL10n: NSObject {
   public static var on: String { 
     return VectorL10n.tr("Vector", "on") 
   }
+  /// Take me home
+  public static var onboardingCongratulationsHomeButton: String { 
+    return VectorL10n.tr("Vector", "onboarding_congratulations_home_button") 
+  }
+  /// Your account\n%@\nhas been created.
+  public static func onboardingCongratulationsMessage(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "onboarding_congratulations_message", p1)
+  }
+  /// Personalise profile
+  public static var onboardingCongratulationsPersonaliseButton: String { 
+    return VectorL10n.tr("Vector", "onboarding_congratulations_personalise_button") 
+  }
+  /// Congratulations!
+  public static var onboardingCongratulationsTitle: String { 
+    return VectorL10n.tr("Vector", "onboarding_congratulations_title") 
+  }
   /// I already have an account
   public static var onboardingSplashLoginButtonTitle: String { 
     return VectorL10n.tr("Vector", "onboarding_splash_login_button_title") 

--- a/Riot/Generated/UntranslatedStrings.swift
+++ b/Riot/Generated/UntranslatedStrings.swift
@@ -1,0 +1,19 @@
+// swiftlint:disable all
+// Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Strings
+
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
+public extension VectorL10n {
+  /// Untranslated test
+  static var untranslatedTest: String { 
+    return VectorL10n.tr("Untranslated", "Untranslated test") 
+  }
+}
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+

--- a/Riot/Generated/UntranslatedStrings.swift
+++ b/Riot/Generated/UntranslatedStrings.swift
@@ -10,9 +10,21 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public extension VectorL10n {
-  /// Untranslated test
-  static var untranslatedTest: String { 
-    return VectorL10n.tr("Untranslated", "Untranslated test") 
+  /// Take me home
+  static var onboardingCongratulationsHomeButton: String { 
+    return VectorL10n.tr("Untranslated", "onboarding_congratulations_home_button") 
+  }
+  /// Your account\n%@\nhas been created.
+  public static func onboardingCongratulationsMessage(_ p1: String) -> String {
+    return VectorL10n.tr("Untranslated", "onboarding_congratulations_message", p1)
+  }
+  /// Personalise profile
+  static var onboardingCongratulationsPersonaliseButton: String { 
+    return VectorL10n.tr("Untranslated", "onboarding_congratulations_personalise_button") 
+  }
+  /// Congratulations!
+  static var onboardingCongratulationsTitle: String { 
+    return VectorL10n.tr("Untranslated", "onboarding_congratulations_title") 
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -94,7 +94,7 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
         authenticationViewController.continueSSOLogin(withToken: loginToken, txnId: transactionID)
     }
     
-    func allowScreenPresentation() {
+    func presentPendingScreensIfNecessary() {
         canPresentAdditionalScreens = true
         
         showLoadingAnimation()

--- a/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
@@ -20,14 +20,16 @@ import Foundation
 
 struct AuthenticationCoordinatorParameters {
     let navigationRouter: NavigationRouterType
+    /// Whether or not the coordinator should show the loading spinner, key verification etc.
+    let canPresentAdditionalScreens: Bool
 }
 
 enum AuthenticationCoordinatorResult {
     /// The user has authenticated but key verification is yet to happen. The session value is
     /// for a fresh session that still needs to load, sync etc before being ready.
-    case didLogin(MXSession)
+    case didLogin(session: MXSession, authenticationType: MXKAuthenticationType)
     /// All of the required authentication steps including key verification is complete.
-    case didComplete(MXKAuthenticationType)
+    case didComplete
 }
 
 /// `AuthenticationCoordinatorProtocol` is a protocol describing a Coordinator that handle's the authentication navigation flow.
@@ -52,4 +54,8 @@ protocol AuthenticationCoordinatorProtocol: Coordinator, Presentable {
     
     /// When SSO login succeeded, when SFSafariViewController is used, continue login with success parameters.
     func continueSSOLogin(withToken loginToken: String, transactionID: String) -> Bool
+    
+    /// Indicates to the coordinator to display any pending screens if it was created with
+    /// the `canPresentAdditionalScreens` parameter set to `false`
+    func allowScreenPresentation()
 }

--- a/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
@@ -57,5 +57,5 @@ protocol AuthenticationCoordinatorProtocol: Coordinator, Presentable {
     
     /// Indicates to the coordinator to display any pending screens if it was created with
     /// the `canPresentAdditionalScreens` parameter set to `false`
-    func allowScreenPresentation()
+    func presentPendingScreensIfNecessary()
 }

--- a/Riot/Modules/MatrixKit/Views/Authentication/MXKAuthInputsView.h
+++ b/Riot/Modules/MatrixKit/Views/Authentication/MXKAuthInputsView.h
@@ -25,7 +25,7 @@ extern NSString *const MXKAuthErrorDomain;
 /**
  Authentication types
  */
-typedef enum {
+typedef NS_ENUM(NSUInteger, MXKAuthenticationType) {
     /**
      Type used to sign up.
      */
@@ -39,7 +39,7 @@ typedef enum {
      */
     MXKAuthenticationTypeForgotPassword
     
-} MXKAuthenticationType;
+};
 
 @class MXKAuthInputsView;
 

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -61,6 +61,13 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     // MARK: Screen results
     private var splashScreenResult: OnboardingSplashScreenViewModelResult?
     private var useCaseResult: OnboardingUseCaseViewModelResult?
+    private var authenticationType: MXKAuthenticationType?
+    private var session: MXSession?
+    
+    /// Whether all of the onboarding steps have been completed or not. `false` if there are more screens to be shown.
+    private var onboardingIsFinished = false
+    /// Whether the main app is ready to be shown or not. `true` once authenticated, verified and the store/data sources are ready.
+    private var appIsReady = false
     
     // MARK: Public
 
@@ -74,7 +81,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         self.parameters = parameters
         
         // Preload the authVC (it is *really* slow to load in realtime)
-        let authenticationParameters = AuthenticationCoordinatorParameters(navigationRouter: parameters.router)
+        let authenticationParameters = AuthenticationCoordinatorParameters(navigationRouter: parameters.router, canPresentAdditionalScreens: false)
         authenticationCoordinator = AuthenticationCoordinator(parameters: authenticationParameters)
         
         super.init()
@@ -115,11 +122,13 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         return authenticationCoordinator.continueSSOLogin(withToken: loginToken, transactionID: transactionID)
     }
     
-    // MARK: - Private
+    // MARK: - Pre-Authentication
     
     @available(iOS 14.0, *)
     /// Show the onboarding splash screen as the root module in the flow.
     private func showSplashScreen() {
+        MXLog.debug("[OnboardingCoordinator] showSplashScreen")
+        
         let coordinator = OnboardingSplashScreenCoordinator()
         coordinator.completion = { [weak self, weak coordinator] result in
             guard let self = self, let coordinator = coordinator else { return }
@@ -129,7 +138,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         coordinator.start()
         add(childCoordinator: coordinator)
         
-        self.navigationRouter.setRootModule(coordinator, popCompletion: nil)
+        navigationRouter.setRootModule(coordinator, popCompletion: nil)
     }
     
     @available(iOS 14.0, *)
@@ -138,8 +147,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         splashScreenResult = result
         
         // Set the auth type early to allow network requests to finish during display of the use case screen.
-        let mxkAuthenticationType = splashScreenResult == .register ? MXKAuthenticationTypeRegister : MXKAuthenticationTypeLogin
-        authenticationCoordinator.update(authenticationType: mxkAuthenticationType)
+        authenticationCoordinator.update(authenticationType: result.mxkAuthenticationType)
         
         switch result {
         case .register:
@@ -152,6 +160,8 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     @available(iOS 14.0, *)
     /// Show the use case screen for new users.
     private func showUseCaseSelectionScreen() {
+        MXLog.debug("[OnboardingCoordinator] showUseCaseSelectionScreen")
+        
         let coordinator = OnboardingUseCaseSelectionCoordinator()
         coordinator.completion = { [weak self, weak coordinator] result in
             guard let self = self, let coordinator = coordinator else { return }
@@ -161,10 +171,10 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         coordinator.start()
         add(childCoordinator: coordinator)
         
-        if self.navigationRouter.modules.isEmpty {
-            self.navigationRouter.setRootModule(coordinator, popCompletion: nil)
+        if navigationRouter.modules.isEmpty {
+            navigationRouter.setRootModule(coordinator, popCompletion: nil)
         } else {
-            self.navigationRouter.push(coordinator, animated: true) { [weak self] in
+            navigationRouter.push(coordinator, animated: true) { [weak self] in
                 self?.remove(childCoordinator: coordinator)
             }
         }
@@ -175,6 +185,8 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         useCaseResult = result
         showAuthenticationScreen()
     }
+    
+    // MARK: - Authentication
     
     /// Show the authentication screen. Any parameters that have been set in previous screens are be applied.
     private func showAuthenticationScreen() {
@@ -187,10 +199,10 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
             guard let self = self, let coordinator = coordinator else { return }
             
             switch result {
-            case .didLogin(let session):
-                self.authenticationCoordinator(coordinator, didLoginWith: session)
-            case .didComplete(let authenticationType):
-                self.authenticationCoordinator(coordinator, didCompleteWith: authenticationType)
+            case .didLogin(let session, let authenticationType):
+                self.authenticationCoordinator(coordinator, didLoginWith: session, and: authenticationType)
+            case .didComplete:
+                self.authenticationCoordinatorDidComplete(coordinator)
             }
             
         }
@@ -217,10 +229,10 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
             coordinator.updateHomeserver(customHomeserver, andIdentityServer: customIdentityServer)
         }
         
-        if self.navigationRouter.modules.isEmpty {
-            self.navigationRouter.setRootModule(coordinator, popCompletion: nil)
+        if navigationRouter.modules.isEmpty {
+            navigationRouter.setRootModule(coordinator, popCompletion: nil)
         } else {
-            self.navigationRouter.push(coordinator, animated: true) { [weak self] in
+            navigationRouter.push(coordinator, animated: true) { [weak self] in
                 self?.remove(childCoordinator: coordinator)
                 self?.isShowingAuthentication = false
             }
@@ -228,18 +240,38 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         isShowingAuthentication = true
     }
     
-    private func authenticationCoordinator(_ coordinator: AuthenticationCoordinatorProtocol, didLoginWith session: MXSession) {
-        // TODO: Show next screens whilst waiting for the everything to load.
+    /// Displays the next view in the flow after the authentication screen,
+    /// whilst crypto and the rest of the app is launching in the background.
+    private func authenticationCoordinator(_ coordinator: AuthenticationCoordinatorProtocol,
+                                           didLoginWith session: MXSession,
+                                           and authenticationType: MXKAuthenticationType) {
+        self.session = session
+        self.authenticationType = authenticationType
+        
         // May need to move the spinner and key verification up to here in order to coordinate properly.
+        
+        // Check whether another screen should be shown.
+        if #available(iOS 14.0, *) {
+            if authenticationType == .register, let userId = session.credentials.userId, BuildSettings.onboardingShowAccountPersonalisation {
+                showCongratulationsScreen(userId: userId)
+                return
+            } else if Analytics.shared.shouldShowAnalyticsPrompt {
+                showAnalyticsPrompt(for: session)
+                return
+            }
+        }
+        
+        // Otherwise onboarding is finished.
+        onboardingIsFinished = true
+        completeIfReady()
     }
     
     /// Displays the next view in the flow after the authentication screen.
-    private func authenticationCoordinator(_ coordinator: AuthenticationCoordinatorProtocol, didCompleteWith authenticationType: MXKAuthenticationType) {
-        completion?()
+    private func authenticationCoordinatorDidComplete(_ coordinator: AuthenticationCoordinatorProtocol) {
         isShowingAuthentication = false
         
         // Handle the chosen use case where applicable
-        if authenticationType == MXKAuthenticationTypeRegister,
+        if authenticationType == .register,
            let useCase = useCaseResult?.userSessionPropertyValue,
            let userSession = UserSessionsService.shared.mainUserSession {
             // Store the value in the user's session
@@ -247,6 +279,112 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
             
             // Update the analytics user properties with the use case
             Analytics.shared.updateUserProperties(ftueUseCase: useCase)
+        }
+        
+        // This method is only called when the app is ready so we can complete if finished
+        appIsReady = true
+        completeIfReady()
+    }
+    
+    // MARK: - Post-Authentication
+    
+    @available(iOS 14.0, *)
+    private func showCongratulationsScreen(userId: String) {
+        MXLog.debug("[OnboardingCoordinator] showCongratulationsScreen")
+        
+        let parameters = OnboardingCongratulationsCoordinatorParameters(userId: userId)
+        let coordinator = OnboardingCongratulationsCoordinator(parameters: parameters)
+        
+        coordinator.completion = { [weak self, weak coordinator] result in
+            guard let self = self, let coordinator = coordinator else { return }
+            self.congratulationsCoordinator(coordinator, didCompleteWith: result)
+        }
+        
+        add(childCoordinator: coordinator)
+        coordinator.start()
+        
+        // Navigating back doesn't make any sense now, so replace the whole stack.
+        navigationRouter.setRootModule(coordinator, hideNavigationBar: true, animated: true) { [weak self] in
+            self?.remove(childCoordinator: coordinator)
+        }
+    }
+    
+    @available(iOS 14.0, *)
+    private func congratulationsCoordinator(_ coordinator: OnboardingCongratulationsCoordinator, didCompleteWith result: OnboardingCongratulationsViewModelResult) {
+        if let session = session {
+            switch result {
+            case .personaliseProfile:
+                // TODO: Profile screens here instead.
+                if Analytics.shared.shouldShowAnalyticsPrompt {
+                    showAnalyticsPrompt(for: session)
+                    return
+                }
+            case .takeMeHome:
+                if Analytics.shared.shouldShowAnalyticsPrompt {
+                    showAnalyticsPrompt(for: session)
+                    return
+                }
+            }
+        }
+        
+        onboardingIsFinished = true
+        completeIfReady()
+    }
+    
+    @available(iOS 14.0, *)
+    private func showAnalyticsPrompt(for session: MXSession) {
+        MXLog.debug("[OnboardingCoordinator]: Invite the user to send analytics")
+        
+        let parameters = AnalyticsPromptCoordinatorParameters(session: session)
+        let coordinator = AnalyticsPromptCoordinator(parameters: parameters)
+        
+        coordinator.completion = { [weak self, weak coordinator] in
+            guard let self = self, let coordinator = coordinator else { return }
+            self.analyticsPromptCoordinatorDidComplete(coordinator)
+        }
+        
+        add(childCoordinator: coordinator)
+        coordinator.start()
+        
+        // TODO: Re-asses replacing the stack based on the previous screen once the whole flow is implemented
+        navigationRouter.setRootModule(coordinator, hideNavigationBar: true, animated: true) { [weak self] in
+            self?.remove(childCoordinator: coordinator)
+        }
+    }
+    
+    private func analyticsPromptCoordinatorDidComplete(_ coordinator: AnalyticsPromptCoordinator) {
+        onboardingIsFinished = true
+        completeIfReady()
+    }
+    
+    // MARK: - Finished
+    
+    private func completeIfReady() {
+        guard onboardingIsFinished else {
+            MXLog.debug("[OnboardingCoordinator] Delaying onboarding completion until all screens have been shown.")
+            return
+        }
+        
+        guard appIsReady else {
+            MXLog.debug("[OnboardingCoordinator] Allowing AuthenticationCoordinator to display any remaining screens.")
+            authenticationCoordinator.allowScreenPresentation()
+            return
+        }
+        
+        completion?()
+    }
+}
+
+// MARK: - Helpers
+
+extension OnboardingSplashScreenViewModelResult {
+    /// The result converted into the MatrixKit authentication type to use.
+    var mxkAuthenticationType: MXKAuthenticationType {
+        switch self {
+        case .login:
+            return .login
+        case .register:
+            return .register
         }
     }
 }

--- a/Riot/Modules/TabBar/MasterTabBarController.h
+++ b/Riot/Modules/TabBar/MasterTabBarController.h
@@ -194,6 +194,5 @@ typedef NS_ENUM(NSUInteger, MasterTabBarIndex) {
 - (void)masterTabBarController:(MasterTabBarController *)masterTabBarController didSelectRoomPreviewWithParameters:(RoomPreviewNavigationParameters*)roomPreviewNavigationParameters completion:(void (^)(void))completion;
 - (void)masterTabBarController:(MasterTabBarController *)masterTabBarController didSelectContact:(MXKContact*)contact withPresentationParameters:(ScreenPresentationParameters*)presentationParameters;
 - (void)masterTabBarController:(MasterTabBarController *)masterTabBarController didSelectGroup:(MXGroup*)group inMatrixSession:(MXSession*)matrixSession presentationParameters:(ScreenPresentationParameters*)presentationParameters;
-- (void)masterTabBarController:(MasterTabBarController *)masterTabBarController shouldPresentAnalyticsPromptForMatrixSession:(MXSession*)matrixSession;
 
 @end

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -73,11 +73,6 @@
 
 @property (nonatomic) BOOL reviewSessionAlertHasBeenDisplayed;
 
-/**
- A flag to indicate that the analytics prompt should be shown during `-addMatrixSession:`.
- */
-@property(nonatomic) BOOL presentAnalyticsPromptOnAddSession;
-
 @end
 
 @implementation MasterTabBarController
@@ -204,20 +199,6 @@
 
     if (!authIsShown)
     {
-        // Check whether the user should be prompted to send analytics.
-        if (Analytics.shared.shouldShowAnalyticsPrompt)
-        {
-            MXSession *mxSession = self.mxSessions.firstObject;
-            if (mxSession)
-            {
-                [self promptUserBeforeUsingAnalyticsForSession:mxSession];
-            }
-            else
-            {
-                self.presentAnalyticsPromptOnAddSession = YES;
-            }
-        }
-        
         [self refreshTabBarBadges];
         
         // Release properly pushed and/or presented view controller
@@ -420,12 +401,6 @@
     {
         MXLogDebug(@"MasterTabBarController already has %@ in mxSessionArray", mxSession)
         return;
-    }
-    
-    if (self.presentAnalyticsPromptOnAddSession)
-    {
-        self.presentAnalyticsPromptOnAddSession = NO;
-        [self promptUserBeforeUsingAnalyticsForSession:mxSession];
     }
     
     // Check whether the controller's view is loaded into memory.
@@ -963,18 +938,6 @@
     }
     
     return NSNotFound;
-}
-
-#pragma mark -
-
-- (void)promptUserBeforeUsingAnalyticsForSession:(MXSession *)mxSession
-{
-    // Analytics aren't collected on iOS 12 & 13.
-    if (@available(iOS 14.0, *))
-    {
-        MXLogDebug(@"[MasterTabBarController]: Invite the user to send analytics");
-        [self.masterTabBarDelegate masterTabBarController:self shouldPresentAnalyticsPromptForMatrixSession:mxSession];
-    }
 }
 
 #pragma mark - Review session

--- a/Riot/Modules/TabBar/TabBarCoordinator.swift
+++ b/Riot/Modules/TabBar/TabBarCoordinator.swift
@@ -575,24 +575,6 @@ final class TabBarCoordinator: NSObject, TabBarCoordinatorType {
         self.splitViewMasterPresentableDelegate?.splitViewMasterPresentableWantsToResetDetail(self)
     }
     
-    @available(iOS 14.0, *)
-    private func presentAnalyticsPrompt(with session: MXSession) {
-        let parameters = AnalyticsPromptCoordinatorParameters(session: session)
-        let coordinator = AnalyticsPromptCoordinator(parameters: parameters)
-        
-        coordinator.completion = { [weak self, weak coordinator] in
-            guard let self = self, let coordinator = coordinator else { return }
-            
-            self.navigationRouter.dismissModule(animated: true, completion: nil)
-            self.remove(childCoordinator: coordinator)
-        }
-        
-        add(childCoordinator: coordinator)
-        
-        navigationRouter.present(coordinator, animated: true)
-        coordinator.start()
-    }
-    
     // MARK: UserSessions management
     
     private func registerUserSessionsServiceNotifications() {
@@ -683,12 +665,6 @@ extension TabBarCoordinator: MasterTabBarControllerDelegate {
         sideMenuBarButtonItem.accessibilityLabel = VectorL10n.sideMenuRevealActionAccessibilityLabel
         
         self.masterTabBarController.navigationItem.leftBarButtonItem = sideMenuBarButtonItem
-    }
-    
-    func masterTabBarController(_ masterTabBarController: MasterTabBarController!, shouldPresentAnalyticsPromptForMatrixSession matrixSession: MXSession!) {
-        if #available(iOS 14.0, *) {
-            presentAnalyticsPrompt(with: matrixSession)
-        }
     }
 }
 

--- a/Riot/target.yml
+++ b/Riot/target.yml
@@ -90,6 +90,7 @@ targets:
     - path: Assets/en.lproj/InfoPlist.strings
     - path: Assets/en.lproj/Localizable.strings
     - path: Assets/en.lproj/Vector.strings
+    - path: Assets/en.lproj/Untranslated.strings
     - path: Assets/eo.lproj/InfoPlist.strings
     - path: Assets/eo.lproj/Localizable.strings
     - path: Assets/eo.lproj/Vector.strings

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPrompt.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPrompt.swift
@@ -125,6 +125,8 @@ struct AnalyticsPrompt: View {
             .background(theme.colors.background.ignoresSafeArea())
             .accentColor(theme.colors.accent)
         }
+        .navigationBarHidden(true)
+        .navigationBarBackButtonHidden(true)
     }
 }
 

--- a/RiotSwiftUI/Modules/Common/Mock/MockAppScreens.swift
+++ b/RiotSwiftUI/Modules/Common/Mock/MockAppScreens.swift
@@ -20,6 +20,7 @@ import Foundation
 @available(iOS 14.0, *)
 enum MockAppScreens {
     static let appScreens: [MockScreenState.Type] = [
+        MockOnboardingCongratulationsScreenState.self,
         MockOnboardingUseCaseSelectionScreenState.self,
         MockOnboardingSplashScreenScreenState.self,
         MockLocationSharingScreenState.self,

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct OnboardingCongratulationsCoordinatorParameters {
+    let userId: String
+}
+
+final class OnboardingCongratulationsCoordinator: Coordinator, Presentable {
+    
+    // MARK: - Properties
+    
+    // MARK: Private
+    
+    private let parameters: OnboardingCongratulationsCoordinatorParameters
+    private let onboardingCongratulationsHostingController: UIViewController
+    private var onboardingCongratulationsViewModel: OnboardingCongratulationsViewModelProtocol
+    
+    // MARK: Public
+
+    // Must be used only internally
+    var childCoordinators: [Coordinator] = []
+    var completion: ((OnboardingCongratulationsViewModelResult) -> Void)?
+    
+    // MARK: - Setup
+    
+    @available(iOS 14.0, *)
+    init(parameters: OnboardingCongratulationsCoordinatorParameters) {
+        self.parameters = parameters
+        
+        let viewModel = OnboardingCongratulationsViewModel(userId: parameters.userId)
+        let view = OnboardingCongratulations(viewModel: viewModel.context)
+        onboardingCongratulationsViewModel = viewModel
+        onboardingCongratulationsHostingController = VectorHostingController(rootView: view)
+    }
+    
+    // MARK: - Public
+    func start() {
+        MXLog.debug("[OnboardingCongratulationsCoordinator] did start.")
+        onboardingCongratulationsViewModel.completion = { [weak self] result in
+            MXLog.debug("[OnboardingCongratulationsCoordinator] OnboardingCongratulationsViewModel did complete with result: \(result).")
+            guard let self = self else { return }
+            self.completion?(result)
+        }
+    }
+    
+    func toPresentable() -> UIViewController {
+        return self.onboardingCongratulationsHostingController
+    }
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
@@ -52,8 +52,8 @@ final class OnboardingCongratulationsCoordinator: Coordinator, Presentable {
     func start() {
         MXLog.debug("[OnboardingCongratulationsCoordinator] did start.")
         onboardingCongratulationsViewModel.completion = { [weak self] result in
-            MXLog.debug("[OnboardingCongratulationsCoordinator] OnboardingCongratulationsViewModel did complete with result: \(result).")
             guard let self = self else { return }
+            MXLog.debug("[OnboardingCongratulationsCoordinator] OnboardingCongratulationsViewModel did complete with result: \(result).")
             self.completion?(result)
         }
     }

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
@@ -43,7 +43,7 @@ final class OnboardingCongratulationsCoordinator: Coordinator, Presentable {
         self.parameters = parameters
         
         let viewModel = OnboardingCongratulationsViewModel(userId: parameters.userId)
-        let view = OnboardingCongratulations(viewModel: viewModel.context)
+        let view = OnboardingCongratulationsScreen(viewModel: viewModel.context)
         onboardingCongratulationsViewModel = viewModel
         onboardingCongratulationsHostingController = VectorHostingController(rootView: view)
     }

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/MockOnboardingCongratulationsScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/MockOnboardingCongratulationsScreenState.swift
@@ -1,0 +1,46 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import SwiftUI
+
+/// Using an enum for the screen allows you define the different state cases with
+/// the relevant associated data for each case.
+@available(iOS 14.0, *)
+enum MockOnboardingCongratulationsScreenState: MockScreenState, CaseIterable {
+    // A case for each state you want to represent
+    // with specific, minimal associated data that will allow you
+    // mock that screen.
+    case congratulations
+    
+    /// The associated screen
+    var screenType: Any.Type {
+        OnboardingCongratulationsScreen.self
+    }
+    
+    /// Generate the view struct for the screen state.
+    var screenView: ([Any], AnyView)  {
+        let viewModel = OnboardingCongratulationsViewModel(userId: "@testuser:example.com")
+        
+        // can simulate service and viewModel actions here if needs be.
+        
+        return (
+            [self, viewModel],
+            AnyView(OnboardingCongratulationsScreen(viewModel: viewModel.context)
+                .addDependency(MockAvatarService.example))
+        )
+    }
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsModels.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsModels.swift
@@ -1,0 +1,37 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+// MARK: - Coordinator
+
+// MARK: View model
+
+enum OnboardingCongratulationsViewModelResult {
+    case personaliseProfile
+    case takeMeHome
+}
+
+// MARK: View
+
+struct OnboardingCongratulationsViewState: BindableState {
+    var userId: String
+}
+
+enum OnboardingCongratulationsViewAction {
+    case personaliseProfile
+    case takeMeHome
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModel.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+@available(iOS 14, *)
+typealias OnboardingCongratulationsViewModelType = StateStoreViewModel<OnboardingCongratulationsViewState,
+                                                                  Never,
+                                                                  OnboardingCongratulationsViewAction>
+@available(iOS 14, *)
+class OnboardingCongratulationsViewModel: OnboardingCongratulationsViewModelType, OnboardingCongratulationsViewModelProtocol {
+
+    // MARK: - Properties
+
+    // MARK: Private
+
+    // MARK: Public
+
+    var completion: ((OnboardingCongratulationsViewModelResult) -> Void)?
+
+    // MARK: - Setup
+
+    init(userId: String, initialCount: Int = 0) {
+        super.init(initialViewState: OnboardingCongratulationsViewState(userId: userId))
+    }
+
+    // MARK: - Public
+
+    override func process(viewAction: OnboardingCongratulationsViewAction) {
+        switch viewAction {
+        case .personaliseProfile:
+            completion?(.personaliseProfile)
+        case .takeMeHome:
+            completion?(.takeMeHome)
+        }
+    }
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModelProtocol.swift
@@ -1,0 +1,24 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol OnboardingCongratulationsViewModelProtocol {
+    
+    var completion: ((OnboardingCongratulationsViewModelResult) -> Void)? { get set }
+    @available(iOS 14, *)
+    var context: OnboardingCongratulationsViewModelType.Context { get }
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/UI/OnboardingCongratulationsUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/UI/OnboardingCongratulationsUITests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import RiotSwiftUI
+
+@available(iOS 14.0, *)
+class OnboardingCongratulationsUITests: MockScreenTest {
+
+    override class var screenType: MockScreenState.Type {
+        return MockOnboardingCongratulationsScreenState.self
+    }
+
+    override class func createTest() -> MockScreenTest {
+        return OnboardingCongratulationsUITests(selector: #selector(verifyOnboardingCongratulationsScreen))
+    }
+
+    func verifyOnboardingCongratulationsScreen() throws {
+        guard let screenState = screenState as? MockOnboardingCongratulationsScreenState else { fatalError("no screen") }
+        switch screenState {
+        case .congratulations:
+            // There isn't anything to test here
+            break
+        }
+    }
+
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/Unit/OnboardingCongratulationsViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/Unit/OnboardingCongratulationsViewModelTests.swift
@@ -1,0 +1,24 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+@testable import RiotSwiftUI
+
+@available(iOS 14.0, *)
+class OnboardingCongratulationsViewModelTests: XCTestCase {
+    // The view modal has minimal set up and no mutation so nothing to test.
+}

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
@@ -64,6 +64,7 @@ struct OnboardingCongratulationsScreen: View {
     var mainContent: some View {
         VStack(spacing: 62) {
             Image(Asset.Images.onboardingCongratulationsIcon.name)
+                .accessibilityHidden(true)
             
             VStack(spacing: 8) {
                 Text(VectorL10n.onboardingCongratulationsTitle)

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
@@ -1,0 +1,108 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+@available(iOS 14.0, *)
+struct OnboardingCongratulationsScreen: View {
+
+    // MARK: - Properties
+    
+    // MARK: Private
+    
+    @Environment(\.theme) private var theme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    
+    private var horizontalPadding: CGFloat {
+        horizontalSizeClass == .regular ? 50 : 16
+    }
+    
+    // MARK: Public
+    
+    @ObservedObject var viewModel: OnboardingCongratulationsViewModel.Context
+    
+    // MARK: Views
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                mainContent
+                    .padding(.top, 60)
+                    .padding(.horizontal, horizontalPadding)
+                
+                Spacer()
+                
+                buttons
+                    .padding(.horizontal, horizontalPadding)
+                    .padding(.bottom, 24)
+                    .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
+            }
+            .frame(maxWidth: OnboardingConstants.maxContentWidth,
+                   maxHeight: OnboardingConstants.maxContentHeight)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(theme.colors.accent.ignoresSafeArea())
+        .accentColor(.white)
+        .navigationBarHidden(true)
+        .preferredColorScheme(.dark)    // make the status bar white
+    }
+    
+    /// The main content of the view to be shown in a scroll view.
+    var mainContent: some View {
+        VStack(spacing: 62) {
+            Image(Asset.Images.onboardingCongratulationsIcon.name)
+            
+            VStack(spacing: 8) {
+                Text(VectorL10n.onboardingCongratulationsTitle)
+                    .font(theme.fonts.title2B)
+                    .foregroundColor(.white)
+                
+                Text(VectorL10n.onboardingCongratulationsMessage(viewModel.viewState.userId))
+                    .font(theme.fonts.body)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+    
+    /// The action buttons shown at the bottom of the view.
+    var buttons: some View {
+        VStack(spacing: 12) {
+            Button { viewModel.send(viewAction: .personaliseProfile) } label: {
+                Text(VectorL10n.onboardingCongratulationsPersonaliseButton)
+                    .font(theme.fonts.bodySB)
+                    .foregroundColor(theme.colors.accent)
+            }
+            .buttonStyle(PrimaryActionButtonStyle(customColor: .white))
+            
+            Button { viewModel.send(viewAction: .takeMeHome) } label: {
+                Text(VectorL10n.onboardingCongratulationsHomeButton)
+                    .font(theme.fonts.body)
+                    .padding(.vertical, 12)
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+@available(iOS 14.0, *)
+struct OnboardingCongratulationsScreen_Previews: PreviewProvider {
+    static let stateRenderer = MockOnboardingCongratulationsScreenState.stateRenderer
+    static var previews: some View {
+        stateRenderer.screenGroup()
+    }
+}

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Coordinator/TemplateSimpleScreenCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Coordinator/TemplateSimpleScreenCoordinator.swift
@@ -52,8 +52,8 @@ final class TemplateSimpleScreenCoordinator: Coordinator, Presentable {
     func start() {
         MXLog.debug("[TemplateSimpleScreenCoordinator] did start.")
         templateSimpleScreenViewModel.completion = { [weak self] result in
-            MXLog.debug("[TemplateSimpleScreenCoordinator] TemplateSimpleScreenViewModel did complete with result: \(result).")
             guard let self = self else { return }
+            MXLog.debug("[TemplateSimpleScreenCoordinator] TemplateSimpleScreenViewModel did complete with result: \(result).")
             self.completion?(result)
         }
     }

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Coordinator/TemplateUserProfileCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Coordinator/TemplateUserProfileCoordinator.swift
@@ -52,8 +52,8 @@ final class TemplateUserProfileCoordinator: Coordinator, Presentable {
     func start() {
         MXLog.debug("[TemplateUserProfileCoordinator] did start.")
         templateUserProfileViewModel.completion = { [weak self] result in
-            MXLog.debug("[TemplateUserProfileCoordinator] TemplateUserProfileViewModel did complete with result: \(result).")
             guard let self = self else { return }
+            MXLog.debug("[TemplateUserProfileCoordinator] TemplateUserProfileViewModel did complete with result: \(result).")
             switch result {
             case .cancel, .done:
                 self.completion?()

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Coordinator/TemplateRoomChatCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Coordinator/TemplateRoomChatCoordinator.swift
@@ -52,8 +52,8 @@ final class TemplateRoomChatCoordinator: Coordinator, Presentable {
     func start() {
         MXLog.debug("[TemplateRoomChatCoordinator] did start.")
         templateRoomChatViewModel.callback = { [weak self] result in
-            MXLog.debug("[TemplateRoomChatCoordinator] TemplateRoomChatViewModel did complete with result: \(result).")
             guard let self = self else { return }
+            MXLog.debug("[TemplateRoomChatCoordinator] TemplateRoomChatViewModel did complete with result: \(result).")
             switch result {
             case .done:
                 self.callback?()

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Coordinator/TemplateRoomListCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Coordinator/TemplateRoomListCoordinator.swift
@@ -53,8 +53,8 @@ final class TemplateRoomListCoordinator: Coordinator, Presentable {
     func start() {
         MXLog.debug("[TemplateRoomListCoordinator] did start.")
         templateRoomListViewModel.callback = { [weak self] result in
-            MXLog.debug("[TemplateRoomListCoordinator] TemplateRoomListViewModel did complete with result \(result).")
             guard let self = self else { return }
+            MXLog.debug("[TemplateRoomListCoordinator] TemplateRoomListViewModel did complete with result \(result).")
             switch result {
             case .didSelectRoom(let roomId):
                 self.callback?(.didSelectRoom(roomId))

--- a/RiotSwiftUI/target.yml
+++ b/RiotSwiftUI/target.yml
@@ -42,6 +42,7 @@ targets:
     - path: ../Riot/Managers/AppInfo/
     - path: ../Riot/Categories/Bundle.swift
     - path: ../Riot/Generated/Strings.swift
+    - path: ../Riot/Generated/UntranslatedStrings.swift
     - path: ../Riot/Generated/Images.swift
     - path: ../Riot/Managers/Theme/
     - path: ../Riot/Managers/Locale/LocaleProviderType.swift
@@ -50,6 +51,7 @@ targets:
     - path: ../Riot/Categories/UIColor.swift
     - path: ../Riot/Categories/UISearchBar.swift
     - path: ../Riot/Assets/en.lproj/Vector.strings
+    - path: ../Riot/Assets/en.lproj/Untranslated.strings
       buildPhase: resources
     - path: ../Riot/Assets/Images.xcassets
       buildPhase: resources

--- a/RiotSwiftUI/targetUITests.yml
+++ b/RiotSwiftUI/targetUITests.yml
@@ -50,6 +50,7 @@ targets:
     - path: ../Riot/Managers/AppInfo/
     - path: ../Riot/Categories/Bundle.swift
     - path: ../Riot/Generated/Strings.swift
+    - path: ../Riot/Generated/UntranslatedStrings.swift
     - path: ../Riot/Generated/Images.swift
     - path: ../Riot/Managers/Theme/
     - path: ../Riot/Managers/Locale/LocaleProviderType.swift
@@ -58,6 +59,7 @@ targets:
     - path: ../Riot/Categories/UIColor.swift
     - path: ../Riot/Categories/UISearchBar.swift
     - path: ../Riot/Assets/en.lproj/Vector.strings
+    - path: ../Riot/Assets/en.lproj/Untranslated.strings
       buildPhase: resources
     - path: ../Riot/Assets/Images.xcassets
       buildPhase: resources

--- a/Tools/SwiftGen/Templates/Strings/flat-swift4-vector-untranslated.stencil
+++ b/Tools/SwiftGen/Templates/Strings/flat-swift4-vector-untranslated.stencil
@@ -1,0 +1,64 @@
+// swiftlint:disable all
+// Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Strings
+
+{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
+  {% for type in types %}
+    _ p{{forloop.counter}}: {{type}}{{ ", " if not forloop.last }}
+  {% endfor %}
+{% endfilter %}{% endmacro %}
+{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
+  {% for type in types %}
+    {% if type == "UnsafeRawPointer" %}
+    Int(bitPattern: p{{forloop.counter}})
+    {% else %}
+    p{{forloop.counter}}
+    {% endif %}
+    {{ ", " if not forloop.last }}
+  {% endfor %}
+{% endfilter %}{% endmacro %}
+{% macro recursiveBlock table item %}
+  {% for string in item.strings %}
+  {% if not param.noComments %}
+  /// {{string.translation}}
+  {% endif %}
+  {% if string.types %}
+  {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
+    return {{className}}.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %})
+  }
+  {% else %}
+  static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { 
+    return {{className}}.tr("{{table}}", "{{string.key}}") 
+  }
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+  {% call recursiveBlock table child %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
+{% set className %}{{param.className|default:"L10n"}}{% endset %}
+{{accessModifier}} extension {{className}} {
+  {% if tables.count > 1 %}
+  {% for table in tables %}
+  {{accessModifier}} class {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call recursiveBlock tables.first.name tables.first.levels %}
+  {% endif %}
+}
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+{% else %}
+// No string found
+{% endif %}

--- a/Tools/SwiftGen/swiftgen-config.yml
+++ b/Tools/SwiftGen/swiftgen-config.yml
@@ -16,6 +16,13 @@ strings:
       params:
         className: VectorL10n
         publicAccess: true
+  - inputs: Assets/en.lproj/Untranslated.strings
+    outputs:
+      templatePath: Templates/Strings/flat-swift4-vector-untranslated.stencil
+      output: UntranslatedStrings.swift
+      params:
+        className: VectorL10n
+        publicAccess: true
   - inputs: Modules/MatrixKit/Assets/MatrixKitAssets.bundle/en.lproj/MatrixKit.strings
     outputs:
       templatePath: Templates/Strings/matrixkit-flat-swift4-vector.stencil

--- a/changelog.d/5651.wip
+++ b/changelog.d/5651.wip
@@ -1,0 +1,1 @@
+Onboarding: Add Congratulations screen.


### PR DESCRIPTION
Part of #5653 and #5651.
- Moves the analytics prompt into the onboarding flow instead of being a modal over the split view.
- Adds a BuildSetting to control the display of the personalisation screens.
- Adds a property to delay the AuthenticationCoordinator from showing any screens until all onboarding is compelte.
- Adds the Congratulations screen to onboarding flow (but disabled behind the build flag).

Screenshot of the Congratulations screen (although there will be more tweaks before it is enabled via the build setting)
![Simulator Screen Shot - iPhone 13 mini - 2022-02-25 at 14 23 08](https://user-images.githubusercontent.com/6060466/155743462-8b4f990c-0251-45ce-aa9f-5277f09484c4.png)

