### PR TITLE
Use only latest profiles in the room timeline (labs)

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -311,7 +311,7 @@ final class BuildSettings: NSObject {
     static var isRoomScreenEnableMessageBubblesByDefault: Bool {
         return self.roomScreenTimelineDefaultStyleIdentifier == .bubble
     }
-    static let roomScreenUseOnlyLatestProfiles: Bool = false
+    static let roomScreenUseOnlyLatestUserAvatarAndName: Bool = false
 
     /// Allow split view detail view stacking    
     static let allowSplitViewDetailsScreenStacking: Bool = true

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -311,6 +311,7 @@ final class BuildSettings: NSObject {
     static var isRoomScreenEnableMessageBubblesByDefault: Bool {
         return self.roomScreenTimelineDefaultStyleIdentifier == .bubble
     }
+    static let roomScreenUseOnlyLatestProfiles: Bool = false
 
     /// Allow split view detail view stacking    
     static let allowSplitViewDetailsScreenStacking: Bool = true

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -619,7 +619,7 @@ Tap the + to start adding people.";
 "settings_labs_enable_ringing_for_group_calls" = "Ring for group calls";
 "settings_labs_enabled_polls" = "Polls";
 "settings_labs_enable_threads" = "Threaded messaging";
-"settings_labs_use_only_latest_profiles" = "Use only latest profiles";
+"settings_labs_use_only_latest_user_avatar_and_name" = "Show latest avatar and name for users in message history";
 
 "settings_version" = "Version %@";
 "settings_olm_version" = "Olm Version %@";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -619,6 +619,7 @@ Tap the + to start adding people.";
 "settings_labs_enable_ringing_for_group_calls" = "Ring for group calls";
 "settings_labs_enabled_polls" = "Polls";
 "settings_labs_enable_threads" = "Threaded messaging";
+"settings_labs_use_only_latest_profiles" = "Use only latest profiles";
 
 "settings_version" = "Version %@";
 "settings_olm_version" = "Olm Version %@";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4935,9 +4935,9 @@ public class VectorL10n: NSObject {
   public static var settingsLabsMessageReaction: String { 
     return VectorL10n.tr("Vector", "settings_labs_message_reaction") 
   }
-  /// Use only latest profiles
-  public static var settingsLabsUseOnlyLatestProfiles: String { 
-    return VectorL10n.tr("Vector", "settings_labs_use_only_latest_profiles") 
+  /// Show latest avatar and name for users in message history
+  public static var settingsLabsUseOnlyLatestUserAvatarAndName: String { 
+    return VectorL10n.tr("Vector", "settings_labs_use_only_latest_user_avatar_and_name") 
   }
   /// LINKS
   public static var settingsLinks: String { 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4935,6 +4935,10 @@ public class VectorL10n: NSObject {
   public static var settingsLabsMessageReaction: String { 
     return VectorL10n.tr("Vector", "settings_labs_message_reaction") 
   }
+  /// Use only latest profiles
+  public static var settingsLabsUseOnlyLatestProfiles: String { 
+    return VectorL10n.tr("Vector", "settings_labs_use_only_latest_profiles") 
+  }
   /// LINKS
   public static var settingsLinks: String { 
     return VectorL10n.tr("Vector", "settings_links") 

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -205,13 +205,13 @@ final class RiotSettings: NSObject {
         return self.roomScreenEnableMessageBubbles ? .bubble : .plain
     }
 
-    /// A setting used to display the latest known profile (display name + avatar) in the timeline
-    /// for the sender, rather than the profile at the time of the event.
+    /// A setting used to display the latest known display name and avatar in the timeline
+    /// for both the sender and target, rather than the profile at the time of the event.
     ///
     /// Note: this is set up from Room perspective, which means that if a user updates their profile after
     /// leaving a Room, it will show up the latest profile used in the Room rather than the latest overall.
-    @UserDefault(key: "roomScreenUseOnlyLatestProfiles", defaultValue: BuildSettings.roomScreenUseOnlyLatestProfiles, storage: defaults)
-    var roomScreenUseOnlyLatestProfiles
+    @UserDefault(key: "roomScreenUseOnlyLatestUserAvatarAndName", defaultValue: BuildSettings.roomScreenUseOnlyLatestUserAvatarAndName, storage: defaults)
+    var roomScreenUseOnlyLatestUserAvatarAndName
     
     // MARK: - Room Contextual Menu
     

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -200,10 +200,18 @@ final class RiotSettings: NSObject {
     
     @UserDefault(key: "roomScreenEnableMessageBubbles", defaultValue: BuildSettings.isRoomScreenEnableMessageBubblesByDefault, storage: defaults)
     var roomScreenEnableMessageBubbles
-    
+
     var roomTimelineStyleIdentifier: RoomTimelineStyleIdentifier {
         return self.roomScreenEnableMessageBubbles ? .bubble : .plain
     }
+
+    /// A setting used to display the latest known profile (display name + avatar) in the timeline
+    /// for the sender, rather than the profile at the time of the event.
+    ///
+    /// Note: this is set up from Room perspective, which means that if a user updates their profile after
+    /// leaving a Room, it will show up the latest profile used in the Room rather than the latest overall.
+    @UserDefault(key: "roomScreenUseOnlyLatestProfiles", defaultValue: BuildSettings.roomScreenUseOnlyLatestProfiles, storage: defaults)
+    var roomScreenUseOnlyLatestProfiles
     
     // MARK: - Room Contextual Menu
     

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -37,12 +37,12 @@
 
 #pragma mark - MXKRoomBubbleCellDataStoring
 
-- (instancetype)initWithEvent:(MXEvent *)event andRoomState:(MXRoomState *)roomState andRoomDataSource:(MXKRoomDataSource *)roomDataSource2
+- (instancetype)initWithEvent:(MXEvent *)event andRoomState:(MXRoomState *)roomState andRoomDataSource:(MXKRoomDataSource *)roomDataSource
 {
     self = [self init];
     if (self)
     {
-        roomDataSource = roomDataSource2;
+        self->roomDataSource = roomDataSource;
 
         // Initialize read receipts
         self.readReceipts = [NSMutableDictionary dictionary];
@@ -58,12 +58,12 @@
             targetId = [event.type isEqualToString:kMXEventTypeStringRoomMember] ? event.stateKey : nil;
             roomId = roomDataSource.roomId;
 
-            MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource2.roomState : roomState;
+            MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource.roomState : roomState;
             senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:profileRoomState];
             senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:profileRoomState];
             senderAvatarPlaceholder = nil;
-            targetDisplayName = [roomDataSource.eventFormatter targetDisplayNameForEvent:event withRoomState:roomState];
-            targetAvatarUrl = [roomDataSource.eventFormatter targetAvatarUrlForEvent:event withRoomState:roomState];
+            targetDisplayName = [roomDataSource.eventFormatter targetDisplayNameForEvent:event withRoomState:profileRoomState];
+            targetAvatarUrl = [roomDataSource.eventFormatter targetAvatarUrlForEvent:event withRoomState:profileRoomState];
             targetAvatarPlaceholder = nil;
             isEncryptedRoom = roomState.isEncrypted;
             isIncoming = ([event.sender isEqualToString:roomDataSource.mxSession.myUser.userId] == NO);
@@ -107,16 +107,24 @@
     bubbleComponents = nil;
 }
 
-- (void)refreshProfileWithRoomDataSource:(MXKRoomDataSource *)roomDataSource2
+- (void)refreshProfile
 {
-    if (self.events.firstObject)
+    MXRoomState *roomState = roomDataSource.roomState;
+    MXEvent* firstEvent = self.events.firstObject;
+
+    if (firstEvent == nil || roomState == nil)
     {
-        MXEvent* firstEvent = self.events.firstObject;
-        senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:firstEvent
-                                                                       withRoomState:roomDataSource2.roomState];
-        senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:firstEvent
-                                                                   withRoomState:roomDataSource2.roomState];
+        return;
     }
+
+    senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:firstEvent
+                                                                   withRoomState:roomState];
+    senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:firstEvent
+                                                               withRoomState:roomState];
+    targetDisplayName = [roomDataSource.eventFormatter targetDisplayNameForEvent:firstEvent
+                                                                   withRoomState:roomState];
+    targetAvatarUrl = [roomDataSource.eventFormatter targetAvatarUrlForEvent:firstEvent
+                                                               withRoomState:roomState];
 }
 
 - (NSUInteger)updateEvent:(NSString *)eventId withEvent:(MXEvent *)event

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -107,6 +107,18 @@
     bubbleComponents = nil;
 }
 
+- (void)refreshProfileWithRoomDataSource:(MXKRoomDataSource *)roomDataSource2
+{
+    if (self.events.firstObject)
+    {
+        MXEvent* firstEvent = self.events.firstObject;
+        senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:firstEvent
+                                                                       withRoomState:roomDataSource2.roomState];
+        senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:firstEvent
+                                                                   withRoomState:roomDataSource2.roomState];
+    }
+}
+
 - (NSUInteger)updateEvent:(NSString *)eventId withEvent:(MXEvent *)event
 {
     NSUInteger count = 0;

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -59,12 +59,12 @@
             roomId = roomDataSource.roomId;
 
             MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource.roomState : roomState;
-            senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:profileRoomState];
-            senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:profileRoomState];
+            [self setRoomState:profileRoomState];
             senderAvatarPlaceholder = nil;
