### PR TITLE
Fix emptyView never being shown in RecentsViewController.

### DIFF
--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1059,10 +1059,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         [[AppDelegate theDelegate].masterTabBarController refreshTabBarBadges];
     }
     
-    if (changes == nil)
-    {
-        [self showEmptyViewIfNeeded];
-    }
+    [self showEmptyViewIfNeeded];
     
     if (dataSource.state == MXKDataSourceStateReady)
     {

--- a/changelog.d/5727.bugfix
+++ b/changelog.d/5727.bugfix
@@ -1,0 +1,1 @@
+Room lists: Show the getting started hints again when there are no rooms in a tab.


### PR DESCRIPTION
This appears to have stopped working since the changes to the room list pagination (although there might be some intermediate changes between 1.6.12 and now):

https://github.com/vector-im/element-ios/commit/2ac2c981fc7976737432ed41f04daa3db0c73f84#diff-8f61a94c5dc8f433447c91a5e149cf49ac2db96dc1217ff17d0759ad6da9183eL1439-R1471

This is the most obvious fix, but happy to update if there is a better solution that wouldn't call this method any time the data source changes.

Fixes #5727