### PR TITLE
Ensure the login button is always visible

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationViewController.h
+++ b/Riot/Modules/Authentication/AuthenticationViewController.h
@@ -31,8 +31,6 @@
 @property (weak, nonatomic) IBOutlet UIButton *skipButton;
 @property (weak, nonatomic) IBOutlet UIButton *forgotPasswordButton;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *submitButtonMinLeadingConstraint;
-
 @property (weak, nonatomic) IBOutlet UIView *serverOptionsContainer;
 @property (weak, nonatomic) IBOutlet UIButton *customServersTickButton;
 @property (weak, nonatomic) IBOutlet UIView *customServersContainer;

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -1058,17 +1058,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
     }
     
     self.forgotPasswordButton.hidden = !showForgotPasswordButton;
-    
-    // Adjust minimum leading constraint of the submit button
-    if (self.forgotPasswordButton.isHidden)
-    {
-        self.submitButtonMinLeadingConstraint.constant = 19;
-    }
-    else
-    {
-        CGRect frame = self.forgotPasswordButton.frame;
-        self.submitButtonMinLeadingConstraint.constant =  frame.origin.x + frame.size.width + 10;
-    }
 }
 
 - (void)afterSetPinFlowCompletedWithCredentials:(MXCredentials*)credentials

--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -44,7 +44,6 @@
                 <outlet property="softLogoutClearDataContainer" destination="vX2-5Y-rQc" id="mgK-41-cnX"/>
                 <outlet property="softLogoutClearDataLabel" destination="QYL-Lo-tmH" id="ks9-5X-xfs"/>
                 <outlet property="submitButton" destination="k3J-Eg-itz" id="fiZ-wK-6YM"/>
-                <outlet property="submitButtonMinLeadingConstraint" destination="bEB-EO-b14" id="Iz5-ks-nSX"/>
                 <outlet property="view" destination="5rn-KE-plm" id="bFJ-yJ-vc0"/>
                 <outlet property="welcomeImageView" destination="d8r-TX-pwX" id="vzD-zK-EeC"/>
             </connections>
@@ -91,7 +90,7 @@
                                             </constraints>
                                         </view>
                                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Currently we do not support authentication flows defined by this homeserver" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="54b-4O-ip9" userLabel="noFlowLabel">
-                                            <rect key="frame" x="28" y="8" width="319.33333333333331" height="33.666666666666664"/>
+                                            <rect key="frame" x="28" y="8" width="319" height="33.666666666666664"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -129,63 +128,73 @@
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gg0-TE-OGb">
                                     <rect key="frame" x="0.0" y="360" width="375" height="125"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AJ2-lJ-NUq">
