### PR TITLE
Log decryption error details as context in AnalyticsEvent

### DIFF
--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -261,12 +261,10 @@ extension Analytics {
     /// Track an E2EE error that occurred
     /// - Parameters:
     ///   - reason: The error that occurred.
-    ///   - count: The number of times that error occurred.
-    func trackE2EEError(_ reason: DecryptionFailureReason, count: Int) {
-        for _ in 0..<count {
-            let event = AnalyticsEvent.Error(context: nil, domain: .E2EE, name: reason.errorName)
-            capture(event: event)
-        }
+    ///   - context: Additional context of the error that occured
+    func trackE2EEError(_ reason: DecryptionFailureReason, context: String) {
+        let event = AnalyticsEvent.Error(context: context, domain: .E2EE, name: reason.errorName)
+        capture(event: event)
     }
     
     /// Track when a user becomes unauthenticated without pressing the `sign out` button.

--- a/Riot/Modules/Analytics/DecryptionFailure.swift
+++ b/Riot/Modules/Analytics/DecryptionFailure.swift
@@ -45,9 +45,12 @@ import AnalyticsEvents
     let ts: TimeInterval = Date().timeIntervalSince1970
     /// Decryption failure reason.
     let reason: DecryptionFailureReason
+    /// Additional context of failure
+    let context: String
     
-    init(failedEventId: String, reason: DecryptionFailureReason) {
+    init(failedEventId: String, reason: DecryptionFailureReason, context: String) {
         self.failedEventId = failedEventId
         self.reason = reason
+        self.context = context
     }
 }

--- a/Riot/Modules/Analytics/DecryptionFailureTracker.m
+++ b/Riot/Modules/Analytics/DecryptionFailureTracker.m
@@ -115,8 +115,10 @@ NSString *const kDecryptionFailureTrackerAnalyticsCategory = @"e2e.failure";
             break;
     }
 
+    NSString *context = [NSString stringWithFormat:@"code: %ld, description: %@", event.decryptionError.code, event.decryptionError.localizedDescription];
     reportedFailures[event.eventId] = [[DecryptionFailure alloc] initWithFailedEventId:failedEventId
-                                                                                reason:reason];
+                                                                                reason:reason
+                                                                               context:context];
 }
 
 - (void)dispatch
@@ -158,14 +160,10 @@ NSString *const kDecryptionFailureTrackerAnalyticsCategory = @"e2e.failure";
         for (DecryptionFailure *failure in failuresToTrack)
         {
             failuresCounts[@(failure.reason)] = @(failuresCounts[@(failure.reason)].unsignedIntegerValue + 1);
+            [self.delegate trackE2EEError:failure.reason context:failure.context];
         }
 
         MXLogDebug(@"[DecryptionFailureTracker] trackFailures: %@", failuresCounts);
-        
-        for (NSNumber *reason in failuresCounts)
-        {
-            [self.delegate trackE2EEError:reason.integerValue count:failuresCounts[reason].integerValue];
-        }
     }
 }
 

--- a/changelog.d/6046_uisi_context
+++ b/changelog.d/6046_uisi_context
@@ -1,0 +1,1 @@
+Analytics: Log decryption error details as context in AnalyticsEvent


### PR DESCRIPTION
Resolves #6046

Use the existing `context` property of `AnalyticsEvent` type to log additional details about UISI and decryption errors, which are currently being discared (and making it harder to monitor and fix errors). The `context` is just a string field and does not have any standardized format, in this particular PR I am logging the data as "code: X, description: more details of the error".

This PR is meant as a transitionary solution to find out faster what the majority of "unknown" errors in our analytics are. As the next step we would like to define a dedicated `DecryptionError` type in the analytics schema and define a broader range of errors suitable for our analytics.