### PR TITLE
Fix crash trying to remove a UserSession for a nil MXSession.

### DIFF
--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -251,7 +251,8 @@ extension AppCoordinator: LegacyAppDelegateDelegate {
     func legacyAppDelegate(_ legacyAppDelegate: LegacyAppDelegate!, didAddMatrixSession session: MXSession!) {
     }
     
-    func legacyAppDelegate(_ legacyAppDelegate: LegacyAppDelegate!, didRemoveMatrixSession session: MXSession!) {
+    func legacyAppDelegate(_ legacyAppDelegate: LegacyAppDelegate!, didRemoveMatrixSession session: MXSession?) {
+        guard let session = session else { return }
         // Handle user session removal on clear cache. On clear cache the account has his session closed but the account is not removed.
         self.userSessionsService.removeUserSession(relatedToMatrixSession: session)
     }

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2048,7 +2048,11 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountManagerDidSoftlogoutAccountNotification  object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
 
         MXKAccount *account = notif.object;
-        [self removeMatrixSession:account.mxSession];
+        
+        if (account.mxSession)
+        {
+            [self removeMatrixSession:account.mxSession];
+        }
 
         // Return to authentication screen
         [self.masterTabBarController showSoftLogoutOnboardingFlowWithCredentials:account.mxCredentials];

--- a/changelog.d/5846.bugfix
+++ b/changelog.d/5846.bugfix
@@ -1,0 +1,1 @@
+Authentication: Fix a crash that occurred when using the app with an account that had a soft logout.


### PR DESCRIPTION
The app was crashing whenever it was in a soft logout state due to a nil `MXSession` being used to try and remove `UserSession` (after a valid call to remove the session had already been made). There is more work to be done as there is also a crash when tapping the "Clear all data" button (#5881), but that looks more involved and I wanted to get this submitted before the next RC so that it at least allows users to log back in without having a crash loop.

Fixes #5846
