### PR TITLE
Remove unused Bindings in RoundedBorderTextField/Editor.

### DIFF
--- a/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextEditor.swift
+++ b/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextEditor.swift
@@ -21,14 +21,14 @@ struct RoundedBorderTextEditor: View {
     
     // MARK: - Properties
     
-    var title: String?
-    var placeHolder: String
+    var title: String? = nil
+    let placeHolder: String
     @Binding var text: String
-    var textMaxHeight: CGFloat?
-    @Binding var error: String?
+    var textMaxHeight: CGFloat? = nil
+    var error: String? = nil
     
-    var onTextChanged: ((String) -> Void)?
-    var onEditingChanged: ((Bool) -> Void)?
+    var onTextChanged: ((String) -> Void)? = nil
+    var onEditingChanged: ((Bool) -> Void)? = nil
 
     @State private var editing = false
     
@@ -36,24 +36,6 @@ struct RoundedBorderTextEditor: View {
     
     @Environment(\.theme) private var theme: ThemeSwiftUI
     @Environment(\.isEnabled) private var isEnabled
-    
-    // MARK: Setup
-    
-    init(title: String? = nil,
-         placeHolder: String,
-         text: Binding<String>,
-         textMaxHeight: CGFloat? = nil,
-         error: Binding<String?> = .constant(nil),
-         onTextChanged: ((String) -> Void)? = nil,
-         onEditingChanged: ((Bool) -> Void)? = nil) {
-        self.title = title
-        self.placeHolder = placeHolder
-        self._text = text
-        self.textMaxHeight = textMaxHeight
-        self._error = error
-        self.onTextChanged = onTextChanged
-        self.onEditingChanged = onEditingChanged
-    }
     
     // MARK: Public
     
@@ -131,10 +113,10 @@ struct ThemableTextEditor_Previews: PreviewProvider {
     
     static var sampleView: some View {
         VStack(alignment: .center, spacing: 40) {
-            RoundedBorderTextEditor(title: "A title", placeHolder: "A placeholder", text: .constant(""), error: .constant(nil))
-            RoundedBorderTextEditor(placeHolder: "A placeholder", text: .constant("Some text"), error: .constant(nil))
-            RoundedBorderTextEditor(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), error: .constant("Some error text"))
-            RoundedBorderTextEditor(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), error: .constant("Some error text"))
+            RoundedBorderTextEditor(title: "A title", placeHolder: "A placeholder", text: .constant(""), error: nil)
+            RoundedBorderTextEditor(placeHolder: "A placeholder", text: .constant("Some text"), error: nil)
+            RoundedBorderTextEditor(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), error: "Some error text")
+            RoundedBorderTextEditor(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), error: "Some error text")
                 .disabled(true)
         }
     }

