### PR TITLE
Strip `in reply to` from thread summaries and latest messages

### DIFF
--- a/Riot/Modules/Room/TimelineDecorations/Threads/Summary/ThreadSummaryView.swift
+++ b/Riot/Modules/Room/TimelineDecorations/Threads/Summary/ThreadSummaryView.swift
@@ -115,7 +115,7 @@ class ThreadSummaryView: UIView {
         room.state { [weak self] roomState in
             guard let self = self else { return }
             let formatterError = UnsafeMutablePointer<MXKEventFormatterError>.allocate(capacity: 1)
-            let lastMessageText = eventFormatter.attributedString(from: lastMessage,
+            let lastMessageText = eventFormatter.attributedString(from: lastMessage.replyStrippedVersion,
                                                                   with: roomState,
                                                                   error: formatterError)
             

--- a/Riot/Modules/Threads/ThreadList/ThreadListViewModel.swift
+++ b/Riot/Modules/Threads/ThreadList/ThreadListViewModel.swift
@@ -206,25 +206,8 @@ final class ThreadListViewModel: ThreadListViewModelProtocol {
         guard let message = thread.rootMessage else {
             return nil
         }
-        if message.isReply(), let newMessage = message.copy() as? MXEvent {
-            var jsonDict = newMessage.isEncrypted ? newMessage.clear?.jsonDictionary() : newMessage.jsonDictionary()
-            if var content = jsonDict?["content"] as? [String: Any] {
-                content.removeValue(forKey: "format")
-                content.removeValue(forKey: "formatted_body")
-                content.removeValue(forKey: kMXEventRelationRelatesToKey)
-                if let replyText = MXReplyEventParser().parse(newMessage)?.bodyParts.replyText {
-                    content["body"] = replyText
-                }
-                jsonDict?["content"] = content
-            }
-            let trimmedMessage = MXEvent(fromJSON: jsonDict)
-            let formatterError = UnsafeMutablePointer<MXKEventFormatterError>.allocate(capacity: 1)
-            return eventFormatter.attributedString(from: trimmedMessage,
-                                                   with: roomState,
-                                                   error: formatterError)
-        }
         let formatterError = UnsafeMutablePointer<MXKEventFormatterError>.allocate(capacity: 1)
-        return eventFormatter.attributedString(from: message,
+        return eventFormatter.attributedString(from: message.replyStrippedVersion,
                                                with: roomState,
                                                error: formatterError)
     }
@@ -238,7 +221,7 @@ final class ThreadListViewModel: ThreadListViewModelProtocol {
         }
         let formatterError = UnsafeMutablePointer<MXKEventFormatterError>.allocate(capacity: 1)
         return (
-            eventFormatter.attributedString(from: message,
+            eventFormatter.attributedString(from: message.replyStrippedVersion,
                                             with: roomState,
                                             error: formatterError),
             eventFormatter.dateString(from: message, withTime: true)

--- a/changelog.d/5488.change
+++ b/changelog.d/5488.change
@@ -1,0 +1,1 @@
+Threads: Strip `ìn reply to` from thread summaries and latest messages.


### PR DESCRIPTION
Part of #5488 

Will be based on develop when other thread PRs merged.