### PR TITLE
Show DM/room start header for every user

### DIFF
--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -107,7 +107,7 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
                 }
                 else
                 {
-                    self.tag = RoomBubbleCellDataTagRoomCreateConfiguration;
+                    self.tag = RoomBubbleCellDataTagRoomCreationIntro;
                 }
                 
                 // Membership events can be collapsed together

--- a/changelog.d/5581.bugfix
+++ b/changelog.d/5581.bugfix
@@ -1,0 +1,1 @@
+Timeline: Show start of conversation header for every user and only at the actual start of the timeline


### PR DESCRIPTION
Fixes #5581 by correcting the tag type of room creation event cell

Additionally enable the conversation start header for every user, not only those that created the room

| Screenshot |
|-------------|
| ![IMG_6C75865CE226-1](https://user-images.githubusercontent.com/3922159/155732015-4bd1e24b-35d0-46f1-957f-6614bd99de69.jpeg) |