### PR TITLE
m.room.join_rules not properly set for private access

### DIFF
--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/MatrixSDK/RoomAccessTypeChooserService.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/MatrixSDK/RoomAccessTypeChooserService.swift
@@ -109,7 +109,7 @@ class RoomAccessTypeChooserService: RoomAccessTypeChooserServiceProtocol {
         
         switch self.selectedType {
         case .private:
-            _joinRule = .private
+            _joinRule = .invite
         case .public:
             _joinRule = .public
         case .restricted:

--- a/changelog.d/5943.bugfix
+++ b/changelog.d/5943.bugfix
@@ -1,0 +1,1 @@
+m.room.join_rules not properly set for private access


### PR DESCRIPTION
resolves #5943 