### PR TITLE
Remember offset of collection views during table view reload to avoid jitter 

### DIFF
--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.h
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.h
@@ -23,6 +23,8 @@
 @class DiscussionsCount;
 @class MXSpace;
 
+#define DATA_SOURCE_INVALID_SECTION -1
+
 /**
  List the different modes used to prepare the recents data source.
  Each mode corresponds to an application tab: Home, Favourites, People and Rooms.

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -102,16 +102,16 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
 
 - (void)resetSectionIndexes
 {
-    crossSigningBannerSection = -1;
-    secureBackupBannerSection = -1;
-    directorySection = -1;
-    invitesSection = -1;
-    favoritesSection = -1;
-    peopleSection = -1;
-    conversationSection = -1;
-    lowPrioritySection = -1;
-    serverNoticeSection = -1;
-    suggestedRoomsSection = -1;
+    crossSigningBannerSection = DATA_SOURCE_INVALID_SECTION;
+    secureBackupBannerSection = DATA_SOURCE_INVALID_SECTION;
+    directorySection = DATA_SOURCE_INVALID_SECTION;
+    invitesSection = DATA_SOURCE_INVALID_SECTION;
+    favoritesSection = DATA_SOURCE_INVALID_SECTION;
+    peopleSection = DATA_SOURCE_INVALID_SECTION;
+    conversationSection = DATA_SOURCE_INVALID_SECTION;
+    lowPrioritySection = DATA_SOURCE_INVALID_SECTION;
+    serverNoticeSection = DATA_SOURCE_INVALID_SECTION;
+    suggestedRoomsSection = DATA_SOURCE_INVALID_SECTION;
 }
 
 #pragma mark - Properties
@@ -402,7 +402,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
 {
     if (dataSource == _publicRoomsDirectoryDataSource)
     {
-        if (-1 != directorySection && !self.droppingCellIndexPath)
+        if (DATA_SOURCE_INVALID_SECTION != directorySection && !self.droppingCellIndexPath)
         {
             // TODO: We should only update the directory section
             [self.delegate dataSource:self didCellChange:nil];
@@ -1486,7 +1486,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
                              forSection:(RecentsListServiceSection)section
                      totalCountsChanged:(BOOL)totalCountsChanged
 {
-    NSInteger sectionIndex = -1;
+    NSInteger sectionIndex = DATA_SOURCE_INVALID_SECTION;
     switch (section)
     {
         case RecentsListServiceSectionInvited:

--- a/Riot/Modules/Common/Recents/RecentsContentOffsetStore.swift
+++ b/Riot/Modules/Common/Recents/RecentsContentOffsetStore.swift
@@ -1,0 +1,107 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import UIKit
+
+/**
+ Types of sections as defined in `RecentsDataSource`, albeit represented as an enum for stronger type safety
+ */
+enum RecentsDataSourceSectionType {
+    case crossSigningBanner
+    case secureBackupBanner
+    case directory
+    case invites
+    case favorites
+    case people
+    case conversation
+    case lowPriority
+    case serverNotice
+    case suggestedRooms
+}
+
+/**
+ A store of content offsets for a special type of table view where each cell contains a collection view,
+ and the content offset needs to be preserved across table view reloads.
+ 
+ This type of table view is used on some of the tabs (e.g. home), where vertical rows represent sections
+ (favourites, people, rooms ... ) and horizontal represents different rooms (shown in a collection view).
+ When such a table view is reloaded, it will dequeue and reuse the previously created collection views
+ in random order, meaning that any contentOffset they may have had will now be arbitrarily swapped around.
+ The store allows saving the current content offsets per section and restoring them after a reload.
+ */
+@objc class RecentsContentOffsetStore: NSObject {
+    private var contentOffsets = [RecentsDataSourceSectionType: CGPoint]()
+    
+    @objc func storeContentOffsets(for tableView: UITableView, dataSource: RecentsDataSource) {
+        reset()
+        let sections = sectionWithTypes(for: tableView, dataSource: dataSource)
+        
+        for (section, sectionType) in sections {
+            
+            let indexPath = IndexPath(row: 0, section: section)
+            guard let cell = tableView.cellForRow(at: indexPath) as? TableViewCellWithCollectionView else {
+                continue
+            }
+            
+            contentOffsets[sectionType] = cell.collectionView.contentOffset
+        }
+    }
+    
+    @objc func restoreContentOffsets(for tableView: UITableView, dataSource: RecentsDataSource) {
+        let sections = sectionWithTypes(for: tableView, dataSource: dataSource)
+        
+        for (section, sectionType) in sections {
+            
+            let indexPath = IndexPath(row: 0, section: section)
+            guard
+                let offset = contentOffsets[sectionType],
+                let cell = tableView.cellForRow(at: indexPath) as? TableViewCellWithCollectionView
+            else {
+                continue
+            }
+            
+            cell.collectionView.contentOffset = offset
+        }
+        reset()
+    }
+    
+    private func reset() {
+        contentOffsets = [:]
+    }
+    
+    private func sectionWithTypes(for tableView: UITableView, dataSource: RecentsDataSource) -> [(Int, RecentsDataSourceSectionType)] {
+        // We associate the arbitrary integer index of a section at any particular time with its semantic value (e.g. 2 = `favorites`).
+        // At this point the index could equal -1 because not all indexes in data source ara valid for every screen
+        return [
+            (dataSource.crossSigningBannerSection, .crossSigningBanner),
+            (dataSource.secureBackupBannerSection, .secureBackupBanner),
+            (dataSource.directorySection, .directory),
+            (dataSource.invitesSection, .invites),
+            (dataSource.favoritesSection, .favorites),
+            (dataSource.peopleSection, .people),
+            (dataSource.conversationSection, .conversation),
+            (dataSource.lowPrioritySection, .lowPriority),
+            (dataSource.serverNoticeSection, .serverNotice),
+            (dataSource.suggestedRoomsSection, .suggestedRooms)
+        ].filter { (section, sectionType) in
+            
+            // We only want indexes that are valid for a given view and actually shown on the table view
+            section != DATA_SOURCE_INVALID_SECTION
+            && section < tableView.numberOfSections
+        }
+    }
+}