-                                            <rect key="frame" x="19" y="33" width="122" height="30"/>
-                                            <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCForgotPasswordButton"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="30" id="1mr-dZ-KtP"/>
-                                            </constraints>
-                                            <state key="normal">
-                                                <attributedString key="attributedTitle">
-                                                    <fragment content="Forgot password?">
-                                                        <attributes>
-                                                            <color key="NSColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <font key="NSFont" size="15" name="HelveticaNeue"/>
-                                                        </attributes>
-                                                    </fragment>
-                                                </attributedString>
-                                            </state>
-                                            <connections>
-                                                <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="UVJ-Re-xe2"/>
-                                            </connections>
-                                        </button>
-                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wEJ-AF-rdH">
-                                            <rect key="frame" x="11" y="33" width="106" height="30"/>
-                                            <color key="backgroundColor" red="0.028153735480000001" green="0.82494870580000002" blue="0.051896891280000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCSkipButton"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="30" id="HIX-iq-vTC"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                            <inset key="contentEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
-                                            <state key="normal" title="Skip">
-                                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </state>
-                                            <connections>
-                                                <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="iEr-Vf-f6P"/>
-                                            </connections>
-                                        </button>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k3J-Eg-itz" userLabel="SubmitBtn">
-                                            <rect key="frame" x="258" y="33" width="106" height="30"/>
-                                            <color key="backgroundColor" red="0.028153735480000001" green="0.82494870580000002" blue="0.051896891280000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCLoginButton"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="3ST-q4-gu8"/>
-                                                <constraint firstAttribute="height" constant="30" id="rR8-KH-2z5"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                            <inset key="contentEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
-                                            <state key="normal" title="Log In">
-                                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </state>
-                                            <connections>
-                                                <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="Ocd-Ag-6hf"/>
-                                            </connections>
-                                        </button>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FIn-2w-e6H">
-                                            <rect key="frame" x="0.0" y="68" width="375" height="178"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7OO-nL-hff">
+                                            <rect key="frame" x="11" y="33" width="353" height="65"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Oeh-7N-HNr">
+                                                    <rect key="frame" x="0.0" y="0.0" width="106" height="30"/>
+                                                    <subviews>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k3J-Eg-itz" userLabel="SubmitBtn">
+                                                            <rect key="frame" x="0.0" y="0.0" width="106" height="30"/>
+                                                            <color key="backgroundColor" red="0.028153735480000001" green="0.82494870580000002" blue="0.051896891280000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCLoginButton"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="30" id="BPY-Sb-k8F"/>
+                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="L9J-9d-puh"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                            <inset key="contentEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
+                                                            <state key="normal" title="Log In">
+                                                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </state>
+                                                            <connections>
+                                                                <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="Ocd-Ag-6hf"/>
+                                                            </connections>
+                                                        </button>
+                                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wEJ-AF-rdH">
+                                                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="30"/>
+                                                            <color key="backgroundColor" red="0.028153735480000001" green="0.82494870580000002" blue="0.051896891280000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCSkipButton"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                            <inset key="contentEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
+                                                            <state key="normal" title="Skip">
+                                                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </state>
+                                                            <connections>
+                                                                <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="iEr-Vf-f6P"/>
+                                                            </connections>
+                                                        </button>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="k3J-Eg-itz" firstAttribute="height" secondItem="wEJ-AF-rdH" secondAttribute="height" id="hhT-7b-PVV"/>
+                                                    </constraints>
+                                                </stackView>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AJ2-lJ-NUq">
+                                                    <rect key="frame" x="0.0" y="35" width="122" height="30"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCForgotPasswordButton"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="30" id="1mr-dZ-KtP"/>
+                                                    </constraints>
+                                                    <state key="normal">
+                                                        <attributedString key="attributedTitle">
+                                                            <fragment content="Forgot password?">
+                                                                <attributes>
+                                                                    <color key="NSColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <font key="NSFont" size="15" name="HelveticaNeue"/>
+                                                                </attributes>
+                                                            </fragment>
+                                                        </attributedString>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="UVJ-Re-xe2"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FIn-2w-e6H" userLabel="Server Options">
+                                            <rect key="frame" x="0.0" y="103" width="375" height="178"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6yx-o1-vbD">
                                                     <rect key="frame" x="19" y="5" width="337" height="30"/>
@@ -333,8 +342,8 @@
                                                 <constraint firstAttribute="trailing" secondItem="6yx-o1-vbD" secondAttribute="trailing" constant="19" id="rWk-Mp-KPS"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vX2-5Y-rQc">
-                                            <rect key="frame" x="0.0" y="96" width="375" height="170"/>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vX2-5Y-rQc" userLabel="Soft Logout">
+                                            <rect key="frame" x="0.0" y="148" width="375" height="170"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QYL-Lo-tmH">
                                                     <rect key="frame" x="10" y="0.0" width="355" height="121"/>
@@ -384,21 +393,16 @@ Clear it if you're finished using this device, or want to sign in to another acc
                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCOptionsContainer"/>
                                     <constraints>
                                         <constraint firstItem="FIn-2w-e6H" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" id="3G8-Tb-KaN"/>
-                                        <constraint firstItem="wEJ-AF-rdH" firstAttribute="width" secondItem="k3J-Eg-itz" secondAttribute="width" id="7sB-YJ-eX4"/>
                                         <constraint firstAttribute="trailing" secondItem="vX2-5Y-rQc" secondAttribute="trailing" id="DPh-Jx-WP1"/>
+                                        <constraint firstItem="FIn-2w-e6H" firstAttribute="top" secondItem="7OO-nL-hff" secondAttribute="bottom" constant="5" id="Ilt-ab-dEa"/>
+                                        <constraint firstItem="vX2-5Y-rQc" firstAttribute="top" secondItem="7OO-nL-hff" secondAttribute="bottom" constant="50" id="LTk-s1-SEs"/>
+                                        <constraint firstItem="7OO-nL-hff" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" constant="11" id="Otw-gC-R6C"/>
                                         <constraint firstItem="vX2-5Y-rQc" firstAttribute="top" secondItem="Gg0-TE-OGb" secondAttribute="top" priority="100" id="QSG-jB-VcV"/>
