### PR TITLE
Track failed creation of attributed strings

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2077,6 +2077,7 @@ Tap the + to start adding people.";
 "notice_error_unsupported_event" = "Unsupported event";
 "notice_error_unexpected_event" = "Unexpected event";
 "notice_error_unknown_event_type" = "Unknown event type";
+"notice_error_unformattable_event" = "** Unable to render message. Please report a bug";
 "notice_room_history_visible_to_anyone" = "%@ made future room history visible to anyone.";
 "notice_room_history_visible_to_members" = "%@ made future room history visible to all room members.";
 "notice_room_history_visible_to_members_for_dm" = "%@ made future messages visible to all room members.";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3175,6 +3175,10 @@ public class VectorL10n: NSObject {
   public static var noticeErrorUnexpectedEvent: String { 
     return VectorL10n.tr("Vector", "notice_error_unexpected_event") 
   }
+  /// ** Unable to render message. Please report a bug
+  public static var noticeErrorUnformattableEvent: String { 
+    return VectorL10n.tr("Vector", "notice_error_unformattable_event") 
+  }
   /// Unknown event type
   public static var noticeErrorUnknownEventType: String { 
     return VectorL10n.tr("Vector", "notice_error_unknown_event_type") 

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -65,6 +65,28 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
 
 - (NSAttributedString *)attributedStringFromEvent:(MXEvent *)event withRoomState:(MXRoomState *)roomState error:(MXKEventFormatterError *)error
 {
+    NSAttributedString *string = [self unsafeAttributedStringFromEvent:event withRoomState:roomState error:error];
+    
+    // If we cannot create attributed string, but the message is nevertheless meant for display (e.g. not an edit event), show generic error
+    // instead of a missing message on a timeline.
+    if (
+        (!string || string.length == 0)
+        && [self.eventTypesFilterForMessages containsObject:event.type]
+        && !event.isEditEvent
+    )
+    {
+        MXLogError(@"[EventFormatter]: Cannot format string for displayable event: %@, error: %lu", event.eventId, *error);
+        string = [[NSAttributedString alloc] initWithString:[VectorL10n noticeErrorUnformattableEvent]];
+    }
+    return string;
+}
+
+// The attributed string can fail to be created for a number of reasons, and the size of the function (as well as super's implementation) makes
+// it impossible to catch all the `return nil` and failure states.
+// To make catching of missing strings reliable (and not place that burden on callers), we use private `unsafeAttributedStringFromEvent` method
+// which is called by the public `attributedStringFromEvent`, and which also handles the catch-all missing message.
+- (NSAttributedString *)unsafeAttributedStringFromEvent:(MXEvent *)event withRoomState:(MXRoomState *)roomState error:(MXKEventFormatterError *)error
+{
     if (event.isRedactedEvent)
     {
         // Check whether the event is a thread root or redacted information is required

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -70,13 +70,21 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
     // If we cannot create attributed string, but the message is nevertheless meant for display (e.g. not an edit event), show generic error
     // instead of a missing message on a timeline.
     if (
-        (!string || string.length == 0)
+        !string
         && [self.eventTypesFilterForMessages containsObject:event.type]
         && !event.isEditEvent
     )
     {
-        MXLogError(@"[EventFormatter]: Cannot format string for displayable event: %@, error: %lu", event.eventId, *error);
-        string = [[NSAttributedString alloc] initWithString:[VectorL10n noticeErrorUnformattableEvent]];
+        MXLogError(@"[EventFormatter]: Cannot format string for displayable event: %@, type: %@, msgtype: %@, has room state: %d, members: %lu, error: %lu",
+                   event.eventId,
+                   event.type,
+                   event.content[@"msgtype"],
+                   roomState != nil,
+                   roomState.membersCount.members,
+                   *error);
+        string = [[NSAttributedString alloc] initWithString:[VectorL10n noticeErrorUnformattableEvent] attributes:@{
+            NSFontAttributeName: [self encryptedMessagesTextFont]
+        }];
     }
     return string;
 }

--- a/changelog.d/5739.change
+++ b/changelog.d/5739.change
@@ -1,0 +1,1 @@
+Timeline: track and show error message when an event cannot be converted to attributed string


### PR DESCRIPTION
Resolves #5739 

After investigating reports of [missing messages](https://github.com/vector-im/element-ios/issues/5374) I noticed that messages that fail to be formatted (for whatever reason, the formatting code has hundreds of lines of code), the formatting error is never logged and the message is not rendered at all on the timeline, appearing as if it was never delivered.

Whilst we want to understand why formatting of messages fails and thus fix the root cause of this behaviour, we first need to acquire more logs when this happens.

Additionally we need to signal to the user an error has occured, because in this case it is more dangerous to fail silently and make it look like a message was never delivered. See screenshot for comparison.

With these changes in place we can use future rageshakes to fix specific formatting issues.

| Without error | With error|
|--------------|-----------|
| ![Simulator Screen Shot - iPhone 13 - 2022-03-03 at 12 34 44](https://user-images.githubusercontent.com/3922159/156567490-124e7828-4d6e-42b3-a413-f33850c6a4a6.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-03 at 12 32 07](https://user-images.githubusercontent.com/3922159/156567511-4e612851-a1c5-4eab-8ee3-e200a3de3513.png) |
 