### PR TITLE
Disable RTL languages for now.

### DIFF
--- a/Riot/target.yml
+++ b/Riot/target.yml
@@ -67,6 +67,8 @@ targets:
     - path: .
       excludes:
         - "Modules/Room/EmojiPicker/Data/EmojiMart/EmojiJSONStore.swift"
+        - "Assets/ar.lproj/**" # RTL is broken so languages are disabled for now
+        - "Assets/he.lproj/**"
     - path: ../RiotShareExtension/Shared
     - path: Modules/MatrixKit
       excludes:

--- a/changelog.d/5935.i18n
+++ b/changelog.d/5935.i18n
@@ -1,1 +1,1 @@
-Translations: Enable all languages rather than waiting for an 80% translation.
+Translations: Enable all languages rather than waiting for an 80% translation. RTL languages are still disabled due to layout and formatting bugs.


### PR DESCRIPTION
This PR disables Arabic and Hebrew languages for now as
1. Hebrew placeholders sometimes crash as `%@` and need to be `@%`. Other times the substitution fails for `@%` and simply renders as `@`.
2. Forcing LTR on switches worked whilst they are static, the animations are broken.
