### PR TITLE
Refactor sections as enum types

### DIFF
--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.h
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.h
@@ -22,6 +22,7 @@
 @protocol RecentsListServiceProtocol;
 @class DiscussionsCount;
 @class MXSpace;
+@class RecentsDataSourceSections;
 
 /**
  List the different modes used to prepare the recents data source.
@@ -67,16 +68,10 @@ extern NSString *const kRecentsDataSourceTapOnDirectoryServerChange;
  */
 @interface RecentsDataSource : MXKInterleavedRecentsDataSource
 
-@property (nonatomic) NSInteger crossSigningBannerSection;
-@property (nonatomic) NSInteger secureBackupBannerSection;
-@property (nonatomic) NSInteger directorySection;
-@property (nonatomic) NSInteger invitesSection;
-@property (nonatomic) NSInteger favoritesSection;
-@property (nonatomic) NSInteger peopleSection;
-@property (nonatomic) NSInteger conversationSection;
-@property (nonatomic) NSInteger lowPrioritySection;
-@property (nonatomic) NSInteger serverNoticeSection;
-@property (nonatomic) NSInteger suggestedRoomsSection;
+/**
+ A set of sections visible in the current table view and associated with their semantic meaning (e.g. "favorites" = 2)
+ */
+@property (nonatomic, strong, readonly) RecentsDataSourceSections *sections;
 
 @property (nonatomic, readonly) NSInteger totalVisibleItemCount;
 
@@ -126,6 +121,11 @@ extern NSString *const kRecentsDataSourceTapOnDirectoryServerChange;
  The data source used to manage the rooms from directory.
  */
 @property (nonatomic) PublicRoomsDirectoryDataSource *publicRoomsDirectoryDataSource;
+
+/**
+ Make a new sections object that reflects the latest state of the data sources
+ */
+- (RecentsDataSourceSections *)makeDataSourceSections;
 
 /**
  Refresh the recents data source and notify its delegate.

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSourceSectionType.swift
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSourceSectionType.swift
@@ -27,4 +27,6 @@ import Foundation
     case lowPriority
     case serverNotice
     case suggestedRooms
+    case searchedRoom
+    case unknown
 }

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSourceSections.swift
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSourceSections.swift
@@ -1,0 +1,78 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/**
+ Data structure representing the current arrangement of sections in a given data source,
+ where a numerical session index (used for table views) is associated with its semantic
+ value (e.g. "favorites" = 2).
+ */
+@objc class RecentsDataSourceSections: NSObject {
+    typealias SectionIndex = Int
+    static let MissingSectionIndex = -1
+    
+    @objc var count: Int {
+        sections.count
+    }
+    
+    @objc var sectionTypes: [NSNumber] {
+        sections
+            .sorted { $0.value < $1.value }
+            .map { NSNumber(value: $0.key.rawValue) }
+    }
+
+    private var sections: [RecentsDataSourceSectionType: SectionIndex] = [:]
+    
+    init(sectionTypes: [RecentsDataSourceSectionType]) {
+        sections = sectionTypes
+            .enumerated()
+            .reduce(into: [RecentsDataSourceSectionType: SectionIndex]()) { dict, item in
+                dict[item.element] = item.offset
+            }
+    }
+    
+    // Objective-C cannot represent int-enums as an array, so a convenience function
+    // allows passing them as a list of NSNumbers, that are internally extracted
+    @objc convenience init(sectionTypes: [NSNumber]) {
+        let types = sectionTypes.compactMap {
+            RecentsDataSourceSectionType(rawValue: $0.intValue)
+        }
+        self.init(sectionTypes: types)
+    }
+    
+    @objc func contains(_ sectionType: RecentsDataSourceSectionType) -> Bool {
+        return sections.contains {
+            $0.key == sectionType
+        }
+    }
+    
+    @objc func sectionIndex(forSectionType sectionType: RecentsDataSourceSectionType) -> SectionIndex {
+        guard let index = sections[sectionType] else {
+            // Objective-c code does not allow returning optional Int, so must use -1
+            return Self.MissingSectionIndex
+        }
+        return index
+    }
+    
+    @objc func sectionType(forSectionIndex sectionIndex: SectionIndex) -> RecentsDataSourceSectionType {
+        guard let item = sections.first(where: { $0.value == sectionIndex }) else {
+            // Objective-c code does not allow returning optional Int, so must use .unknown
+            return .unknown
+        }
+        return item.key
+    }
+}

