### PR TITLE
Do not show user indicators when the view controller is not visible

### DIFF
--- a/Riot/Modules/Common/ActivityIndicator/UserIndicatorPresenterWrapper.swift
+++ b/Riot/Modules/Common/ActivityIndicator/UserIndicatorPresenterWrapper.swift
@@ -30,13 +30,13 @@ import CommonKit
         self.presenter = presenter
     }
     
-    @objc func presentActivityIndicator() {
-        presentActivityIndicator(label: VectorL10n.homeSyncing)
+    @objc func presentLoadingIndicator() {
+        presentLoadingIndicator(label: VectorL10n.homeSyncing)
     }
 
-    @objc func presentActivityIndicator(label: String) {
+    @objc func presentLoadingIndicator(label: String) {
         guard loadingIndicator == nil else {
-            // The app is very liberal with calling `presentActivityIndicator` (often not matched by corresponding `removeCurrentActivityIndicator`),
+            // The app is very liberal with calling `presentLoadingIndicator` (often not matched by corresponding `dismissLoadingIndicator`),
             // so there is no reason to keep adding new indiciators if there is one already showing.
             return
         }
@@ -45,7 +45,7 @@ import CommonKit
         loadingIndicator = presenter.present(.loading(label: label, isInteractionBlocking: false))
     }
     
-    @objc func dismissActivityIndicator() {
+    @objc func dismissLoadingIndicator() {
         MXLog.debug("[UserIndicatorPresenterWrapper] Dismiss loading indicator")
         loadingIndicator = nil
     }

--- a/Riot/Modules/Common/ActivityIndicator/UserIndicatorPresenterWrapper.swift
+++ b/Riot/Modules/Common/ActivityIndicator/UserIndicatorPresenterWrapper.swift
@@ -41,10 +41,12 @@ import CommonKit
             return
         }
 
+        MXLog.debug("[UserIndicatorPresenterWrapper] Present loading indicator")
         loadingIndicator = presenter.present(.loading(label: label, isInteractionBlocking: false))
     }
     
     @objc func dismissActivityIndicator() {
+        MXLog.debug("[UserIndicatorPresenterWrapper] Dismiss loading indicator")
         loadingIndicator = nil
     }
     

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -64,9 +64,8 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
     // when the user selects it.
     UISearchBar *tableSearchBar;
     
-    // Flag determining whether the view controller is ready to use (potentially shared) user indicators
-    // depending on whether the controller is visible or not
-    BOOL isUserIndicatorEnabled;
+    // Flag indicating whether the view controller is (at least partially) visible and not dissapearing
+    BOOL isViewVisible;
     
     // Observe kThemeServiceDidChangeThemeNotification to handle user interface theme change.
     __weak id kThemeServiceDidChangeThemeNotificationObserver;
@@ -268,10 +267,9 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    isViewVisible = YES;
     
     [self.screenTracker trackScreen];
-    
-    isUserIndicatorEnabled = YES;
 
     // Reset back user interactions
     self.userInteractionEnabled = YES;
@@ -307,6 +305,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
+    isViewVisible = NO;
     
     // Leave potential editing mode
     [self cancelEditionMode:NO];
@@ -323,7 +322,6 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         kMXNotificationCenterDidUpdateRulesObserver = nil;
     }
     
-    isUserIndicatorEnabled = NO;
     [self stopActivityIndicator];
 }
 
