### PR TITLE
Allow empty Jitsi default url in BuildSettings

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -206,6 +206,7 @@ final class BuildSettings: NSObject {
     ]
     // Jitsi server used outside integrations to create conference calls from the call button in the timeline.
     // Setting this to nil effectively disables Jitsi conference calls (given that there is no wellknown override).
+    // Note: this will not remove the conference call button, use roomScreenAllowVoIPForNonDirectRoom setting.
     static let jitsiServerUrl: URL? = URL(string: "https://jitsi.riot.im")
 
     

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -204,8 +204,9 @@ final class BuildSettings: NSObject {
         "https://scalar-staging.vector.im/api",
         "https://scalar-staging.riot.im/scalar/api",
     ]
-    // Jitsi server used outside integrations to create conference calls from the call button in the timeline
-    static let jitsiServerUrl: URL = URL(string: "https://jitsi.riot.im")!
+    // Jitsi server used outside integrations to create conference calls from the call button in the timeline.
+    // Setting this to nil effectively disables Jitsi conference calls (given that there is no wellknown override).
+    static let jitsiServerUrl: URL? = URL(string: "https://jitsi.riot.im")
 
     
     // MARK: - Features

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1028,6 +1028,7 @@ Tap the + to start adding people.";
 "call_incoming_video" = "Incoming video call…";
 "call_already_displayed" = "There is already a call in progress.";
 "call_jitsi_error" = "Failed to join the conference call.";
+"call_jitsi_unable_to_start" = "Unable to start conference call";
 
 "call_no_stun_server_error_title" ="Call failed due to misconfigured server";
 "call_no_stun_server_error_message_1" ="Please ask the administrator of your homeserver %@ to configure a TURN server in order for calls to work reliably.";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -687,6 +687,10 @@ public class VectorL10n: NSObject {
   public static var callJitsiError: String { 
     return VectorL10n.tr("Vector", "call_jitsi_error") 
   }
+  /// Unable to start conference call
+  public static var callJitsiUnableToStart: String { 
+    return VectorL10n.tr("Vector", "call_jitsi_unable_to_start") 
+  }
   /// Device Speaker
   public static var callMoreActionsAudioUseDevice: String { 
     return VectorL10n.tr("Vector", "call_more_actions_audio_use_device") 

--- a/Riot/Managers/Widgets/WidgetManager.h
+++ b/Riot/Managers/Widgets/WidgetManager.h
@@ -42,7 +42,8 @@ typedef enum : NSUInteger
     WidgetManagerErrorCodeNoIntegrationsServerConfigured,
     WidgetManagerErrorCodeDisabledIntegrationsServer,
     WidgetManagerErrorCodeFailedToConnectToIntegrationsServer,
-    WidgetManagerErrorCodeTermsNotSigned
+    WidgetManagerErrorCodeTermsNotSigned,
+    WidgetManagerErrorCodeUnavailableJitsiURL
 }
 WidgetManagerErrorCode;
 

--- a/Riot/Managers/Widgets/WidgetManager.m
+++ b/Riot/Managers/Widgets/WidgetManager.m
@@ -278,6 +278,13 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     NSString *widgetId = [NSString stringWithFormat:@"%@_%@_%@", kWidgetTypeJitsiV1, room.mxSession.myUser.userId, @((uint64_t)([[NSDate date] timeIntervalSince1970] * 1000))];
     
     NSURL *preferredJitsiServerUrl = [room.mxSession vc_homeserverConfiguration].jitsi.serverURL;
+    
+    if (!preferredJitsiServerUrl)
+    {
+        MXLogDebug(@"[WidgetManager] createJitsiWidgetInRoom: Error: No Jitsi server URL provided");
+        failure(self.errorForUnavailableJitsiURL);
+        return nil;
+    }
 
     JitsiService *jitsiService = JitsiService.shared;
     
@@ -805,6 +812,13 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     return [NSError errorWithDomain:WidgetManagerErrorDomain
                                code:WidgetManagerErrorCodeDisabledIntegrationsServer
                            userInfo:@{NSLocalizedDescriptionKey: [VectorL10n widgetIntegrationManagerDisabled]}];
+}
+
+- (NSError*)errorForUnavailableJitsiURL
+{
+    return [NSError errorWithDomain:WidgetManagerErrorDomain
+                               code:WidgetManagerErrorCodeUnavailableJitsiURL
+                           userInfo:@{NSLocalizedDescriptionKey: VectorL10n.callJitsiUnableToStart}];
 }
 
 @end