--- a/Riot/Modules/Favorites/FavouritesViewController.m
+++ b/Riot/Modules/Favorites/FavouritesViewController.m
@@ -109,7 +109,7 @@
     // Check whether the recents data source is correctly configured.
     if (recentsDataSource.recentsDataSourceMode == RecentsDataSourceModeFavourites)
     {
-        [self scrollToTheTopTheNextRoomWithMissedNotificationsInSection:recentsDataSource.favoritesSection];
+        [self scrollToTheTopTheNextRoomWithMissedNotificationsInSection:[recentsDataSource.sections sectionIndexForSectionType:RecentsDataSourceSectionTypeFavorites]];
     }
 }
 

--- a/Riot/Modules/Home/HomeViewController.m
+++ b/Riot/Modules/Home/HomeViewController.m
@@ -331,28 +331,6 @@
     return [NSString stringWithFormat:@"%@-%ld", TableViewCellWithCollectionView.defaultReuseIdentifier, sectionType];
 }
 
-- (RecentsDataSourceSectionType)sectionTypeAtIndexPath:(NSIndexPath *)indexPath
-{
-    if (indexPath.section == recentsDataSource.directorySection) {
-        return RecentsDataSourceSectionTypeDirectory;
-    } else if (indexPath.section == recentsDataSource.invitesSection) {
-        return RecentsDataSourceSectionTypeInvites;
-    } else if (indexPath.section == recentsDataSource.favoritesSection) {
-        return RecentsDataSourceSectionTypeFavorites;
-    } else if (indexPath.section == recentsDataSource.peopleSection) {
-        return RecentsDataSourceSectionTypePeople;
-    } else if (indexPath.section == recentsDataSource.conversationSection) {
-        return RecentsDataSourceSectionTypeConversation;
-    } else if (indexPath.section == recentsDataSource.lowPrioritySection) {
-        return RecentsDataSourceSectionTypeLowPriority;
-    } else if (indexPath.section == recentsDataSource.serverNoticeSection) {
-        return RecentsDataSourceSectionTypeServerNotice;
-    } else if (indexPath.section == recentsDataSource.suggestedRoomsSection) {
-        return RecentsDataSourceSectionTypeSuggestedRooms;
-    }
-    return -1;
-}
-
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
     // Return the actual number of sections prepared in recents dataSource.
@@ -377,16 +355,16 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if ((indexPath.section == recentsDataSource.conversationSection && !recentsDataSource.recentsListService.conversationRoomListData.counts.numberOfRooms)
-        || (indexPath.section == recentsDataSource.peopleSection && !recentsDataSource.recentsListService.peopleRoomListData.counts.numberOfRooms)
-        || (indexPath.section == recentsDataSource.secureBackupBannerSection)
-        || (indexPath.section == recentsDataSource.crossSigningBannerSection)
+    RecentsDataSourceSectionType sectionType = [recentsDataSource.sections sectionTypeForSectionIndex:indexPath.section];
+    if ((sectionType == RecentsDataSourceSectionTypeConversation && !recentsDataSource.recentsListService.conversationRoomListData.counts.numberOfRooms)
+        || (sectionType == RecentsDataSourceSectionTypePeople && !recentsDataSource.recentsListService.peopleRoomListData.counts.numberOfRooms)
+        || (sectionType == RecentsDataSourceSectionTypeSecureBackupBanner)
+        || (sectionType == RecentsDataSourceSectionTypeCrossSigningBanner)
         )
     {
         return [recentsDataSource tableView:tableView cellForRowAtIndexPath:indexPath];
     }
     
-    RecentsDataSourceSectionType sectionType = [self sectionTypeAtIndexPath:indexPath];
     NSString *cellIdentifier = [self cellIdentifierForSectionType:sectionType];
     TableViewCellWithCollectionView *tableViewCell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier forIndexPath:indexPath];
     tableViewCell.collectionView.tag = indexPath.section;
@@ -471,24 +449,25 @@
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if ((indexPath.section == recentsDataSource.conversationSection && !recentsDataSource.recentsListService.conversationRoomListData.counts.numberOfRooms)
-        || (indexPath.section == recentsDataSource.peopleSection && !recentsDataSource.recentsListService.peopleRoomListData.counts.numberOfRooms))
+    RecentsDataSourceSectionType sectionType = [recentsDataSource.sections sectionTypeForSectionIndex:indexPath.section];
+    if ((sectionType == RecentsDataSourceSectionTypeConversation && !recentsDataSource.recentsListService.conversationRoomListData.counts.numberOfRooms)
+        || (sectionType == RecentsDataSourceSectionTypePeople && !recentsDataSource.recentsListService.peopleRoomListData.counts.numberOfRooms))
     {
         return [recentsDataSource cellHeightAtIndexPath:indexPath];
     }