-                                        <constraint firstItem="wEJ-AF-rdH" firstAttribute="centerY" secondItem="k3J-Eg-itz" secondAttribute="centerY" id="Vze-EI-oXj"/>
-                                        <constraint firstAttribute="trailing" secondItem="k3J-Eg-itz" secondAttribute="trailing" constant="11" id="ZyA-Tq-Sfq"/>
-                                        <constraint firstItem="k3J-Eg-itz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gg0-TE-OGb" secondAttribute="leading" constant="150" id="bEB-EO-b14"/>
-                                        <constraint firstItem="vX2-5Y-rQc" firstAttribute="top" secondItem="k3J-Eg-itz" secondAttribute="bottom" constant="33" id="db7-2y-vPZ"/>
-                                        <constraint firstItem="AJ2-lJ-NUq" firstAttribute="centerY" secondItem="k3J-Eg-itz" secondAttribute="centerY" id="dcE-Vs-7Rt"/>
+                                        <constraint firstItem="7OO-nL-hff" firstAttribute="top" secondItem="Gg0-TE-OGb" secondAttribute="top" constant="33" id="e4H-ld-bD7"/>
                                         <constraint firstAttribute="trailing" secondItem="FIn-2w-e6H" secondAttribute="trailing" id="kFj-6g-v3H"/>
                                         <constraint firstItem="vX2-5Y-rQc" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" id="kYN-Lj-zYP"/>
                                         <constraint firstAttribute="height" priority="700" constant="300" id="lXv-gM-CjN"/>
-                                        <constraint firstItem="k3J-Eg-itz" firstAttribute="top" secondItem="Gg0-TE-OGb" secondAttribute="top" constant="33" id="mor-t9-7Ke"/>
-                                        <constraint firstItem="FIn-2w-e6H" firstAttribute="top" secondItem="k3J-Eg-itz" secondAttribute="bottom" constant="5" id="oTS-5o-MMW"/>
-                                        <constraint firstItem="wEJ-AF-rdH" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" constant="11" id="sax-RY-aOJ"/>
-                                        <constraint firstItem="AJ2-lJ-NUq" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" constant="19" id="xFm-Bs-yzw"/>
+                                        <constraint firstAttribute="trailing" secondItem="7OO-nL-hff" secondAttribute="trailing" constant="11" id="pPK-AD-wiD"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TjK-XL-dQS">

--- a/changelog.d/5875.bugfix
+++ b/changelog.d/5875.bugfix
@@ -1,0 +1,1 @@
+Authentication: Ensure the login button is always visible


### PR DESCRIPTION
Fixes #5875

Ensure that login / register button is always visible by separating the button and "forgot password" onto two separate lines.

| Before | After |
|--------|------|
| ![159138005-7b7d6925-6042-4f69-a411-a0413e81f522](https://user-images.githubusercontent.com/3922159/159474755-0d39609f-e07a-4608-917a-0d79176301ad.jpeg) | ![Simulator Screen Shot - iPhone 13 - 2022-03-22 at 11 29 30](https://user-images.githubusercontent.com/3922159/159474879-38534c44-2a44-402d-b11d-5e74622ae4bc.png) |

The constraints in the xib file are quite messy so I just embedded the main 3 components (submit, skip, forgotten button) into stack views and replicating the existing distances. Below are a number of different views to make sure there are no collisions

| Login | Register | With Skip | Double length |
|-------|---------|-----------|---------------|
| ![Simulator Screen Shot - iPhone 13 - 2022-03-22 at 11 29 30](https://user-images.githubusercontent.com/3922159/159475218-25d45a6b-21dc-48a6-9870-7d777f902347.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-22 at 11 29 33](https://user-images.githubusercontent.com/3922159/159475288-a73fbbd1-7536-4fd0-971a-0edcec7d238c.png) |  ![Simulator Screen Shot - iPhone 13 - 2022-03-22 at 11 31 26](https://user-images.githubusercontent.com/3922159/159475360-0e580368-4c27-4086-83db-4f510f6b55ee.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-22 at 11 32 07](https://user-images.githubusercontent.com/3922159/159475495-9faac0d9-b10b-4c8c-b5da-5fb276361b20.png) |

| iPad login | iPad register | Small login | Small register |
|-----------|--------------|------------|---------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-03-22 at 11 36 47](https://user-images.githubusercontent.com/3922159/159475630-78770b98-0549-4961-9319-5bf606b39d18.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-03-22 at 11 36 57](https://user-images.githubusercontent.com/3922159/159475657-5264d9ff-869a-4237-b496-92ff574c234f.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-22 at 11 42 10](https://user-images.githubusercontent.com/3922159/159475698-f6b2e9dd-8440-4cda-a3b9-7e7a48c705bf.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2022-03-22 at 11 42 12](https://user-images.githubusercontent.com/3922159/159475715-60042587-8ed7-4906-94a4-83f7a26e229b.png) |

