### PR TITLE
Fix social button visibility during registration

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -43,6 +43,13 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     var childCoordinators: [Coordinator] = []
     var completion: ((AuthenticationCoordinatorResult) -> Void)?
     
+    var customServerFieldsVisible = false {
+        didSet {
+            guard customServerFieldsVisible != oldValue else { return }
+            authenticationViewController.setCustomServerFieldsVisible(customServerFieldsVisible)
+        }
+    }
+    
     // MARK: - Setup
     
     init(parameters: AuthenticationCoordinatorParameters) {
@@ -72,10 +79,6 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     
     func update(authenticationType: MXKAuthenticationType) {
         authenticationViewController.authType = authenticationType
-    }
-    
-    func showCustomServer() {
-        authenticationViewController.setCustomServerFieldsVisible(true)
     }
     
     func update(externalRegistrationParameters: [AnyHashable: Any]) {

--- a/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
@@ -36,11 +36,11 @@ enum AuthenticationCoordinatorResult {
 protocol AuthenticationCoordinatorProtocol: Coordinator, Presentable {
     var completion: ((AuthenticationCoordinatorResult) -> Void)? { get set }
     
+    /// Whether the custom homeserver checkbox is enabled for the user to enter a homeserver URL.
+    var customServerFieldsVisible: Bool { get set }
+    
     /// Update the screen to display registration or login.
     func update(authenticationType: MXKAuthenticationType)
-    
-    /// Enable the custom server checkbox to allow the user to enter a homeserver URL.
-    func showCustomServer()
     
     /// Force a registration process based on a predefined set of parameters from a server provisioning link.
     /// For more information see `AuthenticationViewController.externalRegistrationParameters`.

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -504,6 +504,7 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 
         // Remove the potential back button.
         self.navigationItem.leftBarButtonItem = nil;
+        [self.navigationItem setHidesBackButton:YES];
     }
     else
     {
@@ -903,6 +904,12 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
             authInputsview.thirdPartyIdentifiersHidden = YES;
             
             [self updateRegistrationScreenWithThirdPartyIdentifiersHidden:YES];
+            
+            // Show the social login buttons again if needed.
+            [self updateSocialLoginViewVisibility];
+            
+            // Allow backward navigation in the flow again.
+            [self.navigationItem setHidesBackButton:NO];
         }
     }
     else if (sender == self.submitButton)
@@ -947,7 +954,10 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
                             else
                             {
                                 [self.authenticationActivityIndicator stopAnimating];
-
+                                
+                                // Hide the social login buttons now that a different flow has started.
+                                [self hideSocialLoginView];
+                                
                                 // Show the supported 3rd party ids which may be added to the account
                                 authInputsview.thirdPartyIdentifiersHidden = NO;
                                 [self updateRegistrationScreenWithThirdPartyIdentifiersHidden:NO];

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -215,9 +215,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
             coordinator.update(externalRegistrationParameters: externalRegistrationParameters)
         }
         
-        if useCaseResult == .customServer {
-            coordinator.showCustomServer()
-        }
+        coordinator.customServerFieldsVisible = useCaseResult == .customServer
         
         if let softLogoutCredentials = parameters.softLogoutCredentials {
             coordinator.update(softLogoutCredentials: softLogoutCredentials)

--- a/changelog.d/5879.bugfix
+++ b/changelog.d/5879.bugfix
@@ -1,0 +1,1 @@
+Authentication: Fix social login buttons visibility during registration flow and other minor navigation tweaks.


### PR DESCRIPTION
The social buttons were never hidden during registration after having added them to the registration page. Additionally 
- Hides the navigation back button during registration to enforce use of the custom bar buttons.
- Make sure custom server entry is disabled if navigating back to the use case screen and choosing a different option.

Fixes #5789