-    else if (indexPath.section == recentsDataSource.secureBackupBannerSection || indexPath.section == recentsDataSource.crossSigningBannerSection)
+    else if (sectionType == RecentsDataSourceSectionTypeSecureBackupBanner || sectionType == RecentsDataSourceSectionTypeCrossSigningBanner)
     {
         CGFloat height = 0.0;
         
         UITableViewCell *sizingCell;
         
-        if (indexPath.section == recentsDataSource.secureBackupBannerSection)
+        if (sectionType == RecentsDataSourceSectionTypeSecureBackupBanner)
         {
             SecureBackupBannerCell *secureBackupBannerCell = self.secureBackupBannerPrototypeCell;
             [secureBackupBannerCell configureFor:recentsDataSource.secureBackupBannerDisplay];
             sizingCell = secureBackupBannerCell;
         }
-        else if (indexPath.section == recentsDataSource.crossSigningBannerSection)
+        else if (sectionType == RecentsDataSourceSectionTypeCrossSigningBanner)
         {
             sizingCell = self.keyVerificationSetupBannerPrototypeCell;
         }
@@ -497,7 +476,7 @@
         
         CGSize fittingSize = UILayoutFittingCompressedSize;
         CGFloat tableViewWidth = CGRectGetWidth(tableView.frame);
-        CGFloat safeAreaWidth = MAX(tableView.safeAreaInsets.left, tableView.safeAreaInsets.right);        
+        CGFloat safeAreaWidth = MAX(tableView.safeAreaInsets.left, tableView.safeAreaInsets.right);
         
         fittingSize.width = tableViewWidth - safeAreaWidth;
         
@@ -522,8 +501,9 @@
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     // No header in key banner section
-    if (section == recentsDataSource.secureBackupBannerSection
-        || section == recentsDataSource.crossSigningBannerSection)
+    RecentsDataSourceSectionType sectionType = [recentsDataSource.sections sectionTypeForSectionIndex:section];
+    if (sectionType == RecentsDataSourceSectionTypeSecureBackupBanner
+        || sectionType == RecentsDataSourceSectionTypeCrossSigningBanner)
     {
         return 0.0;
     }
@@ -535,7 +515,8 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.section == recentsDataSource.secureBackupBannerSection)
+    RecentsDataSourceSectionType sectionType = [recentsDataSource.sections sectionTypeForSectionIndex:indexPath.section];
+    if (sectionType == RecentsDataSourceSectionTypeSecureBackupBanner)
     {
         switch (recentsDataSource.secureBackupBannerDisplay) {
             case SecureBackupBannerDisplaySetup:
@@ -545,7 +526,7 @@
                 break;
         }
     }
-    else if (indexPath.section == recentsDataSource.crossSigningBannerSection)
+    else if (sectionType == RecentsDataSourceSectionTypeCrossSigningBanner)
     {
         [self showCrossSigningSetup];
     }
@@ -1069,7 +1050,8 @@
     }
     
     // Check if some banners should be displayed
-    if (recentsDataSource.secureBackupBannerSection != -1 || recentsDataSource.crossSigningBannerSection != -1)
+    if ([recentsDataSource.sections contains:RecentsDataSourceSectionTypeSecureBackupBanner]
+        || [recentsDataSource.sections contains:RecentsDataSourceSectionTypeCrossSigningBanner])
     {
         return NO;
     }

--- a/Riot/Modules/People/PeopleViewController.m
+++ b/Riot/Modules/People/PeopleViewController.m
@@ -152,7 +152,7 @@
     // Check whether the recents data source is correctly configured.
     if (recentsDataSource.recentsDataSourceMode == RecentsDataSourceModePeople)
     {
-        [self scrollToTheTopTheNextRoomWithMissedNotificationsInSection:recentsDataSource.peopleSection];
+        [self scrollToTheTopTheNextRoomWithMissedNotificationsInSection:[recentsDataSource.sections sectionIndexForSectionType:RecentsDataSourceSectionTypePeople]];
     }
 }
 

--- a/Riot/Modules/Rooms/RoomsViewController.m
+++ b/Riot/Modules/Rooms/RoomsViewController.m
@@ -130,7 +130,7 @@
     // Check whether the recents data source is correctly configured.
     if (recentsDataSource.recentsDataSourceMode == RecentsDataSourceModeRooms)
     {
-        [self scrollToTheTopTheNextRoomWithMissedNotificationsInSection:recentsDataSource.conversationSection];
+        [self scrollToTheTopTheNextRoomWithMissedNotificationsInSection:[recentsDataSource.sections sectionTypeForSectionIndex:RecentsDataSourceSectionTypeConversation]];
     }
 }
 

