### PR TITLE
Use split controller's top navigation controller to present toasts

### DIFF
--- a/Riot/Modules/Room/RoomCoordinator.swift
+++ b/Riot/Modules/Room/RoomCoordinator.swift
@@ -318,6 +318,7 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
     private func startLoading() {
         if let presenter = parameters.userIndicatorPresenter {
             if loadingIndicator == nil {
+                MXLog.debug("[RoomCoordinator] Present loading indicator in a room: \(roomId ?? "unknown")")
                 loadingIndicator = presenter.present(.loading(label: VectorL10n.homeSyncing, isInteractionBlocking: false))
             }
         } else {
@@ -326,6 +327,7 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
     }
     
     private func stopLoading() {
+        MXLog.debug("[RoomCoordinator] Dismiss loading indicator in a room: \(roomId ?? "unknown")")
         loadingIndicator = nil
         activityIndicatorPresenter.removeCurrentActivityIndicator(animated: true)
     }

--- a/Riot/Modules/SplitView/SplitViewCoordinator.swift
+++ b/Riot/Modules/SplitView/SplitViewCoordinator.swift
@@ -48,7 +48,7 @@ final class SplitViewCoordinator: NSObject, SplitViewCoordinatorType {
     
     private weak var masterPresentable: SplitViewMasterPresentable?
     private var detailNavigationController: UINavigationController?
-    private(set) var detailNavigationRouter: NavigationRouterType?
+    private var detailNavigationRouter: NavigationRouterType?
     
     private var selectedNavigationRouter: NavigationRouterType? {
         return self.masterPresentable?.selectedNavigationRouter
@@ -60,6 +60,8 @@ final class SplitViewCoordinator: NSObject, SplitViewCoordinatorType {
     private var hasStartedOnce: Bool = false
     
     // MARK: Public
+    
+    private(set) var detailUserIndicatorPresenter: UserIndicatorTypePresenterProtocol?
     
     var childCoordinators: [Coordinator] = []
     
@@ -100,6 +102,10 @@ final class SplitViewCoordinator: NSObject, SplitViewCoordinatorType {
             
             // Setup split view controller
             self.splitViewController.viewControllers = [tabBarCoordinator.toPresentable(), detailNavigationController]
+            
+            // Setup detail user indicator presenter
+            let presentingViewController = splitViewController.isCollapsed ? tabBarCoordinator.toPresentable() : detailNavigationController
+            detailUserIndicatorPresenter = UserIndicatorTypePresenter(presentingViewController: presentingViewController)
                     
             self.add(childCoordinator: tabBarCoordinator)
             

--- a/Riot/Modules/SplitView/SplitViewPresentable.swift
+++ b/Riot/Modules/SplitView/SplitViewPresentable.swift
@@ -18,11 +18,11 @@ import UIKit
 
 protocol SplitViewMasterPresentableDelegate: AnyObject {
     
-    /// Navigation router for the split view detail
-    var detailNavigationRouter: NavigationRouterType? { get }
-    
     /// Detail items from the split view
     var detailModules: [Presentable] { get }
+    
+    /// Shared presenter of user indicators for detail views, such as rooms
+    var detailUserIndicatorPresenter: UserIndicatorTypePresenterProtocol? { get }
     
     /// Replace split view detail with the given detailPresentable
     func splitViewMasterPresentable(_ presentable: Presentable, wantsToReplaceDetailWith detailPresentable: Presentable, popCompletion: (() -> Void)?)

--- a/Riot/Modules/TabBar/TabBarCoordinator.swift
+++ b/Riot/Modules/TabBar/TabBarCoordinator.swift
@@ -415,13 +415,8 @@ final class TabBarCoordinator: NSObject, TabBarCoordinatorType {
                 displayConfig = .default
             }
             
-            var indicatorPresenter: UserIndicatorTypePresenterProtocol?
-            if let detailNavigation = splitViewMasterPresentableDelegate?.detailNavigationRouter?.toPresentable() {
-                indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: detailNavigation)
-            }
-            
             let roomCoordinatorParameters = RoomCoordinatorParameters(navigationRouterStore: NavigationRouterStore.shared,
-                                                                      userIndicatorPresenter: indicatorPresenter,
+                                                                      userIndicatorPresenter: splitViewMasterPresentableDelegate?.detailUserIndicatorPresenter,
                                                                       session: roomNavigationParameters.mxSession,
                                                                       roomId: roomNavigationParameters.roomId,
                                                                       eventId: roomNavigationParameters.eventId,

--- a/changelog.d/5752.bugfix
+++ b/changelog.d/5752.bugfix
@@ -1,0 +1,1 @@
+Activity Indicator: Use split controller's top navigation controller to present toasts


### PR DESCRIPTION
Fixes #5752 

The issue of missing spinner is actually a layout issue caused by split view controller allowing multiple nested navigation controllers. Previously when a toast was presented on a navigation controller, it was added on top of the navigation bar and anchored to the title, which could happen before the navigation controller itself was added to the view controller hierarchy. Once the navigation controller was properly added to the hierarchy, the parent navigation took control over the navigation bar and placed it on top of the spinner as well as invalidating any previously set constraints.

To solve for this issue the app needs to get hold of the ever-present top navigation controller, owned by the split view controller. On iPhones, this is the navigation controller that holds onto the detail navigation controller, whereas on iPads the detail navigation controller *is* the top navigation controller.

The whole point of this change is to expose navigation controller that is always in the view hierarchy, as opposed to a temporary one that may not have stable navigation bar.