--- a/Riot/Modules/Home/Views/TableViewCellWithCollectionView.m
+++ b/Riot/Modules/Home/Views/TableViewCellWithCollectionView.m
@@ -56,6 +56,7 @@ static CGFloat const kEditionViewCornerRadius = 10.0;
     self.editionViewBottomConstraint.constant = 0;
     self.editionView.hidden = YES;
     
+    [self.collectionView setContentOffset:CGPointZero];
     self.collectionView.scrollEnabled = YES;
 }
 

--- a/Riot/SupportingFiles/Riot-Bridging-Header.h
+++ b/Riot/SupportingFiles/Riot-Bridging-Header.h
@@ -69,3 +69,4 @@
 #import "MXRoom+Sync.h"
 #import "UIAlertController+MatrixKit.h"
 #import "MXKMessageTextView.h"
+#import "TableViewCellWithCollectionView.h"

--- a/changelog.d/5958.bugfix
+++ b/changelog.d/5958.bugfix
@@ -1,0 +1,1 @@
+Rooms: Remember offset of collection views during table view reload to avoid jitter


### PR DESCRIPTION
Fixes #5958 

There are a number of reasons why the home screen keeps jitterring (especially with lots of data), but fundamentally they have to do with:
1) Refreshing the entire home screen way too often
2) Not restoring content offsets of collection views when table view is reloaded

To expand on this, home screen table view contains row items, which themselves contain individual collection views. When we reload the table view, the usual data source methods for creating a cell will be called, which creates any given collection view by dequeing it from the table view's pool. This means that if there are multiple collection views, they may be arbitrarily and randomly swapped around and repurposed for different sections, whilst not resetting their content offset. This, I think, is one major downside to nesting table views and collection views (note, this isn't an issue with nested scrollviews).

We could simply reset content offset each time `prepareForReuse` is called (and this is indeed added now), but this on its own is not enough, given the frequency of home screen reloads (on heavy accounts this happens 20-30 times per second). The outcome of this change only would be constant resetting of each collection view to its start, i.e. another inability to scroll.

Whilst a more thorough refactor of the data source and frequency of refreshes is necessary (and will be done as part of #5619), the solution presented here will store current content offsets for each collection view before a table view is reloaded, and then restored immediately afterwards. Whilst we are still refreshing far too many times, and collection views are randomly getting swapped around, at least it should not be visually jarring anymore.

A more thorough refactor of the data source will follow.