--- a/RiotTests/Modules/Common/Recents/DataSources/RecentsDataSourceSectionsTests.swift
+++ b/RiotTests/Modules/Common/Recents/DataSources/RecentsDataSourceSectionsTests.swift
@@ -1,0 +1,115 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import Riot
+
+class RecentsDataSourceSectionsTests: XCTestCase {
+    func test_canCreateWithNSNumbers() {
+        let sections = RecentsDataSourceSections(sectionTypes: [
+            NSNumber(value: -1),
+            NSNumber(value: 0),
+            NSNumber(value: 2),
+            NSNumber(value: 100),
+        ])
+        
+        XCTAssertEqual(sections.count, 2)
+        XCTAssertTrue(sections.contains(.crossSigningBanner))
+        XCTAssertTrue(sections.contains(.directory))
+    }
+    
+    func test_hasCorrectCount() {
+        let sections = RecentsDataSourceSections(sectionTypes: [
+            .invites,
+            .favorites,
+            .searchedRoom,
+            .lowPriority,
+            .serverNotice
+        ])
+        
+        XCTAssertEqual(sections.count, 5)
+    }
+    
+    func test_containsCorrectTypes() {
+        let sections = RecentsDataSourceSections(sectionTypes: [
+            .favorites,
+            .directory,
+            .lowPriority,
+            .serverNotice
+        ])
+        
+        XCTAssertTrue(sections.contains(.favorites))
+        XCTAssertTrue(sections.contains(.directory))
+        XCTAssertTrue(sections.contains(.lowPriority))
+        XCTAssertTrue(sections.contains(.serverNotice))
+        
+        XCTAssertFalse(sections.contains(.invites))
+        XCTAssertFalse(sections.contains(.searchedRoom))
+    }
+    
+    func test_hasCorrectSectionIndices() {
+        let sections = RecentsDataSourceSections(sectionTypes: [
+            .invites,
+            .favorites,
+            .searchedRoom,
+            .lowPriority
+        ])
+        
+        XCTAssertEqual(sections.sectionIndex(forSectionType: .invites), 0)
+        XCTAssertEqual(sections.sectionIndex(forSectionType: .favorites), 1)
+        XCTAssertEqual(sections.sectionIndex(forSectionType: .searchedRoom), 2)
+        XCTAssertEqual(sections.sectionIndex(forSectionType: .lowPriority), 3)
+        
+        XCTAssertEqual(sections.sectionIndex(forSectionType: .suggestedRooms), -1)
+    }
+    
+    func test_indicesMatchCorrectTypes() {
+        let sections = RecentsDataSourceSections(sectionTypes: [
+            .favorites,
+            .invites,
+            .lowPriority,
+            .searchedRoom,
+        ])
+        
+        XCTAssertEqual(sections.sectionType(forSectionIndex: 0), .favorites)
+        XCTAssertEqual(sections.sectionType(forSectionIndex: 1), .invites)
+        XCTAssertEqual(sections.sectionType(forSectionIndex: 2), .lowPriority)
+        XCTAssertEqual(sections.sectionType(forSectionIndex: 3), .searchedRoom)
+        
+        XCTAssertEqual(sections.sectionType(forSectionIndex: -1), .unknown)
+        XCTAssertEqual(sections.sectionType(forSectionIndex: 100), .unknown)
+    }
+    
+    func test_returnsSectionTypesAsNSNumbers() {
+        let sections = RecentsDataSourceSections(sectionTypes: [
+            .favorites,
+            .invites,
+            .lowPriority,
+            .searchedRoom,
+        ])
+        
+        XCTAssertEqual(
+            sections.sectionTypes,
+            [
+                NSNumber(value: RecentsDataSourceSectionType.favorites.rawValue),
+                NSNumber(value: RecentsDataSourceSectionType.invites.rawValue),
+                NSNumber(value: RecentsDataSourceSectionType.lowPriority.rawValue),
+                NSNumber(value: RecentsDataSourceSectionType.searchedRoom.rawValue),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
`RecentsDataSource` and its subclasses have a very brittle way of managing state, which consists in declaring a set of externally mutable integer properties which are set, reset and mutated at random point, and which indicate number of sections in the table view.

In this PR I am replacing all of this state by inetrnalizing inside of `RecentsDataSourceSections` object which ensures strong types via an enum for each section, and no mutability after creation. To alter sections, one must create a whole new object. This also makes it possible to compare and diff two sections objects to see whether a table view needs to be reloaded or not (will come in future PR).

This PR is very large and touches a lot of lines, so there is some room for error. The new code is tested, but the old code is quite impossible to test (and we should continue refactoring it further if we care to improve it). Hopefully the review will be made easier by the code changes being 1:1 between the properties and the enuns.