@@ -2415,16 +2413,16 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
 }
 
 - (void)startActivityIndicatorWithLabel:(NSString *)label {
-    if (self.indicatorPresenter && isUserIndicatorEnabled) {
-        [self.indicatorPresenter presentActivityIndicatorWithLabel:label];
+    if (self.indicatorPresenter && isViewVisible) {
+        [self.indicatorPresenter presentLoadingIndicatorWithLabel:label];
     } else {
         [super startActivityIndicator];
     }
 }
 
 - (void)startActivityIndicator {
-    if (self.indicatorPresenter && isUserIndicatorEnabled) {
-        [self.indicatorPresenter presentActivityIndicator];
+    if (self.indicatorPresenter && isViewVisible) {
+        [self.indicatorPresenter presentLoadingIndicator];
     } else {
         [super startActivityIndicator];
     }
@@ -2432,7 +2430,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
 
 - (void)stopActivityIndicator {
     if (self.indicatorPresenter) {
-        [self.indicatorPresenter dismissActivityIndicator];
+        [self.indicatorPresenter dismissLoadingIndicator];
     } else {
         [super stopActivityIndicator];
     }

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -64,6 +64,10 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
     // when the user selects it.
     UISearchBar *tableSearchBar;
     
+    // Flag determining whether the view controller is ready to use (potentially shared) user indicators
+    // depending on whether the controller is visible or not
+    BOOL isUserIndicatorEnabled;
+    
     // Observe kThemeServiceDidChangeThemeNotification to handle user interface theme change.
     __weak id kThemeServiceDidChangeThemeNotificationObserver;
 }
@@ -266,6 +270,8 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
     [super viewWillAppear:animated];
     
     [self.screenTracker trackScreen];
+    
+    isUserIndicatorEnabled = YES;
 
     // Reset back user interactions
     self.userInteractionEnabled = YES;
@@ -317,6 +323,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         kMXNotificationCenterDidUpdateRulesObserver = nil;
     }
     
+    isUserIndicatorEnabled = NO;
     [self stopActivityIndicator];
 }
 
@@ -2408,7 +2415,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
 }
 
 - (void)startActivityIndicatorWithLabel:(NSString *)label {
-    if (self.indicatorPresenter) {
+    if (self.indicatorPresenter && isUserIndicatorEnabled) {
         [self.indicatorPresenter presentActivityIndicatorWithLabel:label];
     } else {
         [super startActivityIndicator];
@@ -2416,7 +2423,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
 }
 
 - (void)startActivityIndicator {
-    if (self.indicatorPresenter) {
+    if (self.indicatorPresenter && isUserIndicatorEnabled) {
         [self.indicatorPresenter presentActivityIndicator];
     } else {
         [super startActivityIndicator];

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -569,7 +569,7 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     [VoiceMessageMediaServiceProvider.sharedProvider pauseAllServices];
     
     // Stop the loading indicator even if the session is still in progress
-    [self stopLoadingIndicator];
+    [self stopLoadingUserIndicator];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -937,10 +937,14 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     self.updateRoomReadMarker = NO;
 }
 
+#pragma mark - Loading indicators
+
 - (BOOL)providesCustomActivityIndicator {
     return [self.delegate roomViewControllerCanDelegateUserIndicators:self];
 }
 
+// Override of a legacy method to determine whether to use a newer implementation instead.
+// Will be removed in the future https://github.com/vector-im/element-ios/issues/5608
 - (void)startActivityIndicator {
     if ([self providesCustomActivityIndicator]) {
         [self.delegate roomViewControllerDidStartLoading:self];
@@ -949,6 +953,8 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     }
 }
 
+// Override of a legacy method to determine whether to use a newer implementation instead.
+// Will be removed in the future https://github.com/vector-im/element-ios/issues/5608
 - (void)stopActivityIndicator
 {
     if (notificationTaskProfile)
@@ -962,14 +968,14 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
         // to determine whether the indicator can be stopped or not (and the method should thus rather be called `stopActivityIndicatorIfPossible`).
         // Since the newer indicators are not calling super implementation, the check for `canStopActivityIndicator` has to be performed manually.
         if ([self canStopActivityIndicator]) {
-            [self stopLoadingIndicator];
+            [self stopLoadingUserIndicator];
         }
     } else {
         [super stopActivityIndicator];
     }
 }
 
-- (void)stopLoadingIndicator
+- (void)stopLoadingUserIndicator
 {
     [self.delegate roomViewControllerDidStopLoading:self];
 }

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -567,7 +567,9 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
     isAppeared = NO;
     
     [VoiceMessageMediaServiceProvider.sharedProvider pauseAllServices];
-    [self stopActivityIndicator];
+    
+    // Stop the loading indicator even if the session is still in progress
+    [self stopLoadingIndicator];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -956,12 +958,20 @@ const NSTimeInterval kResizeComposerAnimationDuration = .05;
         notificationTaskProfile = nil;
     }
     if ([self providesCustomActivityIndicator]) {
+        // The legacy super implementation of `stopActivityIndicator` contains a number of checks grouped under `canStopActivityIndicator`
+        // to determine whether the indicator can be stopped or not (and the method should thus rather be called `stopActivityIndicatorIfPossible`).
+        // Since the newer indicators are not calling super implementation, the check for `canStopActivityIndicator` has to be performed manually.
         if ([self canStopActivityIndicator]) {
-            [self.delegate roomViewControllerDidStopLoading:self];
+            [self stopLoadingIndicator];
         }
     } else {
         [super stopActivityIndicator];
     }
+}
+
+- (void)stopLoadingIndicator
+{
+    [self.delegate roomViewControllerDidStopLoading:self];
 }
 
 - (void)displayRoom:(MXKRoomDataSource *)dataSource

--- a/changelog.d/5801.bugfix
+++ b/changelog.d/5801.bugfix
@@ -1,0 +1,1 @@
+Activity Indicators: Do not show user indicators when the view controller is not visible


### PR DESCRIPTION
Fixes #5801 

The architecture around user indicators is still not quite ideal, now that we have global user indicators it becomes problematic when view controllers attempt to display something whilst they are not actually visible. For example most view controllers subclass from `MXViewController` which monitors the `MXSession` at all times and starts / stops activity indicator accordingly.

For now I am simply adding some flags to avoid presenting when the view controller is not visible, but this is not a robust enough solution and something else will need to be put in place. In an idea case the loading is more centralized and each room communicates its state changes via some delegate, but this obviously requires a bigger change.

Another angle to this is removing all the state change monitoring from each view controller when the view controller isn't actually visible. This should be done anyways but could have further consequences, so best done outside of a hotfix.