--- a/Riot/Model/HomeserverConfiguration/HomeserverConfigurationBuilder.swift
+++ b/Riot/Model/HomeserverConfiguration/HomeserverConfigurationBuilder.swift
@@ -54,18 +54,15 @@ final class HomeserverConfigurationBuilder: NSObject {
                                                                         secureBackupSetupMethods: secureBackupSetupMethods)
         
         // Jitsi configuration
-        let jitsiPreferredDomain: String
-        let jitsiServerURL: URL
-        let hardcodedJitsiServerURL: URL = BuildSettings.jitsiServerUrl
+        let jitsiPreferredDomain: String?
+        let jitsiServerURL: URL?
+        let hardcodedJitsiServerURL: URL? = BuildSettings.jitsiServerUrl
         
         if let preferredDomain = vectorWellKnownJitsiConfiguration?.preferredDomain {
             jitsiPreferredDomain = preferredDomain
             jitsiServerURL = self.jitsiServerURL(from: preferredDomain) ?? hardcodedJitsiServerURL
         } else {
-            guard let hardcodedJitsiDomain = hardcodedJitsiServerURL.host else {
-                fatalError("[HomeserverConfigurationBuilder] Fail to get Jitsi domain from hardcoded Jitsi URL")
-            }
-            jitsiPreferredDomain = hardcodedJitsiDomain
+            jitsiPreferredDomain = hardcodedJitsiServerURL?.host
             jitsiServerURL = hardcodedJitsiServerURL
         }
         

