### PR TITLE
Fix Font Size for Emoji Only Replies

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -2080,9 +2080,10 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
  Get the text font to use according to the event state.
 
  @param event the event.
+ @param string the string for the event. It may be different from event.content.body. Pass nil to get font just according to event.content.body.
  @return the text font.
  */
-- (UIFont*)fontForEvent:(MXEvent*)event
+- (UIFont*)fontForEvent:(MXEvent*)event string:(NSString*)string
 {
     // Select text font
     UIFont *font = _defaultTextFont;
@@ -2102,7 +2103,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     {
         font = _encryptedMessagesTextFont;
     }
-    else if (!_isForSubtitle && event.eventType == MXEventTypeRoomMessage && (_emojiOnlyTextFont || _singleEmojiTextFont))
+    else if (!_isForSubtitle && !string && event.eventType == MXEventTypeRoomMessage && (_emojiOnlyTextFont || _singleEmojiTextFont))
     {
         NSString *message;
         MXJSONModelSetString(message, event.content[kMXMessageBodyKey]);

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1660,10 +1660,13 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString:string];
 
     NSRange wholeString = NSMakeRange(0, str.length);
+    UIFont *fontForWholeString = [self fontForEvent:event string:string];
 
     // Apply color and font corresponding to the event state
     [str addAttribute:NSForegroundColorAttributeName value:[self textColorForEvent:event] range:wholeString];
-    [str addAttribute:NSFontAttributeName value:[self fontForEvent:event] range:wholeString];
+    [str addAttribute:NSFontAttributeName
+                value:fontForWholeString
+                range:wholeString];
 
     // If enabled, make links clickable
     if (!([[_settings httpLinkScheme] isEqualToString: @"http"] &&
@@ -1695,8 +1698,26 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
         }
     }
 
-    // Apply additional treatments
-    return [self postRenderAttributedString:str];
+    UIFont *fontForBody = [self fontForEvent:event string:nil];
+    if ([fontForWholeString isEqual:fontForBody])
+    {
+        //  body font is the same with the whole string font, no need to change body font
+        //  apply additional treatments
+        return [self postRenderAttributedString:str];
+    }
+
+    NSRange bodyRange = [str.string rangeOfString:event.content[kMXMessageBodyKey]];
+    if (bodyRange.location == NSNotFound)
+    {
+        //  body not found in the whole string
+        //  apply additional treatments
+        return [self postRenderAttributedString:str];
+    }
+
+    NSMutableAttributedString *mutableStr = [str mutableCopy];
+    [mutableStr addAttribute:NSFontAttributeName value:fontForBody range:bodyRange];
+    //  apply additional treatments
+    return [self postRenderAttributedString:mutableStr];
 }
 
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState
@@ -1710,20 +1731,20 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     }
 
     // Apply the css style that corresponds to the event state
-    UIFont *font = [self fontForEvent:event];
+    UIFont *fontForWholeString = [self fontForEvent:event string:htmlString];
     
     // Do some sanitisation before finalizing the string
     MXWeakify(self);
     DTHTMLAttributedStringBuilderWillFlushCallback sanitizeCallback = ^(DTHTMLElement *element) {
         MXStrongifyAndReturnIfNil(self);
-        [element sanitizeWith:self.allowedHTMLTags bodyFont:font imageHandler:self.htmlImageHandler];
+        [element sanitizeWith:self.allowedHTMLTags bodyFont:fontForWholeString imageHandler:self.htmlImageHandler];
     };
 
     NSDictionary *options = @{
                               DTUseiOS6Attributes: @(YES),              // Enable it to be able to display the attributed string in a UITextView
-                              DTDefaultFontFamily: font.familyName,
-                              DTDefaultFontName: font.fontName,
-                              DTDefaultFontSize: @(font.pointSize),
+                              DTDefaultFontFamily: fontForWholeString.familyName,
+                              DTDefaultFontName: fontForWholeString.fontName,
+                              DTDefaultFontSize: @(fontForWholeString.pointSize),
                               DTDefaultTextColor: [self textColorForEvent:event],
                               DTDefaultLinkDecoration: @(NO),
                               DTDefaultStyleSheet: dtCSS,
@@ -1748,7 +1769,23 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     // Finalize HTML blockquote blocks marking
     str = [MXKTools removeMarkedBlockquotesArtifacts:str];
 
-    return str;
+    UIFont *fontForBody = [self fontForEvent:event string:nil];
+    if ([fontForWholeString isEqual:fontForBody])
+    {
+        //  body font is the same with the whole string font, no need to change body font
+        return str;
+    }
+
+    NSRange bodyRange = [str.string rangeOfString:event.content[kMXMessageBodyKey]];
+    if (bodyRange.location == NSNotFound)
+    {
+        //  body not found in the whole string
+        return str;
+    }
+
+    NSMutableAttributedString *mutableStr = [str mutableCopy];
+    [mutableStr addAttribute:NSFontAttributeName value:fontForBody range:bodyRange];
+    return mutableStr;
 }
 
 /**
@@ -2080,7 +2117,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
  Get the text font to use according to the event state.
 
  @param event the event.
- @param string the string for the event. It may be different from event.content.body. Pass nil to get font just according to event.content.body.
+ @param string the string to be rendered for the event. It may be different from event.content.body. Pass nil to get font just according to event.content.body.
  @return the text font.
  */
 - (UIFont*)fontForEvent:(MXEvent*)event string:(NSString*)string

