### PR TITLE
Fix crash when pressing tabs

### DIFF
--- a/Riot/Modules/Favorites/FavouritesViewController.m
+++ b/Riot/Modules/Favorites/FavouritesViewController.m
@@ -130,9 +130,13 @@
     
     [self.tableViewPaginationThrottler throttle:^{
         NSInteger section = indexPath.section;
+        if (tableView.numberOfSections <= section)
+        {
+            return;
+        }
+        
         NSInteger numberOfRowsInSection = [tableView numberOfRowsInSection:section];
-        if (tableView.numberOfSections > section
-            && indexPath.row == numberOfRowsInSection - 1)
+        if (indexPath.row == numberOfRowsInSection - 1)
         {
             [self->recentsDataSource paginateInSection:section];
         }

--- a/Riot/Modules/Home/HomeViewController.m
+++ b/Riot/Modules/Home/HomeViewController.m
@@ -600,9 +600,13 @@
 {
     [self.collectionViewPaginationThrottler throttle:^{
         NSInteger collectionViewSection = indexPath.section;
+        if (collectionView.numberOfSections <= collectionViewSection)
+        {
+            return;
+        }
+        
         NSInteger numberOfItemsInSection = [collectionView numberOfItemsInSection:collectionViewSection];
-        if (collectionView.numberOfSections > collectionViewSection
-            && indexPath.item == numberOfItemsInSection - 1)
+        if (indexPath.item == numberOfItemsInSection - 1)
         {
             NSInteger tableViewSection = collectionView.tag;
             [self->recentsDataSource paginateInSection:tableViewSection];

--- a/Riot/Modules/People/PeopleViewController.m
+++ b/Riot/Modules/People/PeopleViewController.m
@@ -105,9 +105,13 @@
     
     [self.tableViewPaginationThrottler throttle:^{
         NSInteger section = indexPath.section;
+        if (tableView.numberOfSections <= section)
+        {
+            return;
+        }
+        
         NSInteger numberOfRowsInSection = [tableView numberOfRowsInSection:section];
-        if (tableView.numberOfSections > section
-            && indexPath.row == numberOfRowsInSection - 1)
+        if (indexPath.row == numberOfRowsInSection - 1)
         {
             [self->recentsDataSource paginateInSection:section];
         }

--- a/Riot/Modules/Rooms/RoomsViewController.m
+++ b/Riot/Modules/Rooms/RoomsViewController.m
@@ -110,9 +110,13 @@
     
     [self.tableViewPaginationThrottler throttle:^{
         NSInteger section = indexPath.section;
+        if (tableView.numberOfSections <= section)
+        {
+            return;
+        }
+
         NSInteger numberOfRowsInSection = [tableView numberOfRowsInSection:section];
-        if (tableView.numberOfSections > section
-            && indexPath.row == numberOfRowsInSection - 1)
+        if (indexPath.row == numberOfRowsInSection - 1)
         {
             [self->recentsDataSource paginateInSection:section];
         }

--- a/changelog.d/5547.bugfix
+++ b/changelog.d/5547.bugfix
@@ -1,0 +1,1 @@
+Home: Fix crash when pressing tabs


### PR DESCRIPTION
Fixes #5547 

Fix crash where we try to get the number of rows in a section before we ensure the tableview / collectionview has enough sections to begin with.

This would ideally be extracted even further out (3.5x code duplication) into the `RecentsViewController`, but the parent does not seem to know much about pagination so the API might be displaced there.

As to why the tableview / collectionview does not have adequate section even though the `willDisplayCell` is called, this is entirely because of the async throttler. An easy way to reproduce this bug is by forcing `[tableView reloadData]` inside of the throttle block.