### PR TITLE
Stop logging crashes in the share extension.

### DIFF
--- a/Riot/Categories/Bundle.swift
+++ b/Riot/Categories/Bundle.swift
@@ -30,4 +30,9 @@ public extension Bundle {
         }
         return bundle
     }
+    
+    /// Whether or not the current executable is running in the RiotShareExtension.
+    static var isShareExtension: Bool {
+        main.bundleURL.lastPathComponent.contains("RiotShareExtension.appex")
+    }
 }

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -94,8 +94,13 @@ import AnalyticsEvents
         
         MXLog.debug("[Analytics] Started.")
         
-        // Catch and log crashes
-        MXLogger.logCrashes(true)
+        if Bundle.isShareExtension {
+            // Don't log crashes in the share extension
+        } else {
+            // Catch and log crashes
+            MXLogger.logCrashes(true)
+        }
+        
         MXLogger.setBuildVersion(AppInfo.current.buildInfo.readableBuildVersion)
     }
     

--- a/changelog.d/5805.bugfix
+++ b/changelog.d/5805.bugfix
@@ -1,0 +1,1 @@
+Share Extension: Stop logging crashes due to intentional exception that frees up memory.


### PR DESCRIPTION
This fixes a crash report dialog being shown in the main app after every share extension usage due to the following line:
```objc
[NSException raise:@"Kill the app extension" format:@"Free memory used by share extension"];
```

Long term we need to fix whatever memory leak is occurring and remove the exception, but until then this will stop giving a bad impression about the app to our users.

Fixes #5805