--- a/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextField.swift
+++ b/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextField.swift
@@ -22,17 +22,17 @@ struct RoundedBorderTextField: View {
     
     // MARK: - Properties
     
-    var title: String?
-    var placeHolder: String
+    var title: String? = nil
+    let placeHolder: String
     @Binding var text: String
-    @Binding var footerText: String?
-    @Binding var isError: Bool
+    var footerText: String? = nil
+    var isError: Bool = false
     var isFirstResponder = false
 
     var configuration: UIKitTextInputConfiguration = UIKitTextInputConfiguration()
     
-    var onTextChanged: ((String) -> Void)?
-    var onEditingChanged: ((Bool) -> Void)?
+    var onTextChanged: ((String) -> Void)? = nil
+    var onEditingChanged: ((Bool) -> Void)? = nil
 
     // MARK: Private
     
@@ -40,28 +40,6 @@ struct RoundedBorderTextField: View {
     
     @Environment(\.theme) private var theme: ThemeSwiftUI
     @Environment(\.isEnabled) private var isEnabled
-
-    // MARK: Setup
-    
-    init(title: String? = nil,
-         placeHolder: String,
-         text: Binding<String>,
-         footerText: Binding<String?> = .constant(nil),
-         isError: Binding<Bool> = .constant(false),
-         isFirstResponder: Bool = false,
-         configuration: UIKitTextInputConfiguration = UIKitTextInputConfiguration(),
-         onTextChanged: ((String) -> Void)? = nil,
-         onEditingChanged: ((Bool) -> Void)? = nil) {
-        self.title = title
-        self.placeHolder = placeHolder
-        self._text = text
-        self._footerText = footerText
-        self._isError = isError
-        self.isFirstResponder = isFirstResponder
-        self.configuration = configuration
-        self.onTextChanged = onTextChanged
-        self.onEditingChanged = onEditingChanged
-    }
     
     // MARK: Public
     
@@ -139,11 +117,11 @@ struct TextFieldWithError_Previews: PreviewProvider {
     
     static var sampleView: some View {
         VStack(alignment: .center, spacing: 20) {
-            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant(""), footerText: .constant(nil), isError: .constant(false))
-            RoundedBorderTextField(placeHolder: "A placeholder", text: .constant("Some text"), footerText: .constant(nil), isError: .constant(false))
-            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), footerText: .constant("Some error text"), isError: .constant(true))
-            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), footerText: .constant("Some normal text"), isError: .constant(false))
-            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), footerText: .constant("Some normal text"), isError: .constant(false))
+            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant(""), footerText: nil, isError: false)
+            RoundedBorderTextField(placeHolder: "A placeholder", text: .constant("Some text"), footerText: nil, isError: false)
+            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), footerText: "Some error text", isError: true)
+            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), footerText: "Some normal text", isError: false)
+            RoundedBorderTextField(title: "A title", placeHolder: "A placeholder", text: .constant("Some very long text used to check overlapping with the delete button"), footerText: "Some normal text", isError: false)
                 .disabled(true)
         }
     }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/View/SpaceCreationEmailInvites.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/View/SpaceCreationEmailInvites.swift
