### PR TITLE
Make sure strings fall back to English if missing in the Notification extension

### DIFF
--- a/Riot/Categories/Bundle.swift
+++ b/Riot/Categories/Bundle.swift
@@ -19,7 +19,7 @@ import Foundation
 public extension Bundle {
     /// Returns the real app bundle.
     /// Can also be used in app extensions.
-    static var app: Bundle {
+    @objc static var app: Bundle {
         let bundle = main
         if bundle.bundleURL.pathExtension == "appex" {
             // Peel off two directory levels - MY_APP.app/PlugIns/MY_APP_EXTENSION.appex
@@ -29,6 +29,14 @@ public extension Bundle {
             }
         }
         return bundle
+    }
+    
+    /// Get an lproj language bundle from the main app bundle.
+    /// - Parameter language: The language to try to load.
+    /// - Returns: The lproj bundle if found otherwise `nil`.
+    @objc static func lprojBundle(for language: String) -> Bundle? {
+        guard let lprojURL = Bundle.app.url(forResource: language, withExtension: "lproj") else { return nil }
+        return Bundle(url: lprojURL)
     }
     
     /// Whether or not the bundle is the RiotShareExtension.

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -8006,7 +8006,7 @@ public class VectorL10n: NSObject {
 
 extension VectorL10n {
   static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+    let format = NSLocalizedString(key, tableName: table, bundle: Bundle.app, comment: "")
     let locale: Locale
     if let providedLocale = LocaleProvider.locale {
       locale = providedLocale
@@ -8018,4 +8018,3 @@ extension VectorL10n {
     }
 }
 
-private final class BundleToken {}

--- a/Riot/Modules/MatrixKit/Categories/NSBundle+MXKLanguage.m
+++ b/Riot/Modules/MatrixKit/Categories/NSBundle+MXKLanguage.m
@@ -15,6 +15,7 @@
  */
 
 #import "NSBundle+MXKLanguage.h"
+#import "GeneratedInterface-Swift.h"
 
 #import <objc/runtime.h>
 
@@ -55,37 +56,37 @@ static const char _fallbackLanguage = 0;
     [self setupMXKLanguageBundle];
 
     // [NSBundle localizedStringForKey] calls will be redirected to the bundle corresponding
-    // to "language"
-    objc_setAssociatedObject([NSBundle mainBundle],
-                             &_bundle, language ? [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:language ofType:@"lproj"]] : nil,
+    // to "language". `lprojBundleFor` loads this from the main app bundle as we might be running in an extension.
+    objc_setAssociatedObject(NSBundle.app,
+                             &_bundle, language ? [NSBundle lprojBundleFor:language] : nil,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    objc_setAssociatedObject([NSBundle mainBundle],
+    objc_setAssociatedObject(NSBundle.app,
                              &_language, language,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 + (NSString *)mxk_language
 {
-    return objc_getAssociatedObject([NSBundle mainBundle], &_language);
+    return objc_getAssociatedObject(NSBundle.app, &_language);
 }
 
 + (void)mxk_setFallbackLanguage:(NSString *)language
 {
     [self setupMXKLanguageBundle];
 
-    objc_setAssociatedObject([NSBundle mainBundle],
-                             &_fallbackBundle, language ? [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:language ofType:@"lproj"]] : nil,
+    objc_setAssociatedObject(NSBundle.app,
+                             &_fallbackBundle, language ? [NSBundle lprojBundleFor:language] : nil,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    objc_setAssociatedObject([NSBundle mainBundle],
+    objc_setAssociatedObject(NSBundle.app,
                              &_fallbackLanguage, language,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 + (NSString *)mxk_fallbackLanguage
 {
-    return objc_getAssociatedObject([NSBundle mainBundle], &_fallbackLanguage);
+    return objc_getAssociatedObject(NSBundle.app, &_fallbackLanguage);
 }
 
 #pragma mark - Private methods
@@ -96,7 +97,7 @@ static const char _fallbackLanguage = 0;
     dispatch_once(&onceToken, ^{
 
         // Use MXKLanguageBundle as the [NSBundle mainBundle] class
-        object_setClass([NSBundle mainBundle], [MXKLanguageBundle class]);
+        object_setClass(NSBundle.app, MXKLanguageBundle.class);
     });
 }
 

--- a/Tools/SwiftGen/Templates/Strings/flat-swift4-vector.stencil
+++ b/Tools/SwiftGen/Templates/Strings/flat-swift4-vector.stencil
@@ -64,7 +64,7 @@ import Foundation
 
 extension {{className}} {
   static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+    let format = NSLocalizedString(key, tableName: table, bundle: Bundle.app, comment: "")
     let locale: Locale
         
     if let providedLocale = LocaleProvider.locale {
@@ -77,7 +77,6 @@ extension {{className}} {
     }
 }
 
-private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}

--- a/changelog.d/5996.bugfix
+++ b/changelog.d/5996.bugfix
@@ -1,0 +1,1 @@
+Notifications: Strings now fall back to English if they're missing for the current language.


### PR DESCRIPTION
This was a long running bug which become more visible following on from #5936. Instead of using `NSString.localizedUserNotificationString` which provides no fallback, this PR adds a `localizedString(forKey:_:)` method that uses similar logic to `VectorL10n`, but specifically requests the strings from the main app bundle.

In order for this to work, MXKLanguageBundle now always references `Bundle.app` instead of `Bundle.main` so that `setupMXKLanguageBundle` was called on the same bundle that the strings request goes to. I've updated `VectorL10n` to do the same thing - this has the happy coincidence of allowing the share extension to show in the system language as well which I don't believe it was doing before 😄

Fixes #5996
