### PR TITLE
Small changes to localisation

### DIFF
--- a/Config/CommonConfiguration.swift
+++ b/Config/CommonConfiguration.swift
@@ -39,7 +39,7 @@ class CommonConfiguration: NSObject, Configurable {
         settings.syncWithLazyLoadOfRoomMembers = true
         
         // Customize the default notification content
-        settings.notificationBodyLocalizationKey = "NOTIFICATION"
+        settings.notificationBodyLocalizationKey = "Notification"
         
         settings.messageDetailsAllowSharing = BuildSettings.messageDetailsAllowShare
         settings.messageDetailsAllowSaving = BuildSettings.messageDetailsAllowSave

--- a/Riot/Assets/ar.lproj/Localizable.strings
+++ b/Riot/Assets/ar.lproj/Localizable.strings
@@ -167,4 +167,4 @@
 "REPLY_FROM_USER_TITLE" = "%@ رَد";
 /** General **/
 
-"NOTIFICATION" = "إشعار";
+"Notification" = "إشعار";

--- a/Riot/Assets/ca.lproj/Localizable.strings
+++ b/Riot/Assets/ca.lproj/Localizable.strings
@@ -120,4 +120,4 @@
 "REPLY_FROM_USER_TITLE" = "%@ respost";
 /** General **/
 
-"NOTIFICATION" = "Notificació";
+"Notification" = "Notificació";

--- a/Riot/Assets/cs.lproj/Localizable.strings
+++ b/Riot/Assets/cs.lproj/Localizable.strings
@@ -167,4 +167,4 @@
 "MSG_FROM_USER_IN_ROOM_TITLE" = "%@ v %@";
 /** General **/
 
-"NOTIFICATION" = "Oznámení";
+"Notification" = "Oznámení";

--- a/Riot/Assets/de.lproj/Localizable.strings
+++ b/Riot/Assets/de.lproj/Localizable.strings
@@ -106,7 +106,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ hat geantwortet";
 /** General **/
 
-"NOTIFICATION" = "Benachrichtigung";
+"Notification" = "Benachrichtigung";
 
 /* New file message from a specific person, not referencing a room. */
 "FILE_FROM_USER" = "%@ hat die Datei %@ gesendet";

--- a/Riot/Assets/en.lproj/Localizable.strings
+++ b/Riot/Assets/en.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 
 /** General **/
 
-"NOTIFICATION" = "Notification";
+"Notification" = "Notification";
 
 /** Titles **/
 

--- a/Riot/Assets/es.lproj/Localizable.strings
+++ b/Riot/Assets/es.lproj/Localizable.strings
@@ -126,4 +126,4 @@
 "REPLY_FROM_USER_TITLE" = "%@ ha respondido";
 /** General **/
 
-"NOTIFICATION" = "Notificación";
+"Notification" = "Notificación";

--- a/Riot/Assets/et.lproj/Localizable.strings
+++ b/Riot/Assets/et.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ vastas";
 /** General **/
 
-"NOTIFICATION" = "Teavitus";
+"Notification" = "Teavitus";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ jagas oma asukohta";

--- a/Riot/Assets/fr.lproj/Localizable.strings
+++ b/Riot/Assets/fr.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ a répondu";
 /** General **/
 
-"NOTIFICATION" = "Notification";
+"Notification" = "Notification";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ a partagé sa localisation";

--- a/Riot/Assets/hu.lproj/Localizable.strings
+++ b/Riot/Assets/hu.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ válaszolt";
 /** General **/
 
-"NOTIFICATION" = "Értesítés";
+"Notification" = "Értesítés";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ megosztotta a földrajzi helyzetét";

--- a/Riot/Assets/id.lproj/Localizable.strings
+++ b/Riot/Assets/id.lproj/Localizable.strings
@@ -164,7 +164,7 @@
 "MSG_FROM_USER_IN_ROOM_TITLE" = "%@ di %@";
 /** General **/
 
-"NOTIFICATION" = "Notifikasi";
+"Notification" = "Notifikasi";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ membagikan lokasinya";

--- a/Riot/Assets/is.lproj/Localizable.strings
+++ b/Riot/Assets/is.lproj/Localizable.strings
@@ -167,4 +167,4 @@
 "MSG_FROM_USER_IN_ROOM_TITLE" = "%@ í %@";
 /** General **/
 
-"NOTIFICATION" = "Tilkynning";
+"Notification" = "Tilkynning";

--- a/Riot/Assets/it.lproj/Localizable.strings
+++ b/Riot/Assets/it.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ ha risposto";
 /** General **/
 
-"NOTIFICATION" = "Notifica";
+"Notification" = "Notifica";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ ha condiviso la sua posizione";

--- a/Riot/Assets/ja.lproj/Localizable.strings
+++ b/Riot/Assets/ja.lproj/Localizable.strings
@@ -76,7 +76,7 @@
 "MESSAGE" = "メッセージ";
 /** General **/
 
-"NOTIFICATION" = "通知";
+"Notification" = "通知";
 
 /* New message reply from a specific person in a named room. */
 "REPLY_FROM_USER_IN_ROOM_TITLE" = "%@ さんが %@ で返信";

--- a/Riot/Assets/ko.lproj/Localizable.strings
+++ b/Riot/Assets/ko.lproj/Localizable.strings
@@ -128,4 +128,4 @@
 "MESSAGE" = "메세지";
 /** General **/
 
-"NOTIFICATION" = "알림";
+"Notification" = "알림";

--- a/Riot/Assets/nl.lproj/Localizable.strings
+++ b/Riot/Assets/nl.lproj/Localizable.strings
@@ -148,7 +148,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ reageerde";
 /** General **/
 
-"NOTIFICATION" = "Meldingen";
+"Notification" = "Meldingen";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ deelde hun locatie";

--- a/Riot/Assets/pl.lproj/Localizable.strings
+++ b/Riot/Assets/pl.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ napisał(-a)";
 /** General **/
 
-"NOTIFICATION" = "Powiadomienie";
+"Notification" = "Powiadomienie";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ udostępnił(-a) swoją lokację";

--- a/Riot/Assets/pt_BR.lproj/Localizable.strings
+++ b/Riot/Assets/pt_BR.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ respondeu";
 /** General **/
 
-"NOTIFICATION" = "Notificação";
+"Notification" = "Notificação";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ compartilhou a localização dela(e)";

--- a/Riot/Assets/ru.lproj/Localizable.strings
+++ b/Riot/Assets/ru.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ ответил(а)";
 /** General **/
 
-"NOTIFICATION" = "Уведомление";
+"Notification" = "Уведомление";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ поделились своим местоположением";

--- a/Riot/Assets/sk.lproj/Localizable.strings
+++ b/Riot/Assets/sk.lproj/Localizable.strings
@@ -74,7 +74,7 @@
 "MSG_FROM_USER_IN_ROOM_TITLE" = "%@ v %@";
 /** General **/
 
-"NOTIFICATION" = "Oznámenia";
+"Notification" = "Oznámenia";
 
 /* New message from a specific person in a named room */
 "MSG_FROM_USER_IN_ROOM" = "%@ napísal v %@";

--- a/Riot/Assets/sq.lproj/Localizable.strings
+++ b/Riot/Assets/sq.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ u përgjigj";
 /** General **/
 
-"NOTIFICATION" = "Njoftim";
+"Notification" = "Njoftim";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ tregoi vendndodhjen e vet";

--- a/Riot/Assets/sv.lproj/Localizable.strings
+++ b/Riot/Assets/sv.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ svarade";
 /** General **/
 
-"NOTIFICATION" = "Avisering";
+"Notification" = "Avisering";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ delade sin plats";

--- a/Riot/Assets/uk.lproj/Localizable.strings
+++ b/Riot/Assets/uk.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "REPLY_FROM_USER_TITLE" = "%@ відповідає";
 /** General **/
 
-"NOTIFICATION" = "Сповіщення";
+"Notification" = "Сповіщення";
 
 /* New file message from a specific person, not referencing a room. */
 "LOCATION_FROM_USER" = "%@ надсилає дані про своє місцеперебування";

--- a/Riot/Assets/vi.lproj/Localizable.strings
+++ b/Riot/Assets/vi.lproj/Localizable.strings
@@ -131,4 +131,4 @@
 "MSG_FROM_USER_IN_ROOM_TITLE" = "%@ trong %@";
 /** General **/
 
-"NOTIFICATION" = "Thông báo";
+"Notification" = "Thông báo";

--- a/Riot/Assets/zh_Hans.lproj/Localizable.strings
+++ b/Riot/Assets/zh_Hans.lproj/Localizable.strings
@@ -120,4 +120,4 @@
 "REPLY_FROM_USER_TITLE" = "%@ 回复了";
 /** General **/
 
-"NOTIFICATION" = "通知";
+"Notification" = "通知";

--- a/Riot/Categories/Bundle.swift
+++ b/Riot/Categories/Bundle.swift
@@ -19,7 +19,7 @@ import Foundation
 public extension Bundle {
     /// Returns the real app bundle.
     /// Can also be used in app extensions.
-    @objc static var app: Bundle {
+    @objc static let app: Bundle = {
         let bundle = main
         if bundle.bundleURL.pathExtension == "appex" {
             // Peel off two directory levels - MY_APP.app/PlugIns/MY_APP_EXTENSION.appex
@@ -29,7 +29,7 @@ public extension Bundle {
             }
         }
         return bundle
-    }
+    }()
     
     /// Get an lproj language bundle from the main app bundle.
     /// - Parameter language: The language to try to load.

--- a/Riot/target.yml
+++ b/Riot/target.yml
@@ -69,6 +69,7 @@ targets:
         - "Modules/Room/EmojiPicker/Data/EmojiMart/EmojiJSONStore.swift"
         - "Assets/ar.lproj/**" # RTL is broken so languages are disabled for now
         - "Assets/he.lproj/**"
+        - "Assets/pr.lproj/**" # Unsupported language on iOS
     - path: ../RiotShareExtension/Shared
     - path: Modules/MatrixKit
       excludes:

--- a/changelog.d/pr-6011.i18n
+++ b/changelog.d/pr-6011.i18n
@@ -1,0 +1,1 @@
+Fix notifications showing NOTIFICATION instead of Notification when a translation isn't available.


### PR DESCRIPTION
This PR adds a few small changes following on from #5936 and #5996.

- The `NOTIFICATION` key has been renamed to `Notification` as this is what will be shown for languages without a translation of this key.
- `Bundle.app` is now a stored property as its value isn't going to change and we're using it every time we load a string.
- The Pirate language has been excluded from the project as it generates a warning when submitting to ASC 🏴‍☠️

Note: I've synced with Weblate and locked it for now to avoid any conflicts with the change in the translations.