### PR TITLE
Enable home and room user indicators

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -225,15 +225,6 @@ final class BuildSettings: NSObject {
     
     static let allowInviteExernalUsers: Bool = true
     
-    /// Whether a screen uses legacy local activity indicators or improved app-wide indicators
-    static var useAppUserIndicators: Bool {
-        #if DEBUG
-        return true
-        #else
-        return false
-        #endif
-    }
-    
     // MARK: - Side Menu
     static let enableSideMenu: Bool = true
     static let sideMenuShowInviteFriends: Bool = true

--- a/Riot/Modules/Room/RoomCoordinator.swift
+++ b/Riot/Modules/Room/RoomCoordinator.swift
@@ -317,7 +317,9 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
     
     private func startLoading() {
         if let presenter = parameters.userIndicatorPresenter {
-            loadingIndicator = presenter.present(.loading(label: VectorL10n.homeSyncing, isInteractionBlocking: false))
+            if loadingIndicator == nil {
+                loadingIndicator = presenter.present(.loading(label: VectorL10n.homeSyncing, isInteractionBlocking: false))
+            }
         } else {
             activityIndicatorPresenter.presentActivityIndicator(on: roomViewController.view, animated: true)
         }
@@ -438,7 +440,7 @@ extension RoomCoordinator: RoomViewControllerDelegate {
     }
     
     func roomViewControllerCanDelegateUserIndicators(_ roomViewController: RoomViewController) -> Bool {
-        return BuildSettings.useAppUserIndicators
+        return parameters.userIndicatorPresenter != nil
     }
     
     func roomViewControllerDidStartLoading(_ roomViewController: RoomViewController) {

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
@@ -40,7 +40,6 @@ final class RoomInfoListViewController: UIViewController {
     private var viewModel: RoomInfoListViewModelType!
     private var theme: Theme!
     private var errorPresenter: MXKErrorPresentation!
-    private var activityPresenter: ActivityIndicatorPresenterType!
     private var indicatorPresenter: UserIndicatorTypePresenterProtocol!
     private var loadingIndicator: UserIndicator?
     private var isRoomDirect: Bool = false
@@ -119,7 +118,6 @@ final class RoomInfoListViewController: UIViewController {
         
         self.setupViews()
         
-        self.activityPresenter = ActivityIndicatorPresenter()
         self.indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: self)
     
         self.errorPresenter = MXKErrorAlertPresentation()
@@ -270,16 +268,12 @@ final class RoomInfoListViewController: UIViewController {
     }
     
     private func renderLoading() {
-        if BuildSettings.useAppUserIndicators {
-            loadingIndicator = indicatorPresenter.present(
-                .loading(
-                    label: VectorL10n.roomParticipantsLeaveProcessing,
-                    isInteractionBlocking: true
-                )
+        loadingIndicator = indicatorPresenter.present(
+            .loading(
+                label: VectorL10n.roomParticipantsLeaveProcessing,
+                isInteractionBlocking: true
             )
-        } else {
-            activityPresenter.presentActivityIndicator(on: self.view, animated: true)
-        }
+        )
     }
     
     private func renderLoaded(viewData: RoomInfoListViewData) {
@@ -293,11 +287,7 @@ final class RoomInfoListViewController: UIViewController {
     }
     
     private func stopLoading() {
-        if BuildSettings.useAppUserIndicators {
-            loadingIndicator?.cancel()
-        } else {
-            activityPresenter.removeCurrentActivityIndicator(animated: true)
-        }
+        loadingIndicator?.cancel()
     }
     
     // MARK: - Actions

--- a/Riot/Modules/TabBar/TabBarCoordinator.swift
+++ b/Riot/Modules/TabBar/TabBarCoordinator.swift
@@ -231,10 +231,7 @@ final class TabBarCoordinator: NSObject, TabBarCoordinatorType {
         homeViewController.tabBarItem.tag = Int(TABBAR_HOME_INDEX)
         homeViewController.tabBarItem.image = homeViewController.tabBarItem.image
         homeViewController.accessibilityLabel = VectorL10n.titleHome
-        
-        if BuildSettings.useAppUserIndicators {
-            homeViewController.indicatorPresenter = UserIndicatorPresenterWrapper(presenter: indicatorPresenter)
-        }
+        homeViewController.indicatorPresenter = UserIndicatorPresenterWrapper(presenter: indicatorPresenter)
         
         let wrapperViewController = HomeViewControllerWithBannerWrapperViewController(viewController: homeViewController)        
         return wrapperViewController
@@ -416,7 +413,7 @@ final class TabBarCoordinator: NSObject, TabBarCoordinatorType {
             }
             
             var indicatorPresenter: UserIndicatorTypePresenterProtocol?
-            if BuildSettings.useAppUserIndicators, let detailNavigation = splitViewMasterPresentableDelegate?.detailNavigationRouter?.toPresentable() {
+            if let detailNavigation = splitViewMasterPresentableDelegate?.detailNavigationRouter?.toPresentable() {
                 indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: detailNavigation)
             }
             
@@ -690,11 +687,9 @@ extension TabBarCoordinator: RoomCoordinatorDelegate {
     func roomCoordinatorDidLeaveRoom(_ coordinator: RoomCoordinatorProtocol) {
         // For the moment when a room is left, reset the split detail with placeholder
         self.resetSplitViewDetails()
-        if BuildSettings.useAppUserIndicators {
-            indicatorPresenter
-                .present(.success(label: VectorL10n.roomParticipantsLeaveSuccess))
-                .store(in: &indicators)
-        }
+        indicatorPresenter
+            .present(.success(label: VectorL10n.roomParticipantsLeaveSuccess))
+            .store(in: &indicators)
     }
     
     func roomCoordinatorDidCancelRoomPreview(_ coordinator: RoomCoordinatorProtocol) {

--- a/changelog.d/5696.change
+++ b/changelog.d/5696.change
@@ -1,0 +1,1 @@
+Activity Indicators: Enable updated UI for activity indicators and success messages


### PR DESCRIPTION
Resolves #5696 

Enable previously added user indicators on the home screen and in room by removing a build flag.

