### PR TITLE
Disable crash logging in the Share Extension, and reduce memory usage.

### DIFF
--- a/Riot/Categories/Bundle.swift
+++ b/Riot/Categories/Bundle.swift
@@ -30,4 +30,9 @@ public extension Bundle {
         }
         return bundle
     }
+    
+    /// Whether or not the bundle is the RiotShareExtension.
+    var isShareExtension: Bool {
+        bundleURL.lastPathComponent.contains("RiotShareExtension.appex")
+    }
 }

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -121,8 +121,13 @@ import AnalyticsEvents
         
         MXLog.debug("[Analytics] Started.")
         
-        // Catch and log crashes
-        MXLogger.logCrashes(true)
+        if Bundle.main.isShareExtension {
+            // Don't log crashes in the share extension
+        } else {
+            // Catch and log crashes
+            MXLogger.logCrashes(true)
+        }
+        
         MXLogger.setBuildVersion(AppInfo.current.buildInfo.readableBuildVersion)
     }
     

--- a/RiotShareExtension/Shared/ShareDataSource.h
+++ b/RiotShareExtension/Shared/ShareDataSource.h
@@ -31,7 +31,7 @@
 @property (nonatomic, strong, readonly) NSSet<NSString *> *selectedRoomIdentifiers;
 
 - (instancetype)initWithFileStore:(MXFileStore *)fileStore
-                      credentials:(MXCredentials *)credentials;
+                          session:(MXSession *)session;
 
 - (void)selectRoomWithIdentifier:(NSString *)roomIdentifier animated:(BOOL)animated;
 

--- a/RiotShareExtension/Sources/ShareExtensionRootViewController.m
+++ b/RiotShareExtension/Sources/ShareExtensionRootViewController.m
@@ -99,6 +99,10 @@
 {
     [self dismissViewControllerAnimated:true completion:^{
         [self.presentingViewController dismissViewControllerAnimated:false completion:nil];
+        
+        // FIXME: Share extension memory usage increase when launched several times and then crash due to some memory leaks.
+        // For now, we force the share extension to exit and free memory.
+        [NSException raise:@"Kill the app extension" format:@"Free memory used by share extension"];
     }];
 }
 

--- a/RiotShareExtension/Sources/ShareExtensionRootViewController.m
+++ b/RiotShareExtension/Sources/ShareExtensionRootViewController.m
@@ -99,10 +99,6 @@
 {
     [self dismissViewControllerAnimated:true completion:^{
         [self.presentingViewController dismissViewControllerAnimated:false completion:nil];
-        
-        // FIXME: Share extension memory usage increase when launched several times and then crash due to some memory leaks.
-        // For now, we force the share extension to exit and free memory.
-        [NSException raise:@"Kill the app extension" format:@"Free memory used by share extension"];
     }];
 }
 

--- a/RiotShareExtension/Sources/ShareItemSender.m
+++ b/RiotShareExtension/Sources/ShareItemSender.m
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
 
 @interface ShareItemSender ()
 
-@property (nonatomic, strong, readonly) UIViewController *rootViewController;
+@property (nonatomic, weak, readonly) UIViewController *rootViewController;
 @property (nonatomic, strong, readonly) ShareExtensionShareItemProvider *shareItemProvider;
 
 @property (nonatomic, strong, readonly) NSMutableArray<NSData *> *pendingImages;

--- a/RiotShareExtension/Sources/ShareItemSender.m
+++ b/RiotShareExtension/Sources/ShareItemSender.m
@@ -641,7 +641,7 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
     {
         if (!RiotSettings.shared.showMediaCompressionPrompt)
         {
-            [MXSDKOptions sharedInstance].videoConversionPresetName = AVCaptureSessionPreset1920x1080;
+            [MXSDKOptions sharedInstance].videoConversionPresetName = AVAssetExportPreset1920x1080;
             sendVideo();
         }
         else

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -27,6 +27,12 @@
 // Build Settings
 @property (nonatomic) id<Configurable> configuration;
 
+/**
+ The room that is currently being used to send a message. This is to ensure a
+ strong ref is maintained on the `MXRoom` until sending has completed.
+ */
+@property (nonatomic) MXRoom *selectedRoom;
+
 @end
 
 @implementation IntentHandler
@@ -242,17 +248,22 @@
                 [session setStore:fileStore success:^{
                     MXStrongifyAndReturnIfNil(session);
 
-                    MXRoom *room = [MXRoom loadRoomFromStore:fileStore withRoomId:roomID matrixSession:session];
+                    self.selectedRoom = [MXRoom loadRoomFromStore:fileStore withRoomId:roomID matrixSession:session];
 
                     // Do not warn for unknown devices. We have cross-signing now
                     session.crypto.warnOnUnknowDevices = NO;
 
-                    [room sendTextMessage:intent.content
-                                 threadId:nil
-                                  success:^(NSString *eventId) {
+                    MXWeakify(self);
+                    [self.selectedRoom sendTextMessage:intent.content
+                                              threadId:nil
+                                               success:^(NSString *eventId) {
                         completeWithCode(INSendMessageIntentResponseCodeSuccess);
+                        MXStrongifyAndReturnIfNil(self);
+                        self.selectedRoom = nil;
                     } failure:^(NSError *error) {
                         completeWithCode(INSendMessageIntentResponseCodeFailure);
+                        MXStrongifyAndReturnIfNil(self);
+                        self.selectedRoom = nil;
                     }];
 
                 } failure:^(NSError *error) {

--- a/changelog.d/5805.bugfix
+++ b/changelog.d/5805.bugfix
@@ -1,0 +1,1 @@
+Share Extension: Stop logging crashes due to intentional exception that frees up memory and handle changes to MXRoom in the SDK.


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-sdk/pull/1414

Initial attempts in this PR were to fix the memory issues seen in the share extension. Unfortunately this has been abandoned for now due to the `MXSession` created when sending having a log of strong references to it from all over the place. The PR does include some changes to reduce memory usage as some parts of the share extension are used for message forwarding inside the app.

Additionally there are now strong references to the `MXRoom`s being used in the Share extension and Siri extension as the retain cycles on these have been fixed in the SDK PR above.