### PR TITLE
Add generic SwiftUI Error type

### DIFF
--- a/RiotSwiftUI/Modules/Common/ErrorHandling/AlertInfo.swift
+++ b/RiotSwiftUI/Modules/Common/ErrorHandling/AlertInfo.swift
@@ -16,8 +16,14 @@
 
 import SwiftUI
 
-/// A type that describes an alert to be shown after an error occurred.
-struct ErrorAlertInfo<T: Hashable>: Identifiable {
+/// A type that describes an alert to be shown to the user.
+///
+/// The alert info can be added to the view state and used as an alert's `item`:
+/// ```
+/// MyView
+///     .alert(item: $viewModel.alertInfo) { $0.alert }
+/// ```
+struct AlertInfo<T: Hashable>: Identifiable {
     /// An identifier that can be used to distinguish one error from another.
     let id: T
     /// The alert's title.
@@ -30,7 +36,7 @@ struct ErrorAlertInfo<T: Hashable>: Identifiable {
     var secondaryButton: (title: String, action: (() -> Void)?)? = nil
 }
 
-extension ErrorAlertInfo where T == Int {
+extension AlertInfo where T == Int {
     /// Initialises the type with the title and message from an `NSError` along with the default Ok button.
     init?(error: NSError? = nil) {
         guard error?.domain != NSURLErrorDomain && error?.code != NSURLErrorCancelled else { return nil }
@@ -42,7 +48,7 @@ extension ErrorAlertInfo where T == Int {
 }
 
 @available(iOS 13.0, *)
-extension ErrorAlertInfo {
+extension AlertInfo {
     private var messageText: Text? {
         guard let message = message else { return nil }
         return Text(message)

--- a/RiotSwiftUI/Modules/Common/ErrorHandling/ErrorAlertBuilder.swift
+++ b/RiotSwiftUI/Modules/Common/ErrorHandling/ErrorAlertBuilder.swift
@@ -1,0 +1,50 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+/// A type that describes an alert to be shown after an error occurred.
+struct ErrorAlertInfo<T: Hashable>: Identifiable {
+    /// An identifier that can be used to distinguish one error from another.
+    let id: T
+    /// The alert's title.
+    let title: String
+    /// The alert's message (optional).
+    var message: String? = nil
+    /// The alert's primary button title and action. Defaults to an Ok button with no action.
+    var primaryButton: (title: String, action: (() -> Void)?) = (VectorL10n.ok, nil)
+    /// The alert's secondary button title and action.
+    var secondaryButton: (title: String, action: (() -> Void)?)? = nil
+}
+
+extension ErrorAlertInfo where T == Int {
+    /// Initialises the type with the title and message from an `NSError` along with the default Ok button.
+    init?(error: NSError? = nil) {
+        guard error?.domain != NSURLErrorDomain && error?.code != NSURLErrorCancelled else { return nil }
+        
+        id = error?.code ?? -1
+        title = error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String ?? VectorL10n.error
+        message = error?.userInfo[NSLocalizedDescriptionKey] as? String ?? VectorL10n.errorCommonMessage
+    }
+}
+
+@available(iOS 13.0, *)
+extension ErrorAlertInfo {
+    var messageText: Text? {
+        guard let message = message else { return nil }
+        return Text(message)
+    }
+}

--- a/RiotSwiftUI/Modules/Common/ErrorHandling/ErrorAlertBuilder.swift
+++ b/RiotSwiftUI/Modules/Common/ErrorHandling/ErrorAlertBuilder.swift
@@ -43,8 +43,23 @@ extension ErrorAlertInfo where T == Int {
 
 @available(iOS 13.0, *)
 extension ErrorAlertInfo {
-    var messageText: Text? {
+    private var messageText: Text? {
         guard let message = message else { return nil }
         return Text(message)
+    }
+    
+    /// Returns a SwiftUI `Alert` created from this alert info, using default button
+    /// styles for both primary and (if set) secondary buttons.
+    var alert: Alert {
+        if let secondaryButton = secondaryButton {
+            return Alert(title: Text(title),
+                         message: messageText,
+                         primaryButton: .default(Text(primaryButton.title), action: primaryButton.action),
+                         secondaryButton: .default(Text(secondaryButton.title), action: secondaryButton.action))
+        } else {
+            return Alert(title: Text(title),
+                         message: messageText,
+                         dismissButton: .default(Text(primaryButton.title), action: primaryButton.action))
+        }
     }
 }

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
@@ -58,21 +58,13 @@ struct LocationSharingViewState: BindableState {
 }
 
 struct LocationSharingViewStateBindings {
-    var alertInfo: LocationSharingErrorAlertInfo?
+    var alertInfo: ErrorAlertInfo<LocationSharingAlertType>?
     var userLocation: CLLocationCoordinate2D?
 }
 
-struct LocationSharingErrorAlertInfo: Identifiable {
-    enum AlertType {
-        case mapLoadingError
-        case userLocatingError
-        case authorizationError
-        case locationSharingError
-    }
-    
-    let id: AlertType
-    let title: String
-    var subtitle: String? = nil
-    let primaryButton: (title: String, action: (() -> Void)?)
-    var secondaryButton: (title: String, action: (() -> Void)?)? = nil
+enum LocationSharingAlertType {
+    case mapLoadingError
+    case userLocatingError
+    case authorizationError
+    case locationSharingError
 }

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
@@ -58,7 +58,7 @@ struct LocationSharingViewState: BindableState {
 }
 
 struct LocationSharingViewStateBindings {
-    var alertInfo: ErrorAlertInfo<LocationSharingAlertType>?
+    var alertInfo: AlertInfo<LocationSharingAlertType>?
     var userLocation: CLLocationCoordinate2D?
 }
 

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
@@ -72,14 +72,14 @@ class LocationSharingViewModel: LocationSharingViewModelType, LocationSharingVie
         state.showLoadingIndicator = true
     }
     
-    func stopLoading(error: LocationSharingErrorAlertInfo.AlertType?) {
+    func stopLoading(error: LocationSharingAlertType?) {
         state.showLoadingIndicator = false
         
         if let error = error {
-            state.bindings.alertInfo = LocationSharingErrorAlertInfo(id: error,
-                                                                     title: VectorL10n.locationSharingPostFailureTitle,
-                                                                     subtitle: VectorL10n.locationSharingPostFailureSubtitle(AppInfo.current.displayName),
-                                                                     primaryButton: (VectorL10n.ok, nil))
+            state.bindings.alertInfo = ErrorAlertInfo(id: error,
+                                                      title: VectorL10n.locationSharingPostFailureTitle,
+                                                      message: VectorL10n.locationSharingPostFailureSubtitle(AppInfo.current.displayName),
+                                                      primaryButton: (VectorL10n.ok, nil))
         }
     }
     
@@ -96,18 +96,18 @@ class LocationSharingViewModel: LocationSharingViewModelType, LocationSharingVie
         
         switch error {
         case .failedLoadingMap:
-            state.bindings.alertInfo = LocationSharingErrorAlertInfo(id: .mapLoadingError,
-                                                                     title: VectorL10n.locationSharingLoadingMapErrorTitle(AppInfo.current.displayName),
-                                                                     primaryButton: (VectorL10n.ok, primaryButtonCompletion))
+            state.bindings.alertInfo = ErrorAlertInfo(id: LocationSharingAlertType.mapLoadingError,
+                                                      title: VectorL10n.locationSharingLoadingMapErrorTitle(AppInfo.current.displayName),
+                                                      primaryButton: (VectorL10n.ok, primaryButtonCompletion))
         case .failedLocatingUser:
-            state.bindings.alertInfo = LocationSharingErrorAlertInfo(id: .userLocatingError,
-                                                                     title: VectorL10n.locationSharingLocatingUserErrorTitle(AppInfo.current.displayName),
-                                                                     primaryButton: (VectorL10n.ok, primaryButtonCompletion))
+            state.bindings.alertInfo = ErrorAlertInfo(id: LocationSharingAlertType.userLocatingError,
+                                                      title: VectorL10n.locationSharingLocatingUserErrorTitle(AppInfo.current.displayName),
+                                                      primaryButton: (VectorL10n.ok, primaryButtonCompletion))
         case .invalidLocationAuthorization:
-            state.bindings.alertInfo = LocationSharingErrorAlertInfo(id: .authorizationError,
-                                                                     title: VectorL10n.locationSharingInvalidAuthorizationErrorTitle(AppInfo.current.displayName),
-                                                                     primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, primaryButtonCompletion),
-                                                                     secondaryButton: (VectorL10n.locationSharingInvalidAuthorizationSettings, {
+            state.bindings.alertInfo = ErrorAlertInfo(id: LocationSharingAlertType.authorizationError,
+                                                      title: VectorL10n.locationSharingInvalidAuthorizationErrorTitle(AppInfo.current.displayName),
+                                                      primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, primaryButtonCompletion),
+                                                      secondaryButton: (VectorL10n.locationSharingInvalidAuthorizationSettings, {
                 if let applicationSettingsURL = URL(string:UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(applicationSettingsURL)
                 }

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
@@ -76,10 +76,10 @@ class LocationSharingViewModel: LocationSharingViewModelType, LocationSharingVie
         state.showLoadingIndicator = false
         
         if let error = error {
-            state.bindings.alertInfo = ErrorAlertInfo(id: error,
-                                                      title: VectorL10n.locationSharingPostFailureTitle,
-                                                      message: VectorL10n.locationSharingPostFailureSubtitle(AppInfo.current.displayName),
-                                                      primaryButton: (VectorL10n.ok, nil))
+            state.bindings.alertInfo = AlertInfo(id: error,
+                                                 title: VectorL10n.locationSharingPostFailureTitle,
+                                                 message: VectorL10n.locationSharingPostFailureSubtitle(AppInfo.current.displayName),
+                                                 primaryButton: (VectorL10n.ok, nil))
         }
     }
     
@@ -96,18 +96,18 @@ class LocationSharingViewModel: LocationSharingViewModelType, LocationSharingVie
         
         switch error {
         case .failedLoadingMap:
-            state.bindings.alertInfo = ErrorAlertInfo(id: .mapLoadingError,
-                                                      title: VectorL10n.locationSharingLoadingMapErrorTitle(AppInfo.current.displayName),
-                                                      primaryButton: (VectorL10n.ok, primaryButtonCompletion))
+            state.bindings.alertInfo = AlertInfo(id: .mapLoadingError,
+                                                 title: VectorL10n.locationSharingLoadingMapErrorTitle(AppInfo.current.displayName),
+                                                 primaryButton: (VectorL10n.ok, primaryButtonCompletion))
         case .failedLocatingUser:
-            state.bindings.alertInfo = ErrorAlertInfo(id: .userLocatingError,
-                                                      title: VectorL10n.locationSharingLocatingUserErrorTitle(AppInfo.current.displayName),
-                                                      primaryButton: (VectorL10n.ok, primaryButtonCompletion))
+            state.bindings.alertInfo = AlertInfo(id: .userLocatingError,
+                                                 title: VectorL10n.locationSharingLocatingUserErrorTitle(AppInfo.current.displayName),
+                                                 primaryButton: (VectorL10n.ok, primaryButtonCompletion))
         case .invalidLocationAuthorization:
-            state.bindings.alertInfo = ErrorAlertInfo(id: .authorizationError,
-                                                      title: VectorL10n.locationSharingInvalidAuthorizationErrorTitle(AppInfo.current.displayName),
-                                                      primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, primaryButtonCompletion),
-                                                      secondaryButton: (VectorL10n.locationSharingInvalidAuthorizationSettings, {
+            state.bindings.alertInfo = AlertInfo(id: .authorizationError,
+                                                 title: VectorL10n.locationSharingInvalidAuthorizationErrorTitle(AppInfo.current.displayName),
+                                                 primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, primaryButtonCompletion),
+                                                 secondaryButton: (VectorL10n.locationSharingInvalidAuthorizationSettings, {
                 if let applicationSettingsURL = URL(string:UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(applicationSettingsURL)
                 }

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
@@ -96,15 +96,15 @@ class LocationSharingViewModel: LocationSharingViewModelType, LocationSharingVie
         
         switch error {
         case .failedLoadingMap:
-            state.bindings.alertInfo = ErrorAlertInfo(id: LocationSharingAlertType.mapLoadingError,
+            state.bindings.alertInfo = ErrorAlertInfo(id: .mapLoadingError,
                                                       title: VectorL10n.locationSharingLoadingMapErrorTitle(AppInfo.current.displayName),
                                                       primaryButton: (VectorL10n.ok, primaryButtonCompletion))
         case .failedLocatingUser:
-            state.bindings.alertInfo = ErrorAlertInfo(id: LocationSharingAlertType.userLocatingError,
+            state.bindings.alertInfo = ErrorAlertInfo(id: .userLocatingError,
                                                       title: VectorL10n.locationSharingLocatingUserErrorTitle(AppInfo.current.displayName),
                                                       primaryButton: (VectorL10n.ok, primaryButtonCompletion))
         case .invalidLocationAuthorization:
-            state.bindings.alertInfo = ErrorAlertInfo(id: LocationSharingAlertType.authorizationError,
+            state.bindings.alertInfo = ErrorAlertInfo(id: .authorizationError,
                                                       title: VectorL10n.locationSharingInvalidAuthorizationErrorTitle(AppInfo.current.displayName),
                                                       primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, primaryButtonCompletion),
                                                       secondaryButton: (VectorL10n.locationSharingInvalidAuthorizationSettings, {

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModelProtocol.swift
@@ -20,7 +20,7 @@ protocol LocationSharingViewModelProtocol {
     var completion: ((LocationSharingViewModelResult) -> Void)? { get set }
     
     func startLoading()
-    func stopLoading(error: LocationSharingErrorAlertInfo.AlertType?)
+    func stopLoading(error: LocationSharingAlertType?)
 }
 
 extension LocationSharingViewModelProtocol {

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingView.swift
@@ -79,22 +79,7 @@ struct LocationSharingView: View {
                 ThemeService.shared().theme.applyStyle(onNavigationBar: navigationController.navigationBar)
             }
             .alert(item: $context.alertInfo) { info in
-                if let secondaryButton = info.secondaryButton {
-                    return Alert(title: Text(info.title),
-                                 message: info.messageText,
-                                 primaryButton: .default(Text(info.primaryButton.title)) {
-                        info.primaryButton.action?()
-                    },
-                                 secondaryButton: .default(Text(secondaryButton.title)) {
-                        secondaryButton.action?()
-                    })
-                } else {
-                    return Alert(title: Text(info.title),
-                                 message: info.messageText,
-                                 dismissButton: .default(Text(info.primaryButton.title)) {
-                        info.primaryButton.action?()
-                    })
-                }
+                info.alert
             }
         }
         .accentColor(theme.colors.accent)

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingView.swift
@@ -81,7 +81,7 @@ struct LocationSharingView: View {
             .alert(item: $context.alertInfo) { info in
                 if let secondaryButton = info.secondaryButton {
                     return Alert(title: Text(info.title),
-                                 message: subtitleTextForAlertInfo(info),
+                                 message: info.messageText,
                                  primaryButton: .default(Text(info.primaryButton.title)) {
                         info.primaryButton.action?()
                     },
@@ -90,7 +90,7 @@ struct LocationSharingView: View {
                     })
                 } else {
                     return Alert(title: Text(info.title),
-                                 message: subtitleTextForAlertInfo(info),
+                                 message: info.messageText,
                                  dismissButton: .default(Text(info.primaryButton.title)) {
                         info.primaryButton.action?()
                     })
@@ -107,14 +107,6 @@ struct LocationSharingView: View {
         if context.viewState.showLoadingIndicator {
             ActivityIndicator()
         }
-    }
-    
-    private func subtitleTextForAlertInfo(_ alertInfo: LocationSharingErrorAlertInfo) -> Text? {
-        guard let subtitle = alertInfo.subtitle else {
-            return nil
-        }
-        
-        return Text(subtitle)
     }
 }
 

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
@@ -99,7 +99,7 @@ struct TimelinePollViewState: BindableState {
 }
 
 struct TimelinePollViewStateBindings {
-    var alertInfo: ErrorAlertInfo<TimelinePollAlertType>?
+    var alertInfo: AlertInfo<TimelinePollAlertType>?
 }
 
 enum TimelinePollAlertType {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
@@ -99,16 +99,10 @@ struct TimelinePollViewState: BindableState {
 }
 
 struct TimelinePollViewStateBindings {
-    var alertInfo: TimelinePollErrorAlertInfo?
+    var alertInfo: ErrorAlertInfo<TimelinePollAlertType>?
 }
 
-struct TimelinePollErrorAlertInfo: Identifiable {
-    enum AlertType {
-        case failedClosingPoll
-        case failedSubmittingAnswer
-    }
-    
-    let id: AlertType
-    let title: String
-    let subtitle: String
+enum TimelinePollAlertType {
+    case failedClosingPoll
+    case failedSubmittingAnswer
 }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
@@ -64,15 +64,15 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     }
     
     func showAnsweringFailure() {
-        state.bindings.alertInfo = TimelinePollErrorAlertInfo(id: .failedSubmittingAnswer,
-                                                              title: VectorL10n.pollTimelineVoteNotRegisteredTitle,
-                                                              subtitle: VectorL10n.pollTimelineVoteNotRegisteredSubtitle)
+        state.bindings.alertInfo = ErrorAlertInfo(id: TimelinePollAlertType.failedSubmittingAnswer,
+                                                  title: VectorL10n.pollTimelineVoteNotRegisteredTitle,
+                                                  message: VectorL10n.pollTimelineVoteNotRegisteredSubtitle)
     }
     
     func showClosingFailure() {
-        state.bindings.alertInfo = TimelinePollErrorAlertInfo(id: .failedClosingPoll,
-                                                              title: VectorL10n.pollTimelineNotClosedTitle,
-                                                              subtitle: VectorL10n.pollTimelineNotClosedSubtitle)
+        state.bindings.alertInfo = ErrorAlertInfo(id: TimelinePollAlertType.failedClosingPoll,
+                                                  title: VectorL10n.pollTimelineNotClosedTitle,
+                                                  message: VectorL10n.pollTimelineNotClosedSubtitle)
     }
         
     // MARK: - Private

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
@@ -64,15 +64,15 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     }
     
     func showAnsweringFailure() {
-        state.bindings.alertInfo = ErrorAlertInfo(id: .failedSubmittingAnswer,
-                                                  title: VectorL10n.pollTimelineVoteNotRegisteredTitle,
-                                                  message: VectorL10n.pollTimelineVoteNotRegisteredSubtitle)
+        state.bindings.alertInfo = AlertInfo(id: .failedSubmittingAnswer,
+                                             title: VectorL10n.pollTimelineVoteNotRegisteredTitle,
+                                             message: VectorL10n.pollTimelineVoteNotRegisteredSubtitle)
     }
     
     func showClosingFailure() {
-        state.bindings.alertInfo = ErrorAlertInfo(id: .failedClosingPoll,
-                                                  title: VectorL10n.pollTimelineNotClosedTitle,
-                                                  message: VectorL10n.pollTimelineNotClosedSubtitle)
+        state.bindings.alertInfo = AlertInfo(id: .failedClosingPoll,
+                                             title: VectorL10n.pollTimelineNotClosedTitle,
+                                             message: VectorL10n.pollTimelineNotClosedSubtitle)
     }
         
     // MARK: - Private

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
@@ -64,13 +64,13 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     }
     
     func showAnsweringFailure() {
-        state.bindings.alertInfo = ErrorAlertInfo(id: TimelinePollAlertType.failedSubmittingAnswer,
+        state.bindings.alertInfo = ErrorAlertInfo(id: .failedSubmittingAnswer,
                                                   title: VectorL10n.pollTimelineVoteNotRegisteredTitle,
                                                   message: VectorL10n.pollTimelineVoteNotRegisteredSubtitle)
     }
     
     func showClosingFailure() {
-        state.bindings.alertInfo = ErrorAlertInfo(id: TimelinePollAlertType.failedClosingPoll,
+        state.bindings.alertInfo = ErrorAlertInfo(id: .failedClosingPoll,
                                                   title: VectorL10n.pollTimelineNotClosedTitle,
                                                   message: VectorL10n.pollTimelineNotClosedSubtitle)
     }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
@@ -59,7 +59,7 @@ struct TimelinePollView: View {
         .padding([.bottom])
         .alert(item: $viewModel.alertInfo) { info in
             Alert(title: Text(info.title),
-                  message: Text(info.subtitle),
+                  message: info.messageText,
                   dismissButton: .default(Text(VectorL10n.ok)))
         }
     }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
@@ -58,9 +58,7 @@ struct TimelinePollView: View {
         .padding([.horizontal, .top], 2.0)
         .padding([.bottom])
         .alert(item: $viewModel.alertInfo) { info in
-            Alert(title: Text(info.title),
-                  message: info.messageText,
-                  dismissButton: .default(Text(VectorL10n.ok)))
+            info.alert
         }
     }
     

--- a/changelog.d/pr-5742.change
+++ b/changelog.d/pr-5742.change
@@ -1,0 +1,1 @@
+Add a generic SwiftUI Error type with support for showing NSErrors.


### PR DESCRIPTION
Adds a generic `ErrorAlertType` struct that can be used to describe an Alert to be presented. We can pass an `NSError` to the init to use it in a similar way to the existing `errorPresenter` in the UIKit templates. Additionally replaces `LocationSharingErrorAlertInfo` and `TimelinePollErrorAlertInfo` with this new type.

@stefanceriu WDYT about the style of having the `ErrorAlertType.alert` property where the type creates and returns the view? I'm perfectly happy with this when it's simple, but happy to revert it back to the previous commit where there is only a convenience property for the `messageText` if you prefer?

Note: I haven't tested the errors for polls/location sharing.