-            targetDisplayName = [roomDataSource.eventFormatter targetDisplayNameForEvent:event withRoomState:profileRoomState];
-            targetAvatarUrl = [roomDataSource.eventFormatter targetAvatarUrlForEvent:event withRoomState:profileRoomState];
             targetAvatarPlaceholder = nil;
+
+            // Encryption status should always rely on the `MXRoomState`
+            // from the event rather than the latest.
             isEncryptedRoom = roomState.isEncrypted;
             isIncoming = ([event.sender isEqualToString:roomDataSource.mxSession.myUser.userId] == NO);
             
@@ -107,9 +107,8 @@
     bubbleComponents = nil;
 }
 
-- (void)refreshProfile
+- (void)setRoomState:(MXRoomState *)roomState;
 {
-    MXRoomState *roomState = roomDataSource.roomState;
     MXEvent* firstEvent = self.events.firstObject;
 
     if (firstEvent == nil || roomState == nil)

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -58,8 +58,11 @@
             targetId = [event.type isEqualToString:kMXEventTypeStringRoomMember] ? event.stateKey : nil;
             roomId = roomDataSource.roomId;
 
-            MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource.roomState : roomState;
-            [self setRoomState:profileRoomState];
+            // If `roomScreenUseOnlyLatestUserAvatarAndName`is enabled, the avatar and name are
+            // displayed from the latest room state perspective rather than the historical.
+            MXRoomState *latestRoomState = roomDataSource.roomState;
+            MXRoomState *displayRoomState = RiotSettings.shared.roomScreenUseOnlyLatestUserAvatarAndName ? latestRoomState : roomState;
+            [self setRoomState:displayRoomState];
             senderAvatarPlaceholder = nil;
             targetAvatarPlaceholder = nil;
 

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -26,6 +26,8 @@
 
 #import "MXKTools.h"
 
+#import "GeneratedInterface-Swift.h"
+
 @implementation MXKRoomBubbleCellData
 @synthesize senderId, targetId, roomId, senderDisplayName, senderAvatarUrl, senderAvatarPlaceholder, targetDisplayName, targetAvatarUrl, targetAvatarPlaceholder, isEncryptedRoom, isPaginationFirstBubble, shouldHideSenderInformation, date, isIncoming, isAttachmentWithThumbnail, isAttachmentWithIcon, attachment, senderFlair;
 @synthesize textMessage, attributedTextMessage, attributedTextMessageWithoutPositioningSpace;
@@ -55,8 +57,10 @@
             senderId = event.sender;
             targetId = [event.type isEqualToString:kMXEventTypeStringRoomMember] ? event.stateKey : nil;
             roomId = roomDataSource.roomId;
-            senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:roomState];
-            senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:roomState];
+
+            MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource2.roomState : roomState;
+            senderDisplayName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:profileRoomState];
+            senderAvatarUrl = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:profileRoomState];
             senderAvatarPlaceholder = nil;
             targetDisplayName = [roomDataSource.eventFormatter targetDisplayNameForEvent:event withRoomState:roomState];
             targetAvatarUrl = [roomDataSource.eventFormatter targetAvatarUrlForEvent:event withRoomState:roomState];

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -233,10 +233,8 @@
 
 /**
  Refreshes the avatar and display name if needed. Should be used only if `roomScreenUseOnlyLatestProfiles` is enabled.
-
- @param roomDataSource the `MXKRoomDataSource` object that will use this instance.
  */
