### PR TITLE
Restrict UI components on authentication screen to readable width

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -56,7 +56,7 @@
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="interactive" translatesAutoresizingMaskIntoConstraints="NO" id="OHV-KQ-Ww0">
                     <rect key="frame" x="0.0" y="44" width="375" height="768"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rhx-dD-4EJ" userLabel="Content View">
+                        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rhx-dD-4EJ" userLabel="Content View">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="485"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="horizontal_logo" translatesAutoresizingMaskIntoConstraints="NO" id="d8r-TX-pwX" userLabel="Welcome Image View">
@@ -417,21 +417,21 @@ Clear it if you're finished using this device, or want to sign in to another acc
                             <accessibility key="accessibilityConfiguration" identifier="AuthContentView"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="485" id="6v6-fz-e8o"/>
-                                <constraint firstItem="Gg0-TE-OGb" firstAttribute="width" secondItem="rhx-dD-4EJ" secondAttribute="width" id="EBX-KN-pRT"/>
-                                <constraint firstItem="TjK-XL-dQS" firstAttribute="leading" secondItem="rhx-dD-4EJ" secondAttribute="leading" id="MId-fr-A7b"/>
+                                <constraint firstItem="TjK-XL-dQS" firstAttribute="leading" secondItem="rhx-dD-4EJ" secondAttribute="leadingMargin" id="MId-fr-A7b"/>
                                 <constraint firstAttribute="bottom" secondItem="TjK-XL-dQS" secondAttribute="bottom" id="PKr-aT-3Qe"/>
                                 <constraint firstItem="TjK-XL-dQS" firstAttribute="top" secondItem="Gg0-TE-OGb" secondAttribute="bottom" id="Sfy-Zn-JkS"/>
                                 <constraint firstItem="Gg0-TE-OGb" firstAttribute="top" secondItem="rhx-dD-4EJ" secondAttribute="top" priority="250" constant="384" id="UEM-Mh-0H9"/>
-                                <constraint firstItem="xWb-IJ-v7F" firstAttribute="leading" secondItem="rhx-dD-4EJ" secondAttribute="leading" id="YnP-Nk-QxR"/>
+                                <constraint firstItem="xWb-IJ-v7F" firstAttribute="leading" secondItem="rhx-dD-4EJ" secondAttribute="leadingMargin" id="YnP-Nk-QxR"/>
                                 <constraint firstItem="Gg0-TE-OGb" firstAttribute="top" secondItem="xWb-IJ-v7F" secondAttribute="bottom" id="aGH-m3-xL3"/>
-                                <constraint firstAttribute="trailing" secondItem="TjK-XL-dQS" secondAttribute="trailing" id="d1j-OA-Wwm"/>
-                                <constraint firstAttribute="trailing" secondItem="xWb-IJ-v7F" secondAttribute="trailing" id="hko-ol-XDd"/>
+                                <constraint firstAttribute="trailingMargin" secondItem="TjK-XL-dQS" secondAttribute="trailing" id="d1j-OA-Wwm"/>
+                                <constraint firstAttribute="trailingMargin" secondItem="xWb-IJ-v7F" secondAttribute="trailing" id="hko-ol-XDd"/>
                                 <constraint firstItem="xWb-IJ-v7F" firstAttribute="top" secondItem="rhx-dD-4EJ" secondAttribute="top" constant="160" id="khR-Uj-OTH"/>
                                 <constraint firstItem="d8r-TX-pwX" firstAttribute="top" secondItem="rhx-dD-4EJ" secondAttribute="top" constant="35" id="l68-Ta-YKg"/>
                                 <constraint firstAttribute="centerX" secondItem="d8r-TX-pwX" secondAttribute="centerX" id="l6k-EH-Yb8"/>
-                                <constraint firstItem="Gg0-TE-OGb" firstAttribute="leading" secondItem="rhx-dD-4EJ" secondAttribute="leading" id="rS3-go-zbf"/>
-                                <constraint firstItem="TjK-XL-dQS" firstAttribute="width" secondItem="rhx-dD-4EJ" secondAttribute="width" id="zIZ-fl-i3i"/>
+                                <constraint firstItem="Gg0-TE-OGb" firstAttribute="leading" secondItem="rhx-dD-4EJ" secondAttribute="leadingMargin" id="rS3-go-zbf"/>
+                                <constraint firstAttribute="trailingMargin" secondItem="Gg0-TE-OGb" secondAttribute="trailing" id="umc-1H-5ho"/>
                             </constraints>
+                            <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                         </view>
                     </subviews>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/changelog.d/5898.change
+++ b/changelog.d/5898.change
@@ -1,0 +1,1 @@
+Restrict UI components on authentication screen to readable width


### PR DESCRIPTION
### Changes

- Make layout margins on content view follow readable width
- Set zero edge insets on content view
- Constrain all subviews of content view to leading & trailing layout margins of superview

Fixes: #5898

### Screenshots (before)

![pad-landscape-before](https://user-images.githubusercontent.com/1137962/159779210-63b4ae7a-aa89-47cd-aebe-a1ec321be310.png)
![pad-portrait-before](https://user-images.githubusercontent.com/1137962/159779316-632bc537-6927-4962-9c23-2e762f402b2c.png)
![phone-portrait-before](https://user-images.githubusercontent.com/1137962/159779322-4e4864c0-1613-4b00-996e-11b1640cd6ba.png)

### Screenshots (after)

![pad-landscape-after](https://user-images.githubusercontent.com/1137962/159779297-4ccfe7d3-7b5e-49ee-afa7-e7b06c8f25a9.png)
![pad-portrait-after](https://user-images.githubusercontent.com/1137962/159779310-9a49ea18-f4b2-42d3-b2e3-0d0828e97628.png)
![phone-portrait-after](https://user-images.githubusercontent.com/1137962/159779319-caae9f61-81d8-44f6-8d32-04bf107cec25.png)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
