### PR TITLE
Enable joining a room via identifier from another home server

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1481,7 +1481,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                             // Ask the HS to resolve the room alias into a room id and then retry
                             self->universalLinkFragmentPending = fragment;
                             MXKAccount* account = accountManager.activeAccounts.firstObject;
-                            [account.mxSession.matrixRestClient roomIDForRoomAlias:roomIdOrAlias success:^(NSString *roomId) {
+                            [account.mxSession.matrixRestClient resolveRoomAlias:roomIdOrAlias success:^(MXRoomAliasResolution *resolution) {
                                 
                                 // Note: the activity indicator will not disappear if the session is not ready
                                 [homeViewController stopActivityIndicator];
@@ -1489,34 +1489,20 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                                 // Check that 'fragment' has not been cancelled
                                 if ([self->universalLinkFragmentPending isEqualToString:fragment])
                                 {
-                                    // Retry opening the link but with the returned room id
-                                    NSString *newUniversalLinkFragment =
-                                            [fragment stringByReplacingOccurrencesOfString:[MXTools encodeURIComponent:roomIdOrAlias]
-                                                                                withString:[MXTools encodeURIComponent:roomId]
-                                            ];
-                                    
-                                    // The previous operation can fail because of percent encoding
-                                    // TBH we are not clean on data inputs. For the moment, just give another try with no encoding
-                                    // TODO: Have a dedicated module and tests to handle universal links (matrix.to, email link, etc)
-                                    if ([newUniversalLinkFragment isEqualToString:fragment])
+                                    NSString *mewFragment = resolution.deeplinkFragment;
+                                    if (mewFragment && ![mewFragment isEqualToString:fragment])
                                     {
-                                        newUniversalLinkFragment =
-                                        [fragment stringByReplacingOccurrencesOfString:roomIdOrAlias
-                                                                            withString:[MXTools encodeURIComponent:roomId]];
-                                    }
-                                    
-                                    if (![newUniversalLinkFragment isEqualToString:fragment])
-                                    {
-                                        self->universalLinkFragmentPendingRoomAlias = @{roomId: roomIdOrAlias};
-                                        
-                                        UniversalLinkParameters *newParameters = [[UniversalLinkParameters alloc] initWithFragment:newUniversalLinkFragment universalLinkURL:universalLinkURL presentationParameters:presentationParameters];
-                                        
+                                        self->universalLinkFragmentPendingRoomAlias = @{resolution.roomId: roomIdOrAlias};
+
+                                        UniversalLinkParameters *newParameters = [[UniversalLinkParameters alloc] initWithFragment:mewFragment
+                                                                                                                  universalLinkURL:universalLinkURL
+                                                                                                            presentationParameters:presentationParameters];
                                         [self handleUniversalLinkWithParameters:newParameters];
                                     }
                                     else
                                     {
                                         // Do not continue. Else we will loop forever
-                                        MXLogDebug(@"[AppDelegate] Universal link: Error: Cannot resolve alias in %@ to the room id %@", fragment, roomId);
+                                        MXLogDebug(@"[AppDelegate] Universal link: Error: Cannot resolve alias in %@ to the room id %@", fragment, resolution.roomId);
                                     }
                                 }
                                 

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1489,12 +1489,12 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                                 // Check that 'fragment' has not been cancelled
                                 if ([self->universalLinkFragmentPending isEqualToString:fragment])
                                 {
-                                    NSString *mewFragment = resolution.deeplinkFragment;
-                                    if (mewFragment && ![mewFragment isEqualToString:fragment])
+                                    NSString *newFragment = resolution.deeplinkFragment;
+                                    if (newFragment && ![newFragment isEqualToString:fragment])
                                     {
                                         self->universalLinkFragmentPendingRoomAlias = @{resolution.roomId: roomIdOrAlias};
 
-                                        UniversalLinkParameters *newParameters = [[UniversalLinkParameters alloc] initWithFragment:mewFragment
+                                        UniversalLinkParameters *newParameters = [[UniversalLinkParameters alloc] initWithFragment:newFragment
                                                                                                                   universalLinkURL:universalLinkURL
                                                                                                             presentationParameters:presentationParameters];
                                         [self handleUniversalLinkWithParameters:newParameters];

--- a/Riot/Modules/Communities/Home/GroupHomeViewController.m
+++ b/Riot/Modules/Communities/Home/GroupHomeViewController.m
@@ -867,14 +867,13 @@
             __weak typeof(self) weakSelf = self;
             [self startActivityIndicator];
             
-            [self.mxSession.matrixRestClient roomIDForRoomAlias:roomIdOrAlias success:^(NSString *roomId) {
-                
+            [self.mxSession.matrixRestClient resolveRoomAlias:roomIdOrAlias success:^(MXRoomAliasResolution *resolution) {
                 if (roomId && weakSelf)
                 {
                     typeof(self) self = weakSelf;
                     
                     [self stopActivityIndicator];
-                    [self didSelectRoomId:roomId];
+                    [self didSelectRoomId:resolution.roomId];
                 }
                 
             } failure:^(NSError *error) {

--- a/Riot/Modules/DeepLink/MXRoomAliasResolution+Deeplink.swift
+++ b/Riot/Modules/DeepLink/MXRoomAliasResolution+Deeplink.swift
@@ -1,0 +1,38 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import MatrixSDK
+
+@objc extension MXRoomAliasResolution {
+    
+    /// Deeplink fragment using a room identifier and a list of servers aware of this identifier
+    ///
+    /// For more details see
+    /// https://github.com/matrix-org/matrix-spec-proposals/blob/old_master/proposals/1704-matrix.to-permalinks.md
+    var deeplinkFragment: String? {
+        guard let roomId = roomId else {
+            MXLog.debug("[MXRoomAliasResolution]: Missing room identifier")
+            return nil
+        }
+        
+        guard let servers = servers, !servers.isEmpty else {
+            return roomId
+        }
+        
+        return roomId + "?via=" + servers.joined(separator: "&via=")
+    }
+}

--- a/Riot/Modules/DeepLink/MXRoomAliasResolution+Deeplink.swift
+++ b/Riot/Modules/DeepLink/MXRoomAliasResolution+Deeplink.swift
@@ -29,10 +29,15 @@ import MatrixSDK
             return nil
         }
         
+        return MXTools.encodeURIComponent(
+            fragment(for: roomId)
+        )
+    }
+    
+    private func fragment(for roomId: String) -> String {
         guard let servers = servers, !servers.isEmpty else {
             return roomId
         }
-        
         return roomId + "?via=" + servers.joined(separator: "&via=")
     }
 }

--- a/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
+++ b/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
@@ -1,0 +1,56 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import Riot
+
+class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
+    func test_fragmentIsNilForInvalidResolution() {
+        let resolution = MXRoomAliasResolution()
+        XCTAssertNil(resolution.deeplinkFragment)
+    }
+    
+    func test_fragmentDoesNotContainServers_ifNoServers() {
+        let resolution = MXRoomAliasResolution()
+        resolution.roomId = "!abc:matrix.org"
+        
+        XCTAssertEqual(resolution.deeplinkFragment, "!abc:matrix.org")
+    }
+    
+    func test_fragmentContainsSingleServer() {
+        let resolution = MXRoomAliasResolution()
+        resolution.roomId = "xyz:element.io"
+        resolution.servers = [
+            "matrix.org"
+        ]
+        
+        XCTAssertEqual(resolution.deeplinkFragment, "xyz:element.io?via=matrix.org")
+    }
+    
+    func test_fragmentContainsMultipleSerivers() {
+        let resolution = MXRoomAliasResolution()
+        resolution.roomId = "mno:server.com"
+        resolution.servers = [
+            "server.com",
+            "element.io",
+            "wikipedia.org",
+            "matrix.org"
+        ]
+        
+        XCTAssertEqual(resolution.deeplinkFragment, "mno:server.com?via=server.com&via=element.io&via=wikipedia.org&via=matrix.org")
+    }
+}

--- a/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
+++ b/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
@@ -28,7 +28,7 @@ class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
         let resolution = MXRoomAliasResolution()
         resolution.roomId = "!abc:matrix.org"
         
-        XCTAssertEqual(resolution.deeplinkFragment, "!abc:matrix.org")
+        XCTAssertEqual(resolution.deeplinkFragment, "!abc%3Amatrix.org")
     }
     
     func test_fragmentContainsSingleServer() {
@@ -38,7 +38,7 @@ class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
             "matrix.org"
         ]
         
-        XCTAssertEqual(resolution.deeplinkFragment, "xyz:element.io?via=matrix.org")
+        XCTAssertEqual(resolution.deeplinkFragment, "xyz%3Aelement.io%3Fvia%3Dmatrix.org")
     }
     
     func test_fragmentContainsMultipleSerivers() {
@@ -51,6 +51,6 @@ class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
             "matrix.org"
         ]
         
-        XCTAssertEqual(resolution.deeplinkFragment, "mno:server.com?via=server.com&via=element.io&via=wikipedia.org&via=matrix.org")
+        XCTAssertEqual(resolution.deeplinkFragment, "mno%3Aserver.com%3Fvia%3Dserver.com%26via%3Delement.io%26via%3Dwikipedia.org%26via%3Dmatrix.org")
     }
 }

--- a/changelog.d/4858.bugfix
+++ b/changelog.d/4858.bugfix
@@ -1,0 +1,1 @@
+Room: Enable joining a room via identifier from another home server


### PR DESCRIPTION
Resolves #4858 

A room can be joined by providing either an alias or an identifier. When joining via an alias, the server is able to resolve this alias to an identifier as well as whichever homeserver is aware of this room, meaning that it is possible to join a room from one home server by a user on another home server.

This is not the case for joining via an identifier: synapse will currently return a "No known servers" error if the client attempts to join a room without specifying `server_name` (see https://github.com/matrix-org/matrix-spec-proposals/blob/old_master/proposals/1704-matrix.to-permalinks.md for details).

To solve this issue we need to [hold onto a list of servers](https://github.com/matrix-org/matrix-ios-sdk/pull/1426) provided by the API when resolving an alias, and then use this list to set the `server_name` in `join` endpoint.

Note that the second step is already working as long as a permalink has `via=...` attached at the end of it. So once we have a list of servers, we can append them to the end of the room identifier, and the deeplink resolver will pick this up automatically.