-- (void)refreshProfileWithRoomDataSource:(MXKRoomDataSource*)roomDataSource;
+- (void)refreshProfile;
 
 /**
 Update the event because its sent state changed or it is has been redacted.

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -232,9 +232,13 @@
 - (instancetype)initWithEvent:(MXEvent*)event andRoomState:(MXRoomState*)roomState andRoomDataSource:(MXKRoomDataSource*)roomDataSource;
 
 /**
- Refreshes the avatar and display name if needed. Should be used only if `roomScreenUseOnlyLatestProfiles` is enabled.
+ Sets the `MXRoomState` for a buble cell. This allows to adapt the display
+ of a cell with a different room state than its historical. This won't update critical
+ flag/status, such as `isEncryptedRoom`.
+
+ @param roomState the `MXRoomState` to use for this cell.
  */
-- (void)refreshProfile;
+- (void)setRoomState:(MXRoomState *)roomState;
 
 /**
 Update the event because its sent state changed or it is has been redacted.

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -232,6 +232,13 @@
 - (instancetype)initWithEvent:(MXEvent*)event andRoomState:(MXRoomState*)roomState andRoomDataSource:(MXKRoomDataSource*)roomDataSource;
 
 /**
+ Refreshes the avatar and display name if needed. Should be used only if `roomScreenUseOnlyLatestProfiles` is enabled.
+
+ @param roomDataSource the `MXKRoomDataSource` object that will use this instance.
+ */
+- (void)refreshProfileWithRoomDataSource:(MXKRoomDataSource*)roomDataSource;
+
+/**
 Update the event because its sent state changed or it is has been redacted.
  
  @param eventId the id of the event to change.

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
@@ -16,6 +16,8 @@
 
 #import "MXKRoomBubbleCellDataWithAppendingMode.h"
 
+#import "GeneratedInterface-Swift.h"
+
 static NSAttributedString *messageSeparator = nil;
 
 @implementation MXKRoomBubbleCellDataWithAppendingMode
@@ -46,8 +48,9 @@ static NSAttributedString *messageSeparator = nil;
         }
         
         // Check sender information
-        NSString *eventSenderName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:roomState];
-        NSString *eventSenderAvatar = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:roomState];
+        MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource.roomState : roomState;
+        NSString *eventSenderName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:profileRoomState];
+        NSString *eventSenderAvatar = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:profileRoomState];
         if ((self.senderDisplayName || eventSenderName) &&
             ([self.senderDisplayName isEqualToString:eventSenderName] == NO))
         {

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
@@ -24,9 +24,9 @@ static NSAttributedString *messageSeparator = nil;
 
 #pragma mark - MXKRoomBubbleCellDataStoring
 
-- (instancetype)initWithEvent:(MXEvent *)event andRoomState:(MXRoomState *)roomState andRoomDataSource:(MXKRoomDataSource *)roomDataSource2
+- (instancetype)initWithEvent:(MXEvent *)event andRoomState:(MXRoomState *)roomState andRoomDataSource:(MXKRoomDataSource *)roomDataSource
 {
-    self = [super initWithEvent:event andRoomState:roomState andRoomDataSource:roomDataSource2];
+    self = [super initWithEvent:event andRoomState:roomState andRoomDataSource:roomDataSource];
     if (self)
     {
         // Set default settings

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataWithAppendingMode.m
@@ -48,9 +48,12 @@ static NSAttributedString *messageSeparator = nil;
         }
         
         // Check sender information
-        MXRoomState *profileRoomState = RiotSettings.shared.roomScreenUseOnlyLatestProfiles ? roomDataSource.roomState : roomState;
-        NSString *eventSenderName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:profileRoomState];
-        NSString *eventSenderAvatar = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:profileRoomState];
+        // If `roomScreenUseOnlyLatestUserAvatarAndName`is enabled, the avatar and name are
+        // displayed from the latest room state perspective rather than the historical.
+        MXRoomState *latestRoomState = roomDataSource.roomState;
+        MXRoomState *displayRoomState = RiotSettings.shared.roomScreenUseOnlyLatestUserAvatarAndName ? latestRoomState : roomState;
+        NSString *eventSenderName = [roomDataSource.eventFormatter senderDisplayNameForEvent:event withRoomState:displayRoomState];
+        NSString *eventSenderAvatar = [roomDataSource.eventFormatter senderAvatarUrlForEvent:event withRoomState:displayRoomState];
         if ((self.senderDisplayName || eventSenderName) &&
             ([self.senderDisplayName isEqualToString:eventSenderName] == NO))
         {

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -4332,11 +4332,11 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
 
 /**
  Refreshes the avatars and display names if needed. This has no effect
- if `roomScreenUseOnlyLatestProfiles` is disabled.
+ if `roomScreenUseOnlyLatestUserAvatarAndName` is disabled.
  */
 - (void)refreshProfilesIfNeeded
 {
-    if (RiotSettings.shared.roomScreenUseOnlyLatestProfiles)
+    if (RiotSettings.shared.roomScreenUseOnlyLatestUserAvatarAndName)
     {
         @synchronized (bubbles) {
             for (id<MXKRoomBubbleCellDataStoring> bubble in bubbles)

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -4341,7 +4341,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
         @synchronized (bubbles) {
             for (id<MXKRoomBubbleCellDataStoring> bubble in bubbles)
             {
-                [bubble refreshProfileWithRoomDataSource:self];
+                [bubble refreshProfile];
             }
         }
     }

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1012,7 +1012,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
             
             MXStrongifyAndReturnIfNil(self);
 
-            if (RiotSettings.shared.roomScreenUseOnlyLatestProfiles && event.eventType == MXEventTypeRoomMember && event.isUserProfileChange)
+            if (event.eventType == MXEventTypeRoomMember && event.isUserProfileChange)
             {
                 [self refreshProfilesIfNeeded];
             }

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -4341,7 +4341,7 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
         @synchronized (bubbles) {
             for (id<MXKRoomBubbleCellDataStoring> bubble in bubbles)
             {
-                [bubble refreshProfile];
+                [bubble setRoomState:self.roomState];
             }
         }
     }

--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -60,9 +60,9 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
     return self;
 }
 
