### PR TITLE
Threads: Analytics

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -180,7 +180,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AnalyticsEvents:
-    :commit: 53844e3f6f9fefa88384a996b2bf5e60bb301b94
+    :commit: 0101e4fd25ded5fb2cba8a9119cb061e36296369
     :git: https://github.com/matrix-org/matrix-analytics-events.git
 
 SPEC CHECKSUMS:

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -293,7 +293,7 @@ extension Analytics: MXAnalyticsDelegate {
         // Do we still want to track this?
     }
 
-    func trackEventComposed(inThread: Bool, isEditing: Bool, isReply: Bool, startsThread: Bool) {
+    func trackComposerEvent(inThread: Bool, isEditing: Bool, isReply: Bool, startsThread: Bool) {
         let event = AnalyticsEvent.Composer(inThread: inThread,
                                             isEditing: isEditing,
                                             isReply: isReply,

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -175,7 +175,9 @@ extension Analytics {
     /// 
     /// Only non-nil properties will be updated when calling this method.
     func updateUserProperties(ftueUseCase: UserSessionProperties.UseCase? = nil) {
-        let userProperties = AnalyticsEvent.UserProperties(ftueUseCaseSelection: ftueUseCase?.analyticsName, numSpaces: nil)
+        let userProperties = AnalyticsEvent.UserProperties(ftueUseCaseSelection: ftueUseCase?.analyticsName,
+                                                           numFavouriteRooms: nil,
+                                                           numSpaces: nil)
         client.updateUserProperties(userProperties)
     }
     
@@ -184,7 +186,7 @@ extension Analytics {
     ///   - screen: The screen that was shown.
     ///   - milliseconds: An optional value representing how long the screen was shown for in milliseconds.
     func trackScreen(_ screen: AnalyticsScreen, duration milliseconds: Int?) {
-        let event = AnalyticsEvent.Screen(durationMs: milliseconds, screenName: screen.screenName)
+        let event = AnalyticsEvent.MobileScreen(durationMs: milliseconds, screenName: screen.screenName)
         client.screen(event)
     }
     
@@ -276,13 +278,13 @@ extension Analytics: MXAnalyticsDelegate {
         capture(event: event)
     }
     
-    func trackJoinedRoom(asDM isDM: Bool, memberCount: UInt) {
+    func trackJoinedRoom(asDM isDM: Bool, isSpace: Bool, memberCount: UInt) {
         guard let roomSize = AnalyticsEvent.JoinedRoom.RoomSize(memberCount: memberCount) else {
             MXLog.warning("[Analytics] Attempt to capture joined room with invalid member count: \(memberCount)")
             return
         }
         
-        let event = AnalyticsEvent.JoinedRoom(isDM: isDM, roomSize: roomSize)
+        let event = AnalyticsEvent.JoinedRoom(isDM: isDM, isSpace: isSpace, roomSize: roomSize, trigger: nil)
         capture(event: event)
     }
     

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -292,4 +292,13 @@ extension Analytics: MXAnalyticsDelegate {
     func trackContactsAccessGranted(_ granted: Bool) {
         // Do we still want to track this?
     }
+
+    func trackEventComposed(inThread: Bool, isEditing: Bool, isReply: Bool, startsThread: Bool) {
+        let event = AnalyticsEvent.Composer(inThread: inThread,
+                                            isEditing: isEditing,
+                                            isReply: isReply,
+                                            startsThread: startsThread)
+        capture(event: event)
+    }
+
 }

--- a/Riot/Modules/Analytics/AnalyticsScreen.swift
+++ b/Riot/Modules/Analytics/AnalyticsScreen.swift
@@ -51,6 +51,7 @@ import AnalyticsEvents
     case group
     case myGroups
     case inviteFriends
+    case threadList
     
     /// The screen name reported to the AnalyticsEvent.
     var screenName: AnalyticsEvent.MobileScreen.ScreenName {
@@ -121,6 +122,8 @@ import AnalyticsEvents
             return .MyGroups
         case .inviteFriends:
             return .InviteFriends
+        case .threadList:
+            return .ThreadList
         }
     }
 }

--- a/Riot/Modules/Analytics/AnalyticsScreen.swift
+++ b/Riot/Modules/Analytics/AnalyticsScreen.swift
@@ -53,7 +53,7 @@ import AnalyticsEvents
     case inviteFriends
     
     /// The screen name reported to the AnalyticsEvent.
-    var screenName: AnalyticsEvent.Screen.ScreenName {
+    var screenName: AnalyticsEvent.MobileScreen.ScreenName {
         switch self {
         case .welcome:
             return .Welcome
@@ -64,23 +64,23 @@ import AnalyticsEvents
         case .forgotPassword:
             return .ForgotPassword
         case .sidebar:
-            return .MobileSidebar
+            return .Sidebar
         case .home:
             return .Home
         case .favourites:
-            return .MobileFavourites
+            return .Favourites
         case .people:
-            return .MobilePeople
+            return .People
         case .rooms:
-            return .MobileRooms
+            return .Rooms
         case .searchRooms:
-            return .MobileSearchRooms
+            return .SearchRooms
         case .searchMessages:
-            return .MobileSearchMessages
+            return .SearchMessages
         case .searchPeople:
-            return .MobileSearchPeople
+            return .SearchPeople
         case .searchFiles:
-            return .MobileSearchFiles
+            return .SearchFiles
         case .room:
             return .Room
         case .roomDetails:
@@ -100,7 +100,7 @@ import AnalyticsEvents
         case .roomDirectory:
             return .RoomDirectory
         case .switchDirectory:
-            return .MobileSwitchDirectory
+            return .SwitchDirectory
         case .startChat:
             return .StartChat
         case .createRoom:
@@ -120,7 +120,7 @@ import AnalyticsEvents
         case .myGroups:
             return .MyGroups
         case .inviteFriends:
-            return .MobileInviteFriends
+            return .InviteFriends
         }
     }
 }

--- a/Riot/Modules/Analytics/AnalyticsUIElement.swift
+++ b/Riot/Modules/Analytics/AnalyticsUIElement.swift
@@ -18,15 +18,24 @@ import AnalyticsEvents
 
 /// A tappable UI element that can be tracked in Analytics.
 @objc enum AnalyticsUIElement: Int {
-    case removeMe
+    case roomThreadListButton
+    case roomThreadSummaryItem
+    case threadListThreadItem
+    case threadListFilterItem
     
     /// The element name reported to the AnalyticsEvent.
     var name: AnalyticsEvent.Interaction.Name {
         switch self {
         // Note: This is a test element that doesn't need to be captured.
         // It can be removed when some elements are added that relate to mobile.
-        case .removeMe:
-            return .WebRoomSettingsLeaveButton
+        case .roomThreadListButton:
+            return .MobileRoomThreadListButton
+        case .roomThreadSummaryItem:
+            return .MobileRoomThreadSummaryItem
+        case .threadListThreadItem:
+            return .MobileThreadListThreadItem
+        case .threadListFilterItem:
+            return .MobileThreadListFilterItem
         }
     }
 }

--- a/Riot/Modules/Analytics/AnalyticsUIElement.swift
+++ b/Riot/Modules/Analytics/AnalyticsUIElement.swift
@@ -26,8 +26,6 @@ import AnalyticsEvents
     /// The element name reported to the AnalyticsEvent.
     var name: AnalyticsEvent.Interaction.Name {
         switch self {
-        // Note: This is a test element that doesn't need to be captured.
-        // It can be removed when some elements are added that relate to mobile.
         case .roomThreadListButton:
             return .MobileRoomThreadListButton
         case .roomThreadSummaryItem:

--- a/Riot/Modules/Analytics/Helpers/UserProperties+Element.swift
+++ b/Riot/Modules/Analytics/Helpers/UserProperties+Element.swift
@@ -1,0 +1,34 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import AnalyticsEvents
+
+extension AnalyticsEvent.UserProperties {
+
+    //  Initializer for Element. Strips all Web properties.
+    public init(ftueUseCaseSelection: FtueUseCaseSelection?, numFavouriteRooms: Int?, numSpaces: Int?) {
+        self.init(WebMetaSpaceFavouritesEnabled: nil,
+                  WebMetaSpaceHomeAllRooms: nil,
+                  WebMetaSpaceHomeEnabled: nil,
+                  WebMetaSpaceOrphansEnabled: nil,
+                  WebMetaSpacePeopleEnabled: nil,
+                  ftueUseCaseSelection: ftueUseCaseSelection,
+                  numFavouriteRooms: numFavouriteRooms,
+                  numSpaces: numSpaces)
+    }
+
+}

--- a/Riot/Modules/Analytics/PostHogAnalyticsClient.swift
+++ b/Riot/Modules/Analytics/PostHogAnalyticsClient.swift
@@ -80,6 +80,7 @@ class PostHogAnalyticsClient: AnalyticsClientProtocol {
         
         // Merge the updated user properties with the existing ones
         self.pendingUserProperties = AnalyticsEvent.UserProperties(ftueUseCaseSelection: userProperties.ftueUseCaseSelection ?? pendingUserProperties.ftueUseCaseSelection,
+                                                                   numFavouriteRooms: userProperties.numFavouriteRooms ?? pendingUserProperties.numFavouriteRooms,
                                                                    numSpaces: userProperties.numSpaces ?? pendingUserProperties.numSpaces)
     }
     

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4321,6 +4321,8 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
 - (void)roomDataSource:(RoomDataSource *)roomDataSource didTapThread:(id<MXThreadProtocol>)thread
 {
     [self openThreadWithId:thread.id];
+
+    [Analytics.shared trackInteraction:AnalyticsUIElementRoomThreadSummaryItem];
 }
 
 #pragma mark - Segues
@@ -4646,6 +4648,8 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
                                                                                     threadId:nil];
     self.threadsBridgePresenter.delegate = self;
     [self.threadsBridgePresenter pushFrom:self.navigationController animated:YES];
+
+    [Analytics.shared trackInteraction:AnalyticsUIElementRoomThreadListButton];
 }
 
 - (IBAction)onIntegrationsPressed:(id)sender

--- a/Riot/Modules/Threads/ThreadList/ThreadListViewController.swift
+++ b/Riot/Modules/Threads/ThreadList/ThreadListViewController.swift
@@ -63,6 +63,8 @@ final class ThreadListViewController: UIViewController {
         self.viewModel.viewDelegate = self
 
         self.viewModel.process(viewAction: .loadData)
+
+        Analytics.shared.trackScreen(.threadList)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -290,6 +292,8 @@ final class ThreadListViewController: UIViewController {
     @objc
     private func filterButtonTapped(_ sender: UIBarButtonItem) {
         self.viewModel.process(viewAction: .showFilterTypes)
+
+        Analytics.shared.trackInteraction(.threadListFilterItem)
     }
     
     @IBAction private func longPressed(_ sender: UILongPressGestureRecognizer) {
@@ -355,6 +359,8 @@ extension ThreadListViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
         
         viewModel.process(viewAction: .selectThread(indexPath.row))
+
+        Analytics.shared.trackInteraction(.threadListThreadItem)
     }
     
 }

--- a/changelog.d/5365.change
+++ b/changelog.d/5365.change
@@ -1,0 +1,1 @@
+Analytics: Adapt to latest analytics repo & add screens, events & interactions for threads.


### PR DESCRIPTION
Adapts to the latest changes in [matrix-org/matrix-analytics-events](https://github.com/matrix-org/matrix-analytics-events) repository. Adds a simplified initializer for `AnalyticsEvents.UserProperties` class, which is splitting all Web properties.

Fixes #5365 

Requires https://github.com/matrix-org/matrix-ios-sdk/pull/1384 & https://github.com/matrix-org/matrix-analytics-events/pull/49.