### PR TITLE
Room: Refresh header when call actions become available

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1261,6 +1261,7 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
         if (!bubbleTableViewDisplayInTransition && !self.bubblesTableView.isHidden)
         {
             [self refreshActivitiesViewDisplay];
+            [self refreshRoomTitle];
             
             [self checkReadMarkerVisibility];
             [self refreshJumpToLastUnreadBannerDisplay];

--- a/changelog.d/5800.bugfix
+++ b/changelog.d/5800.bugfix
@@ -1,0 +1,1 @@
+Room: Refresh header when call actions become available (member count changes)


### PR DESCRIPTION
Fixes #5800 

This will effectively refresh on data source updates (i.e. RoomState updates), it seems fine performance-wise, we might be able to look into a finer mechanism if needed, but I'm not sure how easy it would be.