### PR TITLE
Bump cocoapods-downloader from 1.5.1 to 1.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/security/dependabot/1