### PR TITLE
Fixed the regular expression used for link detection in attributed strings

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/MXKTools.m
+++ b/Riot/Modules/MatrixKit/Utils/MXKTools.m
@@ -61,7 +61,7 @@ static NSRegularExpression *htmlTagsRegex;
         eventIdRegex = [NSRegularExpression regularExpressionWithPattern:kMXToolsRegexStringForMatrixEventIdentifier options:NSRegularExpressionCaseInsensitive error:nil];
         groupIdRegex = [NSRegularExpression regularExpressionWithPattern:kMXToolsRegexStringForMatrixGroupIdentifier options:NSRegularExpressionCaseInsensitive error:nil];
         
-        httpLinksRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\b(https?://.*)\\b" options:NSRegularExpressionCaseInsensitive error:nil];
+        httpLinksRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\b(https?://\\S*)\\b" options:NSRegularExpressionCaseInsensitive error:nil];
         htmlTagsRegex  = [NSRegularExpression regularExpressionWithPattern:@"<(\\w+)[^>]*>" options:NSRegularExpressionCaseInsensitive error:nil];        
     });
 }

--- a/changelog.d/pr-5926.bugfix
+++ b/changelog.d/pr-5926.bugfix
@@ -1,0 +1,1 @@
+Fixed the regular expression used for link detection in attributed strings.


### PR DESCRIPTION
How it looks like now:
![Screenshot 2022-03-28 at 10 10 18](https://user-images.githubusercontent.com/637564/160345527-39b78d2c-3052-4e8b-ac94-fe142ed2371d.png)

vs. web:
![Screenshot 2022-03-28 at 10 10 29](https://user-images.githubusercontent.com/637564/160345562-eb2e7b0f-0d31-4f18-b468-d56eb0240fc0.png)

vs after the fix:
![Screenshot 2022-03-28 at 10 11 53](https://user-images.githubusercontent.com/637564/160345585-636148f2-71c9-4606-be6c-a292bb5a9ee7.png)


