### PR TITLE
Fix typing performance by avoiding expensive UI operations

### DIFF
--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -1043,6 +1043,10 @@
 
 - (void)setRoomTitleViewClass:(Class)roomTitleViewClass
 {
+    if ([self.titleView.class isEqual:roomTitleViewClass]) {
+        return;
+    }
+    
     // Sanity check: accept only MXKRoomTitleView classes or sub-classes
     NSParameterAssert([roomTitleViewClass isSubclassOfClass:MXKRoomTitleView.class]);
     

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -163,7 +163,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     BOOL isRoomLeft;
     
     // The last known frame of the view used to detect whether size-related layout change is needed
-    CGRect lastViewFrame;
+    CGRect lastViewBounds;
     
     // Tell whether the room has a Jitsi call or not.
     BOOL hasJitsiCall;
@@ -703,8 +703,8 @@ static CGSize kThreadListBarButtonItemImageSize;
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
-    BOOL didViewChangeFrame = !CGRectEqualToRect(lastViewFrame, self.view.frame);
-    lastViewFrame = self.view.frame;
+    BOOL didViewChangeBounds = !CGRectEqualToRect(lastViewBounds, self.view.bounds);
+    lastViewBounds = self.view.bounds;
     
     UIEdgeInsets contentInset = self.bubblesTableView.contentInset;
     contentInset.bottom = self.view.safeAreaInsets.bottom;
@@ -768,7 +768,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     }
     
     // re-scroll to the bottom, if at bottom before the most recent layout
-    if (self.wasScrollAtBottomBeforeLayout && didViewChangeFrame)
+    if (self.wasScrollAtBottomBeforeLayout && didViewChangeBounds)
     {
         self.wasScrollAtBottomBeforeLayout = NO;
         [self scrollBubblesTableViewToBottomAnimated:NO];

--- a/changelog.d/5906.bugfix
+++ b/changelog.d/5906.bugfix
@@ -1,0 +1,1 @@
+Room: Fix typing performance by avoiding expensive UI operations


### PR DESCRIPTION
Relates to #5906

## Root cause
There are a few things going on here, and all related to an insane amount of spaghetti layout code in RoomViewController. Often time a simple sounding method will internally call other less innocent code, escalating the performance cost This is what I observed:

1. On each `viewDidLayoutSubview` we will try to scroll back to the bottom, even if the size of the view has not really changed. The scrolling itself would be fine, but it is one of those methods that trigger a number of other heavy updates (e.g. `updateViewControllerAppearanceOnRoomDataSourceState`). Note that `viewDidLayoutSubview` is called every time you type a character, which means that when typing fast we are essentially doing all of this expensive work many times per second.
2. I think that a [recent change](https://github.com/vector-im/element-ios/pull/5803#discussion_r823878798) of calling `refreshRoomTitle` more often (I eat my words about no performance impact) has made this even worse, because `refreshRoomTitle` is one of those very long methods with ton of side effects that are not easy to see. This is I believe also why we started seeing this issue worse in the latest release.

## Solution
The solution to this is patchwork, because the code is too messy for a simple fix:
- do not scroll to the bottom of the room if the size of the view has not really changed
- do not commit to to `MXFileStore` after typing every single characted (see https://github.com/matrix-org/matrix-ios-sdk/pull/1422)
- do not recreate RoomTitleView unless the class has really changed.

Before my changes typing rapidly would consume around 33% of CPU on iPhone 13 Pro. After the changes it dropped to around 17%. We can certainly do more to bring this down.

I am not able to confirm yet whether this also solves the battery drain issue, but using CPU must be at least partly responsible for it.