### PR TITLE
Fix retain cycle in MXKRoomDataSource

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -1075,7 +1075,10 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     }
 
     // Register a listener to handle redaction which can affect live and past timelines
+    MXWeakify(self);
     redactionListener = [_timeline listenToEventsOfTypes:@[kMXEventTypeStringRoomRedaction] onEvent:^(MXEvent *redactionEvent, MXTimelineDirection direction, MXRoomState *roomState) {
+
+        MXStrongifyAndReturnIfNil(self);
 
         // Consider only live redaction events
         if (direction == MXTimelineDirectionForwards)

--- a/changelog.d/5058.bugfix
+++ b/changelog.d/5058.bugfix
@@ -1,0 +1,1 @@
+MXKRoomDataSource: Fix retain cycle


### PR DESCRIPTION
This is the first part of a fix for a triple-leak involving `MXKRoomDataSource`, `MXRoomEventTimeline` and `MXEventListener`. The second part can be found in matrix-org/matrix-ios-sdk#1424.

The concrete issue here is that `MXKRoomDataSource` stores an event listener in a strong property but captures `self` in the listener's `onEvent` block.

I haven't found concrete steps to reproduce the leak (and the memory graph debugger is also not 100% reliable) but the cycle frequently shows after having entered, left and posted in rooms a few times.

![Screenshot 2022-03-27 at 20 31 21](https://user-images.githubusercontent.com/1137962/160296505-1f4f1412-142c-4f4d-8d30-494e6643f585.png)

Relates to: #5058 

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)