@@ -87,7 +87,7 @@ struct SpaceCreationEmailInvites: View {
         VStack {
             VStack(spacing: 20) {
                 ForEach(viewModel.emailInvites.indices) { index in
-                    RoundedBorderTextField(title: VectorL10n.spacesCreationEmailInvitesEmailTitle, placeHolder: VectorL10n.spacesCreationEmailInvitesEmailTitle, text: $viewModel.emailInvites[index], footerText: .constant(viewModel.viewState.emailAddressesValid[index] ? nil : VectorL10n.authInvalidEmail), isError: .constant(!viewModel.viewState.emailAddressesValid[index]), configuration: UIKitTextInputConfiguration(keyboardType: .emailAddress, returnKeyType: index < viewModel.emailInvites.endIndex - 1 ? .next : .done, autocapitalizationType: .none, autocorrectionType: .no))
+                    RoundedBorderTextField(title: VectorL10n.spacesCreationEmailInvitesEmailTitle, placeHolder: VectorL10n.spacesCreationEmailInvitesEmailTitle, text: $viewModel.emailInvites[index], footerText: viewModel.viewState.emailAddressesValid[index] ? nil : VectorL10n.authInvalidEmail, isError: !viewModel.viewState.emailAddressesValid[index], configuration: UIKitTextInputConfiguration(keyboardType: .emailAddress, returnKeyType: index < viewModel.emailInvites.endIndex - 1 ? .next : .done, autocapitalizationType: .none, autocorrectionType: .no))
                         .accessibility(identifier: "emailTextField")
                 }
             }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/View/SpaceCreationSettings.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/View/SpaceCreationSettings.swift
@@ -104,13 +104,13 @@ struct SpaceCreationSettings: View {
                         Spacer()
                         avatarView
                         Spacer().frame(height:40)
-                        RoundedBorderTextField(title: VectorL10n.createRoomPlaceholderName, placeHolder: "", text: $viewModel.roomName, footerText: .constant(viewModel.viewState.roomNameError), isError: .constant(true), isFirstResponder: false, configuration: UIKitTextInputConfiguration( returnKeyType: .next), onTextChanged: { newText in
+                        RoundedBorderTextField(title: VectorL10n.createRoomPlaceholderName, placeHolder: "", text: $viewModel.roomName, footerText: viewModel.viewState.roomNameError, isError: true, isFirstResponder: false, configuration: UIKitTextInputConfiguration( returnKeyType: .next), onTextChanged: { newText in
                             viewModel.send(viewAction: .nameChanged(newText))
                         })
                         .id("nameTextField")
                         .padding(.horizontal, 2)
                         .padding(.bottom, 20)
-                        RoundedBorderTextEditor(title: nil, placeHolder: VectorL10n.spaceTopic, text: $viewModel.topic, textMaxHeight: 72, error: .constant(nil), onTextChanged:  {
+                        RoundedBorderTextEditor(title: nil, placeHolder: VectorL10n.spaceTopic, text: $viewModel.topic, textMaxHeight: 72, error: nil, onTextChanged:  {
                             newText in
                             viewModel.send(viewAction: .topicChanged(newText))
                         }, onEditingChanged: { editing in
@@ -122,7 +122,7 @@ struct SpaceCreationSettings: View {
                         .padding(.horizontal, 2)
                         .padding(.bottom, viewModel.viewState.showRoomAddress ? 20 : 3)
                         if viewModel.viewState.showRoomAddress {
-                            RoundedBorderTextField(title: VectorL10n.spacesCreationAddress, placeHolder: "# \(viewModel.viewState.defaultAddress)", text: $viewModel.address, footerText: .constant(viewModel.viewState.addressMessage), isError: .constant(!viewModel.viewState.isAddressValid), configuration: UIKitTextInputConfiguration(keyboardType: .URL, returnKeyType: .done, autocapitalizationType: .none), onTextChanged:  {
+                            RoundedBorderTextField(title: VectorL10n.spacesCreationAddress, placeHolder: "# \(viewModel.viewState.defaultAddress)", text: $viewModel.address, footerText: viewModel.viewState.addressMessage, isError: !viewModel.viewState.isAddressValid, configuration: UIKitTextInputConfiguration(keyboardType: .URL, returnKeyType: .done, autocapitalizationType: .none), onTextChanged:  {
                                 newText in
                                 viewModel.send(viewAction: .addressChanged(newText))
                             })

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/View/SpaceSettings.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/View/SpaceSettings.swift
@@ -116,8 +116,8 @@ struct SpaceSettings: View {
                 title: VectorL10n.createRoomPlaceholderName,
                 placeHolder: "",
                 text: $viewModel.name,
-                footerText: .constant(viewModel.viewState.roomNameError),
-                isError: .constant(true),
+                footerText: viewModel.viewState.roomNameError,
+                isError: true,
                 configuration: UIKitTextInputConfiguration( returnKeyType: .next))
                 .padding(.horizontal, 2)
                 .padding(.bottom, 20)
@@ -127,7 +127,7 @@ struct SpaceSettings: View {
                 placeHolder: VectorL10n.spaceTopic,
                 text: $viewModel.topic,
                 textMaxHeight: 72,
-                error: .constant(nil))
+                error: nil)
                 .padding(.horizontal, 2)
                 .padding(.bottom, viewModel.viewState.showRoomAddress ? 20 : 3)
                 .disabled(viewModel.viewState.roomProperties?.isTopicEditable != true)
@@ -136,8 +136,8 @@ struct SpaceSettings: View {
                     title: VectorL10n.spacesCreationAddress,
                     placeHolder: "# \(viewModel.viewState.defaultAddress)",
                     text: $viewModel.address,
-                    footerText: .constant(viewModel.viewState.addressMessage),
-                    isError: .constant(!viewModel.viewState.isAddressValid),
+                    footerText: viewModel.viewState.addressMessage,
+                    isError: !viewModel.viewState.isAddressValid,
                     configuration: UIKitTextInputConfiguration(keyboardType: .URL, returnKeyType: .done, autocapitalizationType: .none), onTextChanged:  {
                         newText in
                         viewModel.send(viewAction: .addressChanged(newText))

--- a/changelog.d/pr-5910.api
+++ b/changelog.d/pr-5910.api
@@ -1,0 +1,1 @@
+Remove unused Bindings in RoundedBorderTextField/Editor


### PR DESCRIPTION
These Bindings were only ever read and never mutated so regular properties are cleaner here.

Additionally I removed the explicit `init` as the synthesised init does everything we need (but happy to revert that if preferred).