### PR TITLE
Do not clear cache if there are no stored filters

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -2073,6 +2073,11 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
               mxSession.syncFilterId, syncFilter.JSONDictionary);
         completion(NO);
     }
+    else if (!mxSession.store.allFilterIds.count)
+    {
+        MXLogDebug(@"[MXKAccount] There are no filters stored in this session, proceed as if no /sync was done before");
+        completion(YES);
+    }
     else
     {
         // Check the filter is the one previously set

--- a/changelog.d/5873.bugfix
+++ b/changelog.d/5873.bugfix
@@ -1,0 +1,1 @@
+MXAccount: Do not clear cache if there are no stored filters


### PR DESCRIPTION
Resolves #5873 and depends on https://github.com/matrix-org/matrix-ios-sdk/pull/1416

If there are no locally stored filters (see https://github.com/matrix-org/matrix-ios-sdk/pull/1416), do not report an incompatibility when `checkSyncFilterCompatibility` is called. Otherwise all cache would be cleared and a full sync triggered.