### PR TITLE
[Location sharing] Fix timeline cell stop button

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -429,6 +429,6 @@ final class BuildSettings: NSObject {
         }
         
         // Do not enable live location sharing atm
-        return true
+        return false
     }
 }

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -429,6 +429,6 @@ final class BuildSettings: NSObject {
         }
         
         // Do not enable live location sharing atm
-        return false
+        return true
     }
 }

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/Location/LocationPlainCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/Location/LocationPlainCell.swift
@@ -32,6 +32,7 @@ class LocationPlainCell: SizableBaseRoomCell, RoomCellReactionsDisplayable, Room
         }
         
         locationView.update(theme: ThemeService.shared().theme)
+        locationView.delegate = self
         
         if bubbleData.cellDataTag == .location,
            let event = bubbleData.events.last {
@@ -130,18 +131,10 @@ class LocationPlainCell: SizableBaseRoomCell, RoomCellReactionsDisplayable, Room
 
 extension LocationPlainCell: RoomTimelineLocationViewDelegate {
     func roomTimelineLocationViewDidTapStopButton(_ roomTimelineLocationView: RoomTimelineLocationView) {
-        guard let event = self.event else {
-            return
-        }
-        
-        delegate.cell(self, didRecognizeAction: kMXKRoomBubbleCellStopShareButtonPressed, userInfo: [kMXKRoomBubbleCellEventKey: event])
+        delegate.cell(self, didRecognizeAction: kMXKRoomBubbleCellStopShareButtonPressed, userInfo: nil)
     }
     
     func roomTimelineLocationViewDidTapRetryButton(_ roomTimelineLocationView: RoomTimelineLocationView) {
-        guard let event = self.event else {
-            return
-        }
-        
-        delegate.cell(self, didRecognizeAction: kMXKRoomBubbleCellRetryShareButtonPressed, userInfo: [kMXKRoomBubbleCellEventKey: event])
+        delegate.cell(self, didRecognizeAction: kMXKRoomBubbleCellRetryShareButtonPressed, userInfo: nil)
     }
 }

--- a/changelog.d/6110.bugfix
+++ b/changelog.d/6110.bugfix
@@ -1,0 +1,1 @@
+Location sharing: fix stop button in timeline


### PR DESCRIPTION
close: #6110 

To test this, you need to start sharing your location from develop.element.io. Start live location sharing is not available yep on iOS.