### PR TITLE
Update issue labelling automation

### DIFF
--- a/.github/workflows/triage-move-labelled.yml
+++ b/.github/workflows/triage-move-labelled.yml
@@ -11,7 +11,6 @@ jobs:
     if: >
         contains(github.event.issue.labels.*.name, 'A-Maths') || 
         contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
-        contains(github.event.issue.labels.*.name, 'A-Threads') ||
         contains(github.event.issue.labels.*.name, 'A-Polls') ||
         contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
         contains(github.event.issue.labels.*.name, 'A-Message-Bubbles') ||


### PR DESCRIPTION
Don't label A-Threads with Z-Labs any more because threads have been released

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