-- (instancetype)initWithEvent:(MXEvent *)event andRoomState:(MXRoomState *)roomState andRoomDataSource:(MXKRoomDataSource *)roomDataSource2
+- (instancetype)initWithEvent:(MXEvent *)event andRoomState:(MXRoomState *)roomState andRoomDataSource:(MXKRoomDataSource *)roomDataSource
 {
-    self = [super initWithEvent:event andRoomState:roomState andRoomDataSource:roomDataSource2];
+    self = [super initWithEvent:event andRoomState:roomState andRoomDataSource:roomDataSource];
     
     if (self)
     {

--- a/Riot/Modules/Room/Search/DataSources/RoomSearchDataSource.m
+++ b/Riot/Modules/Room/Search/DataSources/RoomSearchDataSource.m
@@ -33,12 +33,12 @@
 
 @implementation RoomSearchDataSource
 
-- (instancetype)initWithRoomDataSource:(MXKRoomDataSource *)roomDataSource2
+- (instancetype)initWithRoomDataSource:(MXKRoomDataSource *)roomDataSource
 {
-    self = [super initWithMatrixSession:roomDataSource2.mxSession];
+    self = [super initWithMatrixSession:roomDataSource.mxSession];
     if (self)
     {
-        roomDataSource = roomDataSource2;
+        self->roomDataSource = roomDataSource;
         
         // The messages search is limited to the room data.
         self.roomEventFilter.rooms = @[roomDataSource.roomId];

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -159,7 +159,8 @@ typedef NS_ENUM(NSUInteger, LABS_ENABLE)
 {
     LABS_ENABLE_RINGING_FOR_GROUP_CALLS_INDEX = 0,
     LABS_ENABLE_THREADS_INDEX,
-    LABS_ENABLE_MESSAGE_BUBBLES_INDEX
+    LABS_ENABLE_MESSAGE_BUBBLES_INDEX,
+    LABS_USE_ONLY_LATEST_PROFILES_INDEX
 };
 
 typedef NS_ENUM(NSUInteger, SECURITY)
@@ -572,6 +573,7 @@ TableViewSectionsDelegate>
         [sectionLabs addRowWithTag:LABS_ENABLE_RINGING_FOR_GROUP_CALLS_INDEX];
         [sectionLabs addRowWithTag:LABS_ENABLE_THREADS_INDEX];
         [sectionLabs addRowWithTag:LABS_ENABLE_MESSAGE_BUBBLES_INDEX];
+        [sectionLabs addRowWithTag:LABS_USE_ONLY_LATEST_PROFILES_INDEX];
         sectionLabs.headerTitle = [VectorL10n settingsLabs];
         if (sectionLabs.hasAnyRows)
         {
@@ -2462,6 +2464,18 @@ TableViewSectionsDelegate>
         {
             cell = [self buildMessageBubblesCellForTableView:tableView atIndexPath:indexPath];
         }
+        else if (row == LABS_USE_ONLY_LATEST_PROFILES_INDEX)
+        {
+            MXKTableViewCellWithLabelAndSwitch *labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
+
+            labelAndSwitchCell.mxkLabel.text = VectorL10n.settingsLabsUseOnlyLatestProfiles;
+            labelAndSwitchCell.mxkSwitch.on = RiotSettings.shared.roomScreenUseOnlyLatestProfiles;
+            labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
+
+            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleUseOnlyLatestProfiles:) forControlEvents:UIControlEventTouchUpInside];
+
+            cell = labelAndSwitchCell;
+        }
     }
     else if (section == SECTION_TAG_FLAIR)
     {
@@ -3242,6 +3256,11 @@ TableViewSectionsDelegate>
             }
         }];
     }
