### PR TITLE
Display changelog folder into workspace

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -12,6 +12,7 @@ fileGroups:
     - AUTHORS.rst
     - Podfile
     - project.yml
+    - changelog.d
 
 configFiles:
   Debug: Config/Project-Debug.xcconfig


### PR DESCRIPTION
Small technical update to have a convenient access to create/browse changelog.d directly from Xcode workspace.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/80891108/162474136-1071fc23-7a92-44f8-86ed-1946761e4f92.png">

