### PR TITLE
We should always reset `listenForRoomListDataReady` for a session sta…

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2417,6 +2417,18 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     if (mainSession)
     {
+        
+        switch (mainSession.state)
+        {
+            case MXSessionStateClosed:
+            case MXSessionStateInitialised:
+            case MXSessionStateBackgroundSyncInProgress:
+                self.roomListDataReady = NO;
+                [self listenForRoomListDataReady];
+            default:
+                break;
+        }
+        
         BOOL isLaunching = NO;
         
         if (_masterTabBarController.isOnboardingInProgress)
@@ -2434,8 +2446,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                 case MXSessionStateClosed:
                 case MXSessionStateInitialised:
                 case MXSessionStateBackgroundSyncInProgress:
-                    self.roomListDataReady = NO;
-                    [self listenForRoomListDataReady];
                     isLaunching = YES;
                     break;
                 case MXSessionStateStoreDataReady:

--- a/changelog.d/5948.bugfix
+++ b/changelog.d/5948.bugfix
@@ -1,0 +1,1 @@
+Fix for app occasionally getting stuck during launch after Login/Register.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/5948

We are currently only setting `roomListDataReady` and the listener if the onboard is not in progress.
However the authentication during onboarding triggers the creation of the MXKAccount object, the initialisation of the session and the start of the syncs and session state changes.
So there is a timing issue that has been reported for downstream forks that occasionally the session will changes to states later than`closed`, `initialized` and `BackgroundSyncInProgress` _before_ the onboarding flow is complete. This means that `listenForRoomListDataReady` is never called and the launch gets stuck.

This fix is to set the listener on session start/reset regardless of onboarding.