### PR TITLE
Fix crash with sections

### DIFF
--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -2194,10 +2194,14 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
             cellData = [self.dataSource cellDataAtIndexPath:nextIndexPath];
         }
         
-        if (!cellData && [self.recentsTableView numberOfRowsInSection:section] > 0)
+        if (!cellData && section < self.recentsTableView.numberOfSections && [self.recentsTableView numberOfRowsInSection:section] > 0)
         {
             // Scroll back to the top.
             [self.recentsTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section] atScrollPosition:UITableViewScrollPositionTop animated:YES];
+        }
+        else if (section >= self.recentsTableView.numberOfSections)
+        {
+            MXLogFailure(@"[RecentsViewController] Section %ld is invalid in a table view with only %ld sections", section, self.recentsTableView.numberOfSections);
         }
     }
 }


### PR DESCRIPTION
Fix crash of querying number of rows in a section when that section does not exist. This type of behaviour should not exist if we had a consistent data model, but there is an issue somewhere in the DataSource that creates inconsistent data model.

To fix the crash, we simply check number of existing sections and log and error otherwise.

There are a number of rageshakes possibily related to this crash:

https://github.com/matrix-org/element-ios-rageshakes/issues/18165
https://github.com/matrix-org/element-ios-rageshakes/issues/18160
https://github.com/matrix-org/element-ios-rageshakes/issues/18156
https://github.com/matrix-org/element-ios-rageshakes/issues/18150