+}
+
+- (void)toggleUseOnlyLatestProfiles:(UISwitch *)sender
+{
+    RiotSettings.shared.roomScreenUseOnlyLatestProfiles = sender.isOn;
 }
 
 - (void)markAllAsRead:(id)sender

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -160,7 +160,7 @@ typedef NS_ENUM(NSUInteger, LABS_ENABLE)
     LABS_ENABLE_RINGING_FOR_GROUP_CALLS_INDEX = 0,
     LABS_ENABLE_THREADS_INDEX,
     LABS_ENABLE_MESSAGE_BUBBLES_INDEX,
-    LABS_USE_ONLY_LATEST_PROFILES_INDEX
+    LABS_USE_ONLY_LATEST_USER_AVATAR_AND_NAME_INDEX
 };
 
 typedef NS_ENUM(NSUInteger, SECURITY)
@@ -573,7 +573,7 @@ TableViewSectionsDelegate>
         [sectionLabs addRowWithTag:LABS_ENABLE_RINGING_FOR_GROUP_CALLS_INDEX];
         [sectionLabs addRowWithTag:LABS_ENABLE_THREADS_INDEX];
         [sectionLabs addRowWithTag:LABS_ENABLE_MESSAGE_BUBBLES_INDEX];
-        [sectionLabs addRowWithTag:LABS_USE_ONLY_LATEST_PROFILES_INDEX];
+        [sectionLabs addRowWithTag:LABS_USE_ONLY_LATEST_USER_AVATAR_AND_NAME_INDEX];
         sectionLabs.headerTitle = [VectorL10n settingsLabs];
         if (sectionLabs.hasAnyRows)
         {
@@ -2464,15 +2464,15 @@ TableViewSectionsDelegate>
         {
             cell = [self buildMessageBubblesCellForTableView:tableView atIndexPath:indexPath];
         }
-        else if (row == LABS_USE_ONLY_LATEST_PROFILES_INDEX)
+        else if (row == LABS_USE_ONLY_LATEST_USER_AVATAR_AND_NAME_INDEX)
         {
             MXKTableViewCellWithLabelAndSwitch *labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
 
-            labelAndSwitchCell.mxkLabel.text = VectorL10n.settingsLabsUseOnlyLatestProfiles;
-            labelAndSwitchCell.mxkSwitch.on = RiotSettings.shared.roomScreenUseOnlyLatestProfiles;
+            labelAndSwitchCell.mxkLabel.text = VectorL10n.settingsLabsUseOnlyLatestUserAvatarAndName;
+            labelAndSwitchCell.mxkSwitch.on = RiotSettings.shared.roomScreenUseOnlyLatestUserAvatarAndName;
             labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
 
-            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleUseOnlyLatestProfiles:) forControlEvents:UIControlEventTouchUpInside];
+            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleUseOnlyLatestUserAvatarAndName:) forControlEvents:UIControlEventTouchUpInside];
 
             cell = labelAndSwitchCell;
         }