--- a/Riot/Model/HomeserverConfiguration/HomeserverJitsiConfiguration.swift
+++ b/Riot/Model/HomeserverConfiguration/HomeserverJitsiConfiguration.swift
@@ -19,10 +19,10 @@ import Foundation
 /// `HomeserverJitsiConfiguration` gives Jitsi widget configuration used by homeserver
 @objcMembers
 final class HomeserverJitsiConfiguration: NSObject {
-    let serverDomain: String
-    let serverURL: URL
+    let serverDomain: String?
+    let serverURL: URL?
     
-    init(serverDomain: String, serverURL: URL) {
+    init(serverDomain: String?, serverURL: URL?) {
         self.serverDomain = serverDomain
         self.serverURL = serverURL
         

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -476,9 +476,14 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
 #ifdef CALL_STACK_JINGLE
     // Setup Jitsi
-    [JitsiService.shared configureDefaultConferenceOptionsWith:BuildSettings.jitsiServerUrl];
+    NSURL *jitsiServerUrl = BuildSettings.jitsiServerUrl;
+    if (jitsiServerUrl)
+    {
+        [JitsiService.shared configureDefaultConferenceOptionsWith:jitsiServerUrl];
 
-    [JitsiService.shared application:application didFinishLaunchingWithOptions:launchOptions];
+        [JitsiService.shared application:application didFinishLaunchingWithOptions:launchOptions];
+    }
+
 #endif
     
     self.majorUpdateManager = [MajorUpdateManager new];

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -932,12 +932,17 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 
     NSString *title = [error.userInfo valueForKey:NSLocalizedFailureReasonErrorKey];
     NSString *msg = [error.userInfo valueForKey:NSLocalizedDescriptionKey];
+    NSString *localizedDescription = error.localizedDescription;
     if (!title)
     {
         if (msg)
         {
             title = msg;
             msg = nil;
+        }
+        else if (localizedDescription.length > 0)
+        {
+            title = localizedDescription;
         }
         else
         {

--- a/Riot/Modules/Integrations/Widgets/Jitsi/JitsiService.swift
+++ b/Riot/Modules/Integrations/Widgets/Jitsi/JitsiService.swift
@@ -143,31 +143,30 @@ final class JitsiService: NSObject {
         }
         
         return self.getWellKnown(for: jitsiServerURL) { (result) in
-            var continueOperation: Bool = false
-            var authType: JitsiAuthenticationType?
-            
+            func continueOperation(authType: JitsiAuthenticationType?) {
+                guard let widgetContent = self.createJitsiWidgetContent(serverDomain: serverDomain,
+                                                                        authenticationType: authType,
+                                                                        roomID: roomID,
+                                                                        isAudioOnly: isAudioOnly)
+                else {
+                    failure(JitsiServiceError.widgetContentCreationFailed)
+                    return
+                }
+                
+                success(widgetContent)
+            }
+                        
             switch result {
             case .success(let jitsiWellKnown):
-                authType = jitsiWellKnown.authenticationType
-                continueOperation = true
+                continueOperation(authType: jitsiWellKnown.authenticationType)
             case .failure(let error):
                 MXLog.debug("[JitsiService] Fail to get Jitsi Well Known with error: \(error)")
                 if let error = error as? JitsiServiceError, error == .noWellKnown {
                     //  no well-known, continue with no auth
-                    continueOperation = true
+                    continueOperation(authType: nil)
                 } else {
                     failure(error)
                 }
-            }
-            
-            if continueOperation,
-               let widgetContent = self.createJitsiWidgetContent(serverDomain: serverDomain,
-                                                                 authenticationType: authType,
-                                                                 roomID: roomID,
-                                                                 isAudioOnly: isAudioOnly) {
-                success(widgetContent)
-            } else {
-                failure(JitsiServiceError.widgetContentCreationFailed)
             }
         }
     }

--- a/Riot/Modules/Integrations/Widgets/Jitsi/JitsiService.swift
+++ b/Riot/Modules/Integrations/Widgets/Jitsi/JitsiService.swift
@@ -19,11 +19,15 @@ import Foundation
 #if canImport(JitsiMeetSDK)
 import JitsiMeetSDK
 
-enum JitsiServiceError: Error {
+enum JitsiServiceError: LocalizedError {
     case widgetContentCreationFailed
     case emptyResponse
     case noWellKnown
     case unknown
+    
+    var errorDescription: String? {
+        return VectorL10n.callJitsiUnableToStart
+    }
 }
 
 private enum HTTPStatusCodes {

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1611,7 +1611,8 @@ static CGSize kThreadListBarButtonItemImageSize;
     {
         return NO;
     }
-    BOOL callOptionAllowed = (self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForDirectRoom) || (!self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForNonDirectRoom);
+    BOOL callOptionAllowed = (self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForDirectRoom)
+    || (!self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForNonDirectRoom && self.mainSession.vc_homeserverConfiguration.jitsi.serverURL);
     return callOptionAllowed && BuildSettings.allowVoIPUsage && self.roomDataSource.mxSession.callManager && self.roomDataSource.room.summary.membersCount.joined >= 2;
 }
 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1611,8 +1611,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     {
         return NO;
     }
-    BOOL callOptionAllowed = (self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForDirectRoom)
-    || (!self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForNonDirectRoom && self.mainSession.vc_homeserverConfiguration.jitsi.serverURL);
+    BOOL callOptionAllowed = (self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForDirectRoom) || (!self.roomDataSource.room.isDirect && RiotSettings.shared.roomScreenAllowVoIPForNonDirectRoom);
     return callOptionAllowed && BuildSettings.allowVoIPUsage && self.roomDataSource.mxSession.callManager && self.roomDataSource.room.summary.membersCount.joined >= 2;
 }
 

--- a/RiotTests/HomeserverConfigurationTests.swift
+++ b/RiotTests/HomeserverConfigurationTests.swift
@@ -74,7 +74,7 @@ class HomeserverConfigurationTests: XCTestCase {
         let homeserverConfiguration = homeserverConfigurationBuilder.build(from: wellKnown)
     
         XCTAssertEqual(homeserverConfiguration.jitsi.serverDomain, expectedJitsiServer)
-        XCTAssertEqual(homeserverConfiguration.jitsi.serverURL.absoluteString, expectedJitsiServerStringURL)
+        XCTAssertEqual(homeserverConfiguration.jitsi.serverURL?.absoluteString, expectedJitsiServerStringURL)
         XCTAssertEqual(homeserverConfiguration.encryption.isE2EEByDefaultEnabled, expectedE2EEEByDefaultEnabled)
         XCTAssertEqual(homeserverConfiguration.encryption.isSecureBackupRequired, expectedSecureBackupRequired)
         XCTAssertEqual(homeserverConfiguration.encryption.secureBackupSetupMethods, expectedSecureBackupSetupMethods)

--- a/changelog.d/5837.change
+++ b/changelog.d/5837.change
@@ -1,0 +1,1 @@
+Allow empty Jitsi default URL in BuildConfig

--- a/changelog.d/5837.change
+++ b/changelog.d/5837.change
@@ -1,1 +1,1 @@
-Allow empty Jitsi default URL in BuildConfig
+Allow empty Jitsi default URL in BuildSettings


### PR DESCRIPTION
Fixes #5837 

This allows to remove default Jitsi URL from BuildSettings.