--- a/RiotTests/AnalyticsTests.swift
+++ b/RiotTests/AnalyticsTests.swift
@@ -78,43 +78,46 @@ class AnalyticsTests: XCTestCase {
         XCTAssertNil(client.pendingUserProperties, "No user properties should have been set yet.")
         
         // When updating the user properties
-        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numSpaces: 5))
+        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numFavouriteRooms: 4, numSpaces: 5))
         
         // Then the properties should be cached
         XCTAssertNotNil(client.pendingUserProperties, "The user properties should be cached.")
         XCTAssertEqual(client.pendingUserProperties?.ftueUseCaseSelection, .PersonalMessaging, "The use case selection should match.")
+        XCTAssertEqual(client.pendingUserProperties?.numFavouriteRooms, 4, "The number of favorite rooms should match.")
         XCTAssertEqual(client.pendingUserProperties?.numSpaces, 5, "The number of spaces should match.")
     }
     
     func testMergingUserProperties() {
         // Given a client with a cached use case user properties
         let client = PostHogAnalyticsClient()
-        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numSpaces: nil))
+        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numFavouriteRooms: nil, numSpaces: nil))
         
         XCTAssertNotNil(client.pendingUserProperties, "The user properties should be cached.")
         XCTAssertEqual(client.pendingUserProperties?.ftueUseCaseSelection, .PersonalMessaging, "The use case selection should match.")
+        XCTAssertNil(client.pendingUserProperties?.numFavouriteRooms, "The number of favorite rooms should not be set.")
         XCTAssertNil(client.pendingUserProperties?.numSpaces, "The number of spaces should not be set.")
         
         // When updating the number of spaced
-        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: nil, numSpaces: 5))
+        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: nil, numFavouriteRooms: 4, numSpaces: 5))
         
         // Then the new properties should be updated and the existing properties should remain unchanged
         XCTAssertNotNil(client.pendingUserProperties, "The user properties should be cached.")
         XCTAssertEqual(client.pendingUserProperties?.ftueUseCaseSelection, .PersonalMessaging, "The use case selection shouldn't have changed.")
+        XCTAssertEqual(client.pendingUserProperties?.numFavouriteRooms, 4, "The number of favorite rooms should have been updated.")
         XCTAssertEqual(client.pendingUserProperties?.numSpaces, 5, "The number of spaces should have been updated.")
     }
     
     func testSendingUserProperties() {
         // Given a client with user properties set
         let client = PostHogAnalyticsClient()
-        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numSpaces: nil))
+        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numFavouriteRooms: nil, numSpaces: nil))
         client.start()
         
         XCTAssertNotNil(client.pendingUserProperties, "The user properties should be cached.")
         XCTAssertEqual(client.pendingUserProperties?.ftueUseCaseSelection, .PersonalMessaging, "The use case selection should match.")
         
         // When sending an event (tests run under Debug configuration so this is sent to the development instance)
-        client.screen(AnalyticsEvent.Screen(durationMs: nil, screenName: .Home))
+        client.screen(AnalyticsEvent.MobileScreen(durationMs: nil, screenName: .Home))
         
         // Then the properties should be cleared
         XCTAssertNil(client.pendingUserProperties, "The user properties should be cleared.")
@@ -123,7 +126,7 @@ class AnalyticsTests: XCTestCase {
     func testSendingUserPropertiesWithIdentify() {
         // Given a client with user properties set
         let client = PostHogAnalyticsClient()
-        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numSpaces: nil))
+        client.updateUserProperties(AnalyticsEvent.UserProperties(ftueUseCaseSelection: .PersonalMessaging, numFavouriteRooms: nil, numSpaces: nil))
         client.start()
         
         XCTAssertNotNil(client.pendingUserProperties, "The user properties should be cached.")

--- a/changelog.d/5712.bugfix
+++ b/changelog.d/5712.bugfix
@@ -1,0 +1,1 @@
+MXKEventFormatter: Fix font size for emoji-only replies.


### PR DESCRIPTION
Fixes #5712 by altering the font for only the `event.content.body` in the whole event string rendered.

![Simulator Screen Shot - iPhone 13 - 2022-03-01 at 16 47 20](https://user-images.githubusercontent.com/3072286/156181195-9b3e4fd4-6403-447d-811c-6408f8a545a0.png)