@@ -3258,9 +3258,9 @@ TableViewSectionsDelegate>
     }
 }
 
-- (void)toggleUseOnlyLatestProfiles:(UISwitch *)sender
+- (void)toggleUseOnlyLatestUserAvatarAndName:(UISwitch *)sender
 {
-    RiotSettings.shared.roomScreenUseOnlyLatestProfiles = sender.isOn;
+    RiotSettings.shared.roomScreenUseOnlyLatestUserAvatarAndName = sender.isOn;
 }
 
 - (void)markAllAsRead:(id)sender

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -430,7 +430,7 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
     if (membership && [membership isEqualToString:@"join"] && [eventAvatarUrl length] && ![eventAvatarUrl isEqualToString:prevEventAvatarUrl])
     {
         // Use the actual avatar
-        senderAvatarUrl = event.content[@"avatar_url"];
+        senderAvatarUrl = eventAvatarUrl;
     }
     
     // We ignore non mxc avatar url (The identicons are removed here).

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -425,7 +425,9 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
     
     // Check whether this avatar url is updated by the current event (This happens in case of new joined member)
     NSString* membership = event.content[@"membership"];
-    if (membership && [membership isEqualToString:@"join"] && [event.content[@"avatar_url"] length])
+    NSString* eventAvatarUrl = event.content[@"avatar_url"];
+    NSString* prevEventAvatarUrl = event.prevContent[@"avatar_url"];
+    if (membership && [membership isEqualToString:@"join"] && [eventAvatarUrl length] && ![eventAvatarUrl isEqualToString:prevEventAvatarUrl])
     {
         // Use the actual avatar
         senderAvatarUrl = event.content[@"avatar_url"];

--- a/changelog.d/5726.change
+++ b/changelog.d/5726.change
@@ -1,0 +1,1 @@
+Labs/Room: Add a setting to use only latest sender profiles


### PR DESCRIPTION
Closes #5726 

Note: Enabling or disabling this setting will require a clear cache in order to be immediately effective (otherwise it will only apply for new events or after someone updates their profile in `enabled` case).