### PR TITLE
Prevent crash when searching for rooms

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.h
+++ b/Riot/Modules/Application/LegacyAppDelegate.h
@@ -231,14 +231,6 @@ UINavigationControllerDelegate
  Process the fragment part of a vector.im link.
 
  @param fragment the fragment part of the universal link.
- @return YES in case of processing success.
- */
-- (BOOL)handleUniversalLinkFragment:(NSString*)fragment;
-
-/**
- Process the fragment part of a vector.im link.
-
- @param fragment the fragment part of the universal link.
  @param universalLinkURL the unprocessed the universal link URL (optional).
  @return YES in case of processing success.
  */

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1263,12 +1263,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     return [self handleUniversalLinkFragment:webURL.fragment fromURL:webURL];
 }
 
-- (BOOL)handleUniversalLinkFragment:(NSString*)fragment
-{
-    return [self handleUniversalLinkFragment:fragment fromURL:nil];
-}
-
-
 - (BOOL)handleUniversalLinkFragment:(NSString*)fragment fromURL:(NSURL*)universalLinkURL
 
 {

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1564,7 +1564,8 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         {
             // Open the room or preview it
             NSString *fragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:roomIdOrAlias]];
-            [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
+            NSURL *url = [NSURL URLWithString:[MXTools permalinkToRoom:fragment]];
+            [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromURL:url];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:NO];
     }

--- a/Riot/Modules/Communities/Home/GroupHomeViewController.m
+++ b/Riot/Modules/Communities/Home/GroupHomeViewController.m
@@ -890,7 +890,7 @@
         // Open the group or preview it
         NSString *fragment = [NSString stringWithFormat:@"/group/%@",
                         [MXTools encodeURIComponent:absoluteURLString]];
-        [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
+        [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromURL:URL];
     }
     
     return shouldInteractWithURL;

--- a/Riot/Modules/DeepLink/UniversalLinkParameters.swift
+++ b/Riot/Modules/DeepLink/UniversalLinkParameters.swift
@@ -23,7 +23,7 @@ class UniversalLinkParameters: NSObject {
     // MARK: - Properties
         
     /// The unprocessed the universal link URL
-    let universalLinkURL: URL
+    let universalLinkURL: URL?
     
     /// The fragment part of the universal link
     let fragment: String
@@ -34,7 +34,7 @@ class UniversalLinkParameters: NSObject {
     // MARK: - Setup
     
     init(fragment: String,
-         universalLinkURL: URL,
+         universalLinkURL: URL?,
          presentationParameters: ScreenPresentationParameters) {
         self.fragment = fragment
         self.universalLinkURL = universalLinkURL

--- a/Riot/Modules/DeepLink/UniversalLinkParameters.swift
+++ b/Riot/Modules/DeepLink/UniversalLinkParameters.swift
@@ -22,7 +22,7 @@ class UniversalLinkParameters: NSObject {
         
     // MARK: - Properties
         
-    /// The unprocessed the universal link URL
+    /// The unprocessed universal link URL
     let universalLinkURL: URL?
     
     /// The fragment part of the universal link

--- a/Riot/Modules/DeepLink/UniversalLinkParameters.swift
+++ b/Riot/Modules/DeepLink/UniversalLinkParameters.swift
@@ -23,7 +23,7 @@ class UniversalLinkParameters: NSObject {
     // MARK: - Properties
         
     /// The unprocessed universal link URL
-    let universalLinkURL: URL?
+    let universalLinkURL: URL
     
     /// The fragment part of the universal link
     let fragment: String
@@ -34,7 +34,7 @@ class UniversalLinkParameters: NSObject {
     // MARK: - Setup
     
     init(fragment: String,
-         universalLinkURL: URL?,
+         universalLinkURL: URL,
          presentationParameters: ScreenPresentationParameters) {
         self.fragment = fragment
         self.universalLinkURL = universalLinkURL

--- a/changelog.d/5883.bugfix
+++ b/changelog.d/5883.bugfix
@@ -1,0 +1,2 @@
+Search: prevent crash when searching for rooms
+


### PR DESCRIPTION
Fixes #5883 

Apparently a deeplink can be opened with only a fragment and no url, as seen for example [here](https://github.com/vector-im/element-ios/blob/96c3ed8df300be5fd743eb0cf6a832644b0ee976/Riot/Modules/Application/LegacyAppDelegate.m#L1268). This means that the `UniversalLinkParameters` must be able to accept nil urls by design. Otherwise the obj-c code may inject nil value (compiler does not prevent obj-c passing nil value to non-nil swift code) and the app crashes.