### PR TITLE
Tidy up SwiftUI/Onboarding screens

### DIFF
--- a/DesignKit/Variants/Fonts/ElementFonts.swift
+++ b/DesignKit/Variants/Fonts/ElementFonts.swift
@@ -28,26 +28,7 @@ public class ElementFonts {
     /// (even if that font was created with the appropriate metrics).
     public struct SharedFont {
         public let uiFont: UIFont
-        /// The underlying font for the `font` property. This is stored
-        /// as an optional `Any` due to unavailability on iOS 12.
-        private let _font: Any?
-        
-        @available(iOS 13.0, *)
-        public var font: Font {
-            _font as! Font
-        }
-        
-        @available(iOS, deprecated: 13.0, message: "Use init(uiFont:font:) instead and remove this initialiser.")
-        init(uiFont: UIFont) {
-            self.uiFont = uiFont
-            self._font = nil
-        }
-        
-        @available(iOS 13.0, *)
-        init(uiFont: UIFont, font: Font) {
-            self.uiFont = uiFont
-            self._font = font
-        }
+        public let font: Font
     }
     
     // MARK: - Setup
@@ -69,213 +50,101 @@ extension ElementFonts: Fonts {
     
     public var largeTitle: SharedFont {
         let uiFont = self.font(forTextStyle: .largeTitle)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .largeTitle)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .largeTitle)
     }
     
     public var largeTitleB: SharedFont {
         let uiFont = self.largeTitle.uiFont.vc_bold
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .largeTitle.bold())
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .largeTitle.bold())
     }
             
     public var title1: SharedFont {
         let uiFont = self.font(forTextStyle: .title1)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .title)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .title)
     }
     
     public var title1B: SharedFont {
         let uiFont = self.title1.uiFont.vc_bold
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .title.bold())
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .title.bold())
     }
     
     public var title2: SharedFont {
         let uiFont = self.font(forTextStyle: .title2)
-        
-        if #available(iOS 14.0, *) {
-            return SharedFont(uiFont: uiFont, font: .title2)
-        } else if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: Font(uiFont))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .title2)
     }
     
     public var title2B: SharedFont {
         let uiFont = self.title2.uiFont.vc_bold
-        
-        if #available(iOS 14.0, *) {
-            return SharedFont(uiFont: uiFont, font: .title2.bold())
-        } else if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: Font(uiFont))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .title2.bold())
     }
     
     public var title3: SharedFont {
         let uiFont = self.font(forTextStyle: .title3)
-        
-        if #available(iOS 14.0, *) {
-            return SharedFont(uiFont: uiFont, font: .title3)
-        } else if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: Font(uiFont))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .title3)
     }
     
     public var title3SB: SharedFont {
         let uiFont = self.title3.uiFont.vc_semiBold
-        
-        if #available(iOS 14.0, *) {
-            return SharedFont(uiFont: uiFont, font: .title3.weight(.semibold))
-        } else if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: Font(uiFont))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .title3.weight(.semibold))
     }
     
     public var headline: SharedFont {
         let uiFont = self.font(forTextStyle: .headline)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .headline)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .headline)
     }
     
     public var subheadline: SharedFont {
         let uiFont = self.font(forTextStyle: .subheadline)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .subheadline)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .subheadline)
     }
     
     public var body: SharedFont {
         let uiFont = self.font(forTextStyle: .body)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .body)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .body)
     }
     
     public var bodySB: SharedFont {
         let uiFont = self.body.uiFont.vc_semiBold
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .body.weight(.semibold))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .body.weight(.semibold))
     }
     
     public var callout: SharedFont {
         let uiFont = self.font(forTextStyle: .callout)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .callout)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .callout)
     }
     
     public var calloutSB: SharedFont {
         let uiFont = self.callout.uiFont.vc_semiBold
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .callout.weight(.semibold))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .callout.weight(.semibold))
     }
     
     public var footnote: SharedFont {
         let uiFont = self.font(forTextStyle: .footnote)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .footnote)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .footnote)
     }
     
     public var footnoteSB: SharedFont {
         let uiFont = self.footnote.uiFont.vc_semiBold
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .footnote.weight(.semibold))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .footnote.weight(.semibold))
     }
     
     public var caption1: SharedFont {
         let uiFont = self.font(forTextStyle: .caption1)
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .caption)
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .caption)
     }
     
     public var caption1SB: SharedFont {
         let uiFont = self.caption1.uiFont.vc_semiBold
-        
-        if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: .caption.weight(.semibold))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .caption.weight(.semibold))
     }
     
     public var caption2: SharedFont {
         let uiFont = self.font(forTextStyle: .caption2)
-        
-        if #available(iOS 14.0, *) {
-            return SharedFont(uiFont: uiFont, font: .caption2)
-        } else if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: Font(uiFont))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .caption2)
     }
     
     public var caption2SB: SharedFont {
         let uiFont = self.caption2.uiFont.vc_semiBold
-        
-        if #available(iOS 14.0, *) {
-            return SharedFont(uiFont: uiFont, font: .caption2.weight(.semibold))
-        } else if #available(iOS 13.0, *) {
-            return SharedFont(uiFont: uiFont, font: Font(uiFont))
-        } else {
-            return SharedFont(uiFont: uiFont)
-        }
+        return SharedFont(uiFont: uiFont, font: .caption2.weight(.semibold))
     }
 }

--- a/Riot/Modules/Onboarding/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Onboarding/AuthenticationCoordinator.swift
@@ -18,7 +18,6 @@
 
 import UIKit
 
-@available(iOS 14.0, *)
 struct AuthenticationCoordinatorParameters {
     let navigationRouter: NavigationRouterType
     /// The screen that should be shown when starting the flow.
@@ -28,7 +27,6 @@ struct AuthenticationCoordinatorParameters {
 }
 
 /// A coordinator that handles authentication, verification and setting a PIN.
-@available(iOS 14.0, *)
 final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtocol {
     
     enum EntryPoint {
@@ -150,7 +148,6 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
         }
     }
     
-    @available(iOS 14.0, *)
     /// Shows the next screen in the flow after the server selection screen.
     @MainActor private func serverSelectionCoordinator(_ coordinator: AuthenticationServerSelectionCoordinator,
                                                        didCompleteWith result: AuthenticationServerSelectionCoordinatorResult) {
@@ -189,7 +186,6 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     }
     
     /// Displays the next view in the flow after the registration screen.
-    @available(iOS 14.0, *)
     @MainActor private func registrationCoordinator(_ coordinator: AuthenticationRegistrationCoordinator,
                                                     didCompleteWith result: AuthenticationRegistrationCoordinatorResult) {
         switch result {
@@ -292,7 +288,6 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
 }
 
 // MARK: - KeyVerificationCoordinatorDelegate
-@available(iOS 14.0, *)
 extension AuthenticationCoordinator: KeyVerificationCoordinatorDelegate {
     func keyVerificationCoordinatorDidComplete(_ coordinator: KeyVerificationCoordinatorType, otherUserId: String, otherDeviceId: String) {
         if let crypto = session?.crypto,
@@ -314,7 +309,6 @@ extension AuthenticationCoordinator: KeyVerificationCoordinatorDelegate {
 }
 
 // MARK: - UIAdaptivePresentationControllerDelegate
-@available(iOS 14.0, *)
 extension AuthenticationCoordinator: UIAdaptivePresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         // Prevent Key Verification from using swipe to dismiss
@@ -325,7 +319,6 @@ extension AuthenticationCoordinator: UIAdaptivePresentationControllerDelegate {
 
 
 // MARK: - Unused conformances
-@available(iOS 14.0, *)
 extension AuthenticationCoordinator {
     var customServerFieldsVisible: Bool {
         get { false }

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -101,7 +101,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     
     func start() {
         // TODO: Manage a separate flow for soft logout that just uses AuthenticationCoordinator
-        if #available(iOS 14.0, *), parameters.softLogoutCredentials == nil, BuildSettings.authScreenShowRegister {
+        if parameters.softLogoutCredentials == nil, BuildSettings.authScreenShowRegister {
             showSplashScreen()
         } else {
             showLegacyAuthenticationScreen()
@@ -134,7 +134,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     
     // MARK: - Pre-Authentication
     
-    @available(iOS 14.0, *)
     /// Show the onboarding splash screen as the root module in the flow.
     private func showSplashScreen() {
         MXLog.debug("[OnboardingCoordinator] showSplashScreen")
@@ -151,7 +150,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         navigationRouter.setRootModule(coordinator, popCompletion: nil)
     }
     
-    @available(iOS 14.0, *)
     /// Displays the next view in the flow after the splash screen.
     private func splashScreenCoordinator(_ coordinator: OnboardingSplashScreenCoordinator, didCompleteWith result: OnboardingSplashScreenViewModelResult) {
         splashScreenResult = result
@@ -167,7 +165,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         }
     }
     
-    @available(iOS 14.0, *)
     /// Show the use case screen for new users.
     private func showUseCaseSelectionScreen() {
         MXLog.debug("[OnboardingCoordinator] showUseCaseSelectionScreen")
@@ -191,7 +188,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     }
     
     /// Displays the next view in the flow after the use case screen.
-    @available(iOS 14.0, *)
     private func useCaseSelectionCoordinator(_ coordinator: OnboardingUseCaseSelectionCoordinator, didCompleteWith result: OnboardingUseCaseViewModelResult) {
         useCaseResult = result
         
@@ -210,7 +206,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     // MARK: - Authentication
     
     /// Show the authentication flow, starting at the specified initial screen.
-    @available(iOS 14.0, *)
     private func beginAuthentication(with initialScreen: AuthenticationCoordinator.EntryPoint) {
         MXLog.debug("[OnboardingCoordinator] beginAuthentication")
         
@@ -294,22 +289,20 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         self.authenticationType = authenticationType
         
         // Check whether another screen should be shown.
-        if #available(iOS 14.0, *) {
-            if authenticationFlow == .register,
-               let userId = session.credentials.userId,
-               let userSession = UserSessionsService.shared.userSession(withUserId: userId) {
-                // If personalisation is to be shown, check that the homeserver supports it otherwise show the congratulations screen
-                if BuildSettings.onboardingShowAccountPersonalization {
-                    checkHomeserverCapabilities(for: userSession)
-                    return
-                } else {
-                    showCongratulationsScreen(for: userSession)
-                    return
-                }
-            } else if Analytics.shared.shouldShowAnalyticsPrompt {
-                showAnalyticsPrompt(for: session)
+        if authenticationFlow == .register,
+           let userId = session.credentials.userId,
+           let userSession = UserSessionsService.shared.userSession(withUserId: userId) {
+            // If personalisation is to be shown, check that the homeserver supports it otherwise show the congratulations screen
+            if BuildSettings.onboardingShowAccountPersonalization {
+                checkHomeserverCapabilities(for: userSession)
+                return
+            } else {
+                showCongratulationsScreen(for: userSession)
                 return
             }
+        } else if Analytics.shared.shouldShowAnalyticsPrompt {
+            showAnalyticsPrompt(for: session)
+            return
         }
         
         // Otherwise onboarding is finished.
@@ -321,7 +314,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     /// whether or not the display name and avatar can be updated.
     ///
     /// Once complete this method will start the post authentication flow automatically.
-    @available(iOS 14.0, *)
     private func checkHomeserverCapabilities(for userSession: UserSession) {
         userSession.matrixSession.matrixRestClient.capabilities { [weak self] capabilities in
             guard let self = self else { return }
@@ -358,13 +350,11 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     // MARK: - Post-Authentication
     
     /// Starts the part of the flow that comes after authentication for new users.
-    @available(iOS 14.0, *)
     private func beginPostAuthentication(for userSession: UserSession) {
         showCongratulationsScreen(for: userSession)
     }
     
     /// Show the congratulations screen for new users. The screen will be configured based on the homeserver's capabilities.
-    @available(iOS 14.0, *)
     private func showCongratulationsScreen(for userSession: UserSession) {
         MXLog.debug("[OnboardingCoordinator] showCongratulationsScreen")
         
@@ -387,7 +377,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     }
     
     /// Displays the next view in the flow after the congratulations screen.
-    @available(iOS 14.0, *)
     private func congratulationsCoordinator(_ coordinator: OnboardingCongratulationsCoordinator, didCompleteWith result: OnboardingCongratulationsCoordinatorResult) {
         switch result {
         case .personalizeProfile(let userSession):
@@ -413,7 +402,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     }
     
     /// Show the display name personalization screen for new users using the supplied user session.
-    @available(iOS 14.0, *)
     private func showDisplayNameScreen(for userSession: UserSession) {
         MXLog.debug("[OnboardingCoordinator]: showDisplayNameScreen")
         
@@ -434,7 +422,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     }
     
     /// Displays the next view in the flow after the display name screen.
-    @available(iOS 14.0, *)
     private func displayNameCoordinator(_ coordinator: OnboardingDisplayNameCoordinator, didCompleteWith userSession: UserSession) {
         if shouldShowAvatarScreen {
             showAvatarScreen(for: userSession)
@@ -444,7 +431,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     }
     
     /// Show the avatar personalization screen for new users using the supplied user session.
-    @available(iOS 14.0, *)
     private func showAvatarScreen(for userSession: UserSession) {
         MXLog.debug("[OnboardingCoordinator]: showAvatarScreen")
         
@@ -479,7 +465,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     }
     
     /// Displays the next view in the flow after the avatar screen.
-    @available(iOS 14.0, *)
     private func avatarCoordinator(_ coordinator: OnboardingAvatarCoordinator, didCompleteWith userSession: UserSession) {
         showCelebrationScreen(for: userSession)
         
@@ -487,7 +472,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         selectedAvatar = nil
     }
     
-    @available(iOS 14.0, *)
     private func showCelebrationScreen(for userSession: UserSession) {
         MXLog.debug("[OnboardingCoordinator] showCelebrationScreen")
         
@@ -507,7 +491,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         }
     }
     
-    @available(iOS 14.0, *)
     private func celebrationCoordinator(_ coordinator: OnboardingCelebrationCoordinator, didCompleteWith userSession: UserSession) {
         if Analytics.shared.shouldShowAnalyticsPrompt {
             showAnalyticsPrompt(for: userSession.matrixSession)
@@ -521,7 +504,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
     /// Shows the analytics prompt for the supplied session.
     ///
     /// Check `Analytics.shared.shouldShowAnalyticsPrompt` before calling this method.
-    @available(iOS 14.0, *)
     private func showAnalyticsPrompt(for session: MXSession) {
         MXLog.debug("[OnboardingCoordinator]: Invite the user to send analytics")
         

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPrompt.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPrompt.swift
@@ -60,6 +60,7 @@ struct AnalyticsPrompt: View {
             
             AnalyticsPromptCheckmarkItem(string: VectorL10n.analyticsPromptPoint3)
         }
+        .fixedSize(horizontal: false, vertical: true)
         .font(theme.fonts.body)
         .frame(maxWidth: .infinity)
     }
@@ -118,14 +119,13 @@ struct AnalyticsPrompt: View {
                         .frame(height: OnboardingMetrics.spacerHeight(in: geometry))
                     
                     mainContent
-                        .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                        .readableFrame()
                         .padding(.horizontal, horizontalPadding)
                         .padding(.top, OnboardingMetrics.breakerScreenTopPadding)
                 }
-                .frame(maxWidth: .infinity)
                 
                 buttons
-                    .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                    .readableFrame()
                     .padding(.horizontal, horizontalPadding)
                     .padding(.bottom, OnboardingMetrics.actionButtonBottomPadding)
                     .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
@@ -16,12 +16,10 @@
 
 import Foundation
 
-@available(iOS 14.0, *)
 protocol AuthenticationServiceDelegate: AnyObject {
     func authenticationServiceDidUpdateRegistrationParameters(_ authenticationService: AuthenticationService)
 }
 
-@available(iOS 14.0, *)
 class AuthenticationService: NSObject {
     
     /// The shared service object.

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationState.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationState.swift
@@ -17,7 +17,6 @@
 import Foundation
 import MatrixSDK
 
-@available(iOS 14.0, *)
 struct AuthenticationState {
     // var serverType: ServerType = .unknown
     var flow: AuthenticationFlow

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
@@ -16,7 +16,6 @@
 
 import Foundation
 
-@available(iOS 14.0, *)
 /// Set of methods to be able to create an account on a homeserver.
 ///
 /// Common scenario to register an account successfully:

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModel.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModel.swift
@@ -17,13 +17,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias AuthenticationRegistrationViewModelType = StateStoreViewModel<AuthenticationRegistrationViewState,
                                                                         Never,
                                                                         AuthenticationRegistrationViewAction>
 
-
-@available(iOS 14, *)
 class AuthenticationRegistrationViewModel: AuthenticationRegistrationViewModelType, AuthenticationRegistrationViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModelProtocol.swift
@@ -19,7 +19,6 @@ import Foundation
 protocol AuthenticationRegistrationViewModelProtocol {
     
     @MainActor var completion: ((AuthenticationRegistrationViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: AuthenticationRegistrationViewModelType.Context { get }
     
     /// Update the view with new homeserver information.

--- a/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
@@ -18,7 +18,6 @@ import SwiftUI
 import CommonKit
 import MatrixSDK
 
-@available(iOS 14.0, *)
 struct AuthenticationRegistrationCoordinatorParameters {
     let navigationRouter: NavigationRouterType
     let authenticationService: AuthenticationService
@@ -35,7 +34,6 @@ enum AuthenticationRegistrationCoordinatorResult {
     case completed(RegistrationResult)
 }
 
-@available(iOS 14.0, *)
 final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/Registration/MockAuthenticationRegistrationScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/MockAuthenticationRegistrationScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationRegistrationScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Authentication/Registration/Test/UI/AuthenticationRegistrationUITests.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Test/UI/AuthenticationRegistrationUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class AuthenticationRegistrationUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Authentication/Registration/Test/Unit/AuthenticationRegistrationViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Test/Unit/AuthenticationRegistrationViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 @MainActor class AuthenticationRegistrationViewModelTests: XCTestCase {
     var viewModel: AuthenticationRegistrationViewModelProtocol!
     var context: AuthenticationRegistrationViewModelType.Context!

--- a/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct AuthenticationRegistrationScreen: View {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
@@ -57,27 +57,20 @@ struct AuthenticationRegistrationScreen: View {
                 }
                 
             }
-            .frame(maxWidth: OnboardingMetrics.maxContentWidth)
-            .frame(maxWidth: .infinity)
+            .readableFrame()
             .padding(.horizontal, 16)
             .padding(.bottom, 16)
         }
-        .accentColor(theme.colors.accent)
         .background(theme.colors.background.ignoresSafeArea())
         .alert(item: $viewModel.alertInfo) { $0.alert }
+        .accentColor(theme.colors.accent)
     }
     
     /// The header containing the icon, title and message.
     var header: some View {
         VStack(spacing: 8) {
-            Image(Asset.Images.onboardingCongratulationsIcon.name)
-                .resizable()
-                .renderingMode(.template)
-                .foregroundColor(theme.colors.accent)
-                .frame(width: 90, height: 90)
-                .background(Circle().foregroundColor(.white).padding(2))
+            OnboardingIconImage(image: Asset.Images.onboardingCongratulationsIcon)
                 .padding(.bottom, 8)
-                .accessibilityHidden(true)
             
             Text(VectorL10n.authenticationRegistrationTitle)
                 .font(theme.fonts.title2B)

--- a/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationSSOButton.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationSSOButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// An button that displays the icon and name of an SSO provider.
 struct AuthenticationSSOButton: View {
     

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModel.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModel.swift
@@ -16,11 +16,10 @@
 
 import SwiftUI
 
-@available(iOS 14, *)
 typealias AuthenticationServerSelectionViewModelType = StateStoreViewModel<AuthenticationServerSelectionViewState,
                                                                            Never,
                                                                            AuthenticationServerSelectionViewAction>
-@available(iOS 14, *)
+
 class AuthenticationServerSelectionViewModel: AuthenticationServerSelectionViewModelType, AuthenticationServerSelectionViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModelProtocol.swift
@@ -19,7 +19,6 @@ import Foundation
 protocol AuthenticationServerSelectionViewModelProtocol {
     
     @MainActor var completion: ((AuthenticationServerSelectionViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: AuthenticationServerSelectionViewModelType.Context { get }
     
     /// Displays an error to the user.

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/Coordinator/AuthenticationServerSelectionCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/Coordinator/AuthenticationServerSelectionCoordinator.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import CommonKit
 
-@available(iOS 14.0, *)
 struct AuthenticationServerSelectionCoordinatorParameters {
     let authenticationService: AuthenticationService
     /// Whether the screen is presented modally or within a navigation stack.
@@ -29,7 +28,6 @@ enum AuthenticationServerSelectionCoordinatorResult {
     case dismiss
 }
 
-@available(iOS 14.0, *)
 final class AuthenticationServerSelectionCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/MockAuthenticationServerSelectionScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/MockAuthenticationServerSelectionScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationServerSelectionScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/Test/UI/AuthenticationServerSelectionUITests.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/Test/UI/AuthenticationServerSelectionUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class AuthenticationServerSelectionUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/Test/Unit/AuthenticationServerSelectionViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/Test/Unit/AuthenticationServerSelectionViewModelTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class AuthenticationServerSelectionViewModelTests: XCTestCase {
     private enum Constants {
         static let counterInitialValue = 0

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/View/AuthenticationServerSelectionScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/View/AuthenticationServerSelectionScreen.swift
@@ -53,8 +53,8 @@ struct AuthenticationServerSelectionScreen: View {
                         emsBanner
                             .padding(.vertical, 16)
                     }
-                    .frame(maxWidth: OnboardingMetrics.maxContentWidth, minHeight: geometry.size.height)
-                    .frame(maxWidth: .infinity)
+                    .readableFrame()
+                    .frame(minHeight: geometry.size.height)
                     .padding(.horizontal, 16)
                     .onAppear { scrollView = reader }
                 }
@@ -70,14 +70,8 @@ struct AuthenticationServerSelectionScreen: View {
     /// The title, message and icon at the top of the screen.
     var header: some View {
         VStack(spacing: 8) {
-            Image(Asset.Images.authenticationServerSelectionIcon.name)
-                .resizable()
-                .renderingMode(.template)
-                .foregroundColor(theme.colors.accent)
-                .frame(width: 90, height: 90)
-                .background(Circle().foregroundColor(.white).padding(4))
+            OnboardingIconImage(image: Asset.Images.authenticationServerSelectionIcon)
                 .padding(.bottom, 8)
-                .accessibilityHidden(true)
             
             Text(VectorL10n.authenticationServerSelectionTitle)
                 .font(theme.fonts.title2B)

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/View/AuthenticationServerSelectionScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/View/AuthenticationServerSelectionScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct AuthenticationServerSelectionScreen: View {
     
     enum Constants {

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/Coordinator/OnboardingAvatarCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/Coordinator/OnboardingAvatarCoordinator.swift
@@ -30,7 +30,6 @@ enum OnboardingAvatarCoordinatorResult {
     case complete(UserSession)
 }
 
-@available(iOS 14.0, *)
 final class OnboardingAvatarCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties
@@ -178,7 +177,6 @@ final class OnboardingAvatarCoordinator: Coordinator, Presentable {
 
 // MARK: - MediaPickerPresenterDelegate
 
-@available(iOS 14.0, *)
 extension OnboardingAvatarCoordinator: MediaPickerPresenterDelegate {
     /// **Note:** MediaPickerPresenter fails to load images on the simulator as of Xcode 13.3 (at least on an M1 Mac),
     /// so whilst this method may not appear to be called, everything works fine when run on a device.
@@ -195,7 +193,6 @@ extension OnboardingAvatarCoordinator: MediaPickerPresenterDelegate {
 
 // MARK: - CameraPresenterDelegate
 
-@available(iOS 14.0, *)
 extension OnboardingAvatarCoordinator: CameraPresenterDelegate {
     func cameraPresenter(_ presenter: CameraPresenter, didSelectImage image: UIImage) {
         onboardingAvatarViewModel.updateAvatarImage(with: image)

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/MockOnboardingAvatarScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/MockOnboardingAvatarScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockOnboardingAvatarScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you
@@ -63,7 +62,6 @@ enum MockOnboardingAvatarScreenState: MockScreenState, CaseIterable {
     }
 }
 
-@available(iOS 14.0, *)
 extension MockOnboardingAvatarScreenState: CustomStringConvertible {
     // Added to have different descriptions in the SwiftUI target's list.
     var description: String {

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModel.swift
@@ -17,11 +17,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias OnboardingAvatarViewModelType = StateStoreViewModel<OnboardingAvatarViewState,
                                                               Never,
                                                               OnboardingAvatarViewAction>
-@available(iOS 14, *)
+
 class OnboardingAvatarViewModel: OnboardingAvatarViewModelType, OnboardingAvatarViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModelProtocol.swift
@@ -19,7 +19,6 @@ import SwiftUI
 protocol OnboardingAvatarViewModelProtocol {
     
     var completion: ((OnboardingAvatarViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: OnboardingAvatarViewModelType.Context { get }
     
     /// Update the view model to show the image that the user has picked.

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/Test/UI/OnboardingAvatarUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/Test/UI/OnboardingAvatarUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingAvatarUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/Test/Unit/OnboardingAvatarViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/Test/Unit/OnboardingAvatarViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingAvatarViewModelTests: XCTestCase {
     private enum Constants {
         static let userId = "@user:matrix.org"

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/View/OnboardingAvatarScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/View/OnboardingAvatarScreen.swift
@@ -43,14 +43,14 @@ struct OnboardingAvatarScreen: View {
                 
                 buttons
             }
-            .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+            .readableFrame()
             .padding(.horizontal)
             .padding(.top, OnboardingMetrics.topPaddingToNavigationBar)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accentColor(theme.colors.accent)
+        .frame(maxHeight: .infinity)
         .background(theme.colors.background.ignoresSafeArea())
         .alert(item: $viewModel.alertInfo) { $0.alert }
+        .accentColor(theme.colors.accent)
     }
     
     

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/View/OnboardingAvatarScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/View/OnboardingAvatarScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import DesignKit
 
-@available(iOS 14.0, *)
 struct OnboardingAvatarScreen: View {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/Coordinator/OnboardingCelebrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/Coordinator/OnboardingCelebrationCoordinator.swift
@@ -20,7 +20,6 @@ struct OnboardingCelebrationCoordinatorParameters {
     let userSession: UserSession
 }
 
-@available(iOS 14.0, *)
 final class OnboardingCelebrationCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/MockOnboardingCelebrationScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/MockOnboardingCelebrationScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockOnboardingCelebrationScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/OnboardingCelebrationViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/OnboardingCelebrationViewModel.swift
@@ -16,11 +16,10 @@
 
 import SwiftUI
 
-@available(iOS 14, *)
 typealias OnboardingCelebrationViewModelType = StateStoreViewModel<OnboardingCelebrationViewState,
-                                                                  Never,
-                                                                  OnboardingCelebrationViewAction>
-@available(iOS 14, *)
+                                                                   Never,
+                                                                   OnboardingCelebrationViewAction>
+
 class OnboardingCelebrationViewModel: OnboardingCelebrationViewModelType, OnboardingCelebrationViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/OnboardingCelebrationViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/OnboardingCelebrationViewModelProtocol.swift
@@ -19,6 +19,5 @@ import Foundation
 protocol OnboardingCelebrationViewModelProtocol {
     
     var completion: (() -> Void)? { get set }
-    @available(iOS 14, *)
     var context: OnboardingCelebrationViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/Test/UI/OnboardingCelebrationUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/Test/UI/OnboardingCelebrationUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingCelebrationUITests: MockScreenTest {
     // Nothing to test as the view is completely static
 }

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/Test/Unit/OnboardingCelebrationViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/Test/Unit/OnboardingCelebrationViewModelTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingCelebrationViewModelTests: XCTestCase {
     // Nothing to test as there is no mutable state
 }

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
@@ -39,19 +39,18 @@ struct OnboardingCelebrationScreen: View {
     var body: some View {
         GeometryReader { geometry in
             VStack {
-                ScrollView(showsIndicators: false) {
+                ScrollView {
                     Spacer()
                         .frame(height: OnboardingMetrics.spacerHeight(in: geometry))
                     
                     mainContent
-                        .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                        .readableFrame()
                         .padding(.top, OnboardingMetrics.breakerScreenTopPadding)
                         .padding(.horizontal, horizontalPadding)
                 }
-                .frame(maxWidth: .infinity)
                 
                 buttons
-                    .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                    .readableFrame()
                     .padding(.horizontal, horizontalPadding)
                     .padding(.bottom, OnboardingMetrics.actionButtonBottomPadding)
                     .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
@@ -59,7 +58,7 @@ struct OnboardingCelebrationScreen: View {
                 Spacer()
                     .frame(height: OnboardingMetrics.spacerHeight(in: geometry))
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxHeight: .infinity)
         }
         .overlay(effects.ignoresSafeArea())
         .background(theme.colors.background.ignoresSafeArea())

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import SceneKit
 
-@available(iOS 14.0, *)
 struct OnboardingCelebrationScreen: View {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Common/OnboardingButtonStyle.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Common/OnboardingButtonStyle.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OnboardingButtonStyle: ButtonStyle {
     @Environment(\.theme) private var theme
     

--- a/RiotSwiftUI/Modules/Onboarding/Common/OnboardingMetrics.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Common/OnboardingMetrics.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 /// Metrics used across the entire onboarding flow.
-@available(iOS 14.0, *)
 struct OnboardingMetrics {
     static let maxContentWidth: CGFloat = 600
     static let maxContentHeight: CGFloat = 750

--- a/RiotSwiftUI/Modules/Onboarding/Common/OnboardingTintedFullStopText.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Common/OnboardingTintedFullStopText.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A view that displays text, highlighting the first occurrence of
 /// the character `.` in the theme's accent color.
 struct OnboardingTintedFullStopText: View {

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
@@ -31,7 +31,6 @@ enum OnboardingCongratulationsCoordinatorResult {
     case takeMeHome(UserSession)
 }
 
-@available(iOS 14.0, *)
 final class OnboardingCongratulationsCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/MockOnboardingCongratulationsScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/MockOnboardingCongratulationsScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockOnboardingCongratulationsScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModel.swift
@@ -16,11 +16,10 @@
 
 import SwiftUI
 
-@available(iOS 14, *)
 typealias OnboardingCongratulationsViewModelType = StateStoreViewModel<OnboardingCongratulationsViewState,
-                                                                  Never,
-                                                                  OnboardingCongratulationsViewAction>
-@available(iOS 14, *)
+                                                                       Never,
+                                                                       OnboardingCongratulationsViewAction>
+
 class OnboardingCongratulationsViewModel: OnboardingCongratulationsViewModelType, OnboardingCongratulationsViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/OnboardingCongratulationsViewModelProtocol.swift
@@ -19,6 +19,5 @@ import Foundation
 protocol OnboardingCongratulationsViewModelProtocol {
     
     var completion: ((OnboardingCongratulationsViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: OnboardingCongratulationsViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/UI/OnboardingCongratulationsUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/UI/OnboardingCongratulationsUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingCongratulationsUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/Unit/OnboardingCongratulationsViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/Unit/OnboardingCongratulationsViewModelTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingCongratulationsViewModelTests: XCTestCase {
     // The view modal has minimal set up and no mutation so nothing to test.
 }

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
@@ -43,14 +43,13 @@ struct OnboardingCongratulationsScreen: View {
                         .frame(height: OnboardingMetrics.spacerHeight(in: geometry))
                     
                     mainContent
-                        .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                        .readableFrame()
                         .padding(.top, OnboardingMetrics.breakerScreenTopPadding)
                         .padding(.horizontal, horizontalPadding)
                 }
-                .frame(maxWidth: .infinity)
                 
                 footer
-                    .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                    .readableFrame()
                     .padding(.horizontal, horizontalPadding)
                     .padding(.bottom, OnboardingMetrics.actionButtonBottomPadding)
                     .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
@@ -62,9 +61,9 @@ struct OnboardingCongratulationsScreen: View {
         }
         .overlay(effects.ignoresSafeArea())
         .background(theme.colors.accent.ignoresSafeArea())
-        .accentColor(.white)
         .navigationBarHidden(true)
         .preferredColorScheme(.dark)    // make the status bar white
+        .accentColor(.white)
     }
     
     /// The main content of the view to be shown in a scroll view.

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OnboardingCongratulationsScreen: View {
 
     // MARK: - Properties
@@ -142,7 +141,6 @@ struct OnboardingCongratulationsScreen: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct OnboardingCongratulationsScreen_Previews: PreviewProvider {
     static let stateRenderer = MockOnboardingCongratulationsScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/Coordinator/OnboardingDisplayNameCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/Coordinator/OnboardingDisplayNameCoordinator.swift
@@ -21,7 +21,6 @@ struct OnboardingDisplayNameCoordinatorParameters {
     let userSession: UserSession
 }
 
-@available(iOS 14.0, *)
 final class OnboardingDisplayNameCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/MockOnboardingDisplayNameScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/MockOnboardingDisplayNameScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockOnboardingDisplayNameScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/OnboardingDisplayNameViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/OnboardingDisplayNameViewModel.swift
@@ -17,11 +17,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias OnboardingDisplayNameViewModelType = StateStoreViewModel<OnboardingDisplayNameViewState,
-                                                                 Never,
-                                                                 OnboardingDisplayNameViewAction>
-@available(iOS 14, *)
+                                                                   Never,
+                                                                   OnboardingDisplayNameViewAction>
+
 class OnboardingDisplayNameViewModel: OnboardingDisplayNameViewModelType, OnboardingDisplayNameViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/OnboardingDisplayNameViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/OnboardingDisplayNameViewModelProtocol.swift
@@ -19,7 +19,6 @@ import Foundation
 protocol OnboardingDisplayNameViewModelProtocol {
     
     var completion: ((OnboardingDisplayNameViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: OnboardingDisplayNameViewModelType.Context { get }
     
     /// Update the view model to show that an error has occurred.

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/Test/UI/OnboardingDisplayNameUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/Test/UI/OnboardingDisplayNameUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingDisplayNameUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/Test/Unit/OnboardingDisplayNameViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/Test/Unit/OnboardingDisplayNameViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingDisplayNameViewModelTests: XCTestCase {
     var viewModel: OnboardingDisplayNameViewModel!
     var context: OnboardingDisplayNameViewModelType.Context!

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/View/OnboardingDisplayNameScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/View/OnboardingDisplayNameScreen.swift
@@ -48,14 +48,14 @@ struct OnboardingDisplayNameScreen: View {
                 
                 buttons
             }
-            .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+            .readableFrame()
             .padding(.horizontal)
             .padding(.top, OnboardingMetrics.topPaddingToNavigationBar)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accentColor(theme.colors.accent)
+        .frame(maxHeight: .infinity)
         .background(theme.colors.background.ignoresSafeArea())
         .alert(item: $viewModel.alertInfo) { $0.alert }
+        .accentColor(theme.colors.accent)
         .onChange(of: viewModel.displayName) { _ in
             viewModel.send(viewAction: .validateDisplayName)
         }

--- a/RiotSwiftUI/Modules/Onboarding/DisplayName/View/OnboardingDisplayNameScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/DisplayName/View/OnboardingDisplayNameScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OnboardingDisplayNameScreen: View {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/Coordinator/OnboardingSplashScreenCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/Coordinator/OnboardingSplashScreenCoordinator.swift
@@ -20,7 +20,6 @@ protocol OnboardingSplashScreenCoordinatorProtocol: Coordinator, Presentable {
     var completion: ((OnboardingSplashScreenViewModelResult) -> Void)? { get set }
 }
 
-@available(iOS 14.0, *)
 final class OnboardingSplashScreenCoordinator: OnboardingSplashScreenCoordinatorProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/MockOnboardingSplashScreenScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/MockOnboardingSplashScreenScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockOnboardingSplashScreenScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/OnboardingSplashScreenModels.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/OnboardingSplashScreenModels.swift
@@ -18,7 +18,6 @@ import SwiftUI
 
 // MARK: - Coordinator
 
-@available(iOS 13.0, *)
 /// The content displayed in a single splash screen page.
 struct OnboardingSplashScreenPageContent {
     let title: String
@@ -37,7 +36,6 @@ enum OnboardingSplashScreenViewModelResult {
 
 // MARK: View
 
-@available(iOS 13.0, *)
 struct OnboardingSplashScreenViewState: BindableState, CustomDebugStringConvertible {
     
     // MARK: - Constants

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/OnboardingSplashScreenViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/OnboardingSplashScreenViewModel.swift
@@ -17,19 +17,15 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias OnboardingSplashScreenViewModelType = StateStoreViewModel<OnboardingSplashScreenViewState,
                                                                     Never,
                                                                     OnboardingSplashScreenViewAction>
 
 protocol OnboardingSplashScreenViewModelProtocol {
     var completion: ((OnboardingSplashScreenViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: OnboardingSplashScreenViewModelType.Context { get }
 }
 
-
-@available(iOS 14, *)
 class OnboardingSplashScreenViewModel: OnboardingSplashScreenViewModelType, OnboardingSplashScreenViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/Test/Unit/OnboardingSplashScreenViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/Test/Unit/OnboardingSplashScreenViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingSplashScreenViewModelTests: XCTestCase {
     
 }

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/View/OnboardingSplashScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/View/OnboardingSplashScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// The splash screen shown at the beginning of the onboarding flow.
 struct OnboardingSplashScreen: View {
 
@@ -199,7 +198,6 @@ struct OnboardingSplashScreen: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct OnboardingSplashScreen_Previews: PreviewProvider {
     static let stateRenderer = MockOnboardingSplashScreenScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/View/OnboardingSplashScreenPage.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/View/OnboardingSplashScreenPage.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OnboardingSplashScreenPage: View {
     
     // MARK: - Properties
@@ -75,7 +74,6 @@ struct OnboardingSplashScreenPage: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct OnboardingSplashScreenPage_Previews: PreviewProvider {
     static let content = OnboardingSplashScreenViewState().content
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/View/OnboardingSplashScreenPageIndicator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/View/OnboardingSplashScreenPageIndicator.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OnboardingSplashScreenPageIndicator: View {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/Coordinator/OnboardingUseCaseSelectionCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/Coordinator/OnboardingUseCaseSelectionCoordinator.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 final class OnboardingUseCaseSelectionCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/MockOnboardingUseCaseScreenState.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/MockOnboardingUseCaseScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockOnboardingUseCaseSelectionScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/OnboardingUseCaseViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/OnboardingUseCaseViewModel.swift
@@ -16,11 +16,10 @@
 
 import SwiftUI
 
-@available(iOS 14, *)
 typealias OnboardingUseCaseViewModelType = StateStoreViewModel<OnboardingUseCaseViewState,
-                                                                 OnboardingUseCaseStateAction,
-                                                                 OnboardingUseCaseViewAction>
-@available(iOS 14, *)
+                                                               OnboardingUseCaseStateAction,
+                                                               OnboardingUseCaseViewAction>
+
 class OnboardingUseCaseViewModel: OnboardingUseCaseViewModelType, OnboardingUseCaseViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/OnboardingUseCaseViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/OnboardingUseCaseViewModelProtocol.swift
@@ -19,6 +19,5 @@ import Foundation
 protocol OnboardingUseCaseViewModelProtocol {
     
     var completion: ((OnboardingUseCaseViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: OnboardingUseCaseViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/Test/UI/OnboardingUseCaseUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/Test/UI/OnboardingUseCaseUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingUseCaseUITests: MockScreenTest {
     // The view has no parameters or changing state to test.
 }

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/Test/Unit/OnboardingUseCaseViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/Test/Unit/OnboardingUseCaseViewModelTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class OnboardingUseCaseViewModelTests: XCTestCase {
     // The view model has nothing to test.
 }

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseButton.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A button used for the Use Case selection.
 struct OnboardingUseCaseButton: View {
     
@@ -48,7 +47,6 @@ struct OnboardingUseCaseButton: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct Previews_OnboardingUseCaseButton_Previews: PreviewProvider {
     static var previews: some View {
         OnboardingUseCaseButton(title: VectorL10n.onboardingUseCaseWorkMessaging,

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseSelectionScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseSelectionScreen.swift
@@ -102,12 +102,11 @@ struct OnboardingUseCaseSelectionScreen: View {
                         
                         useCaseButtons
                     }
-                    .frame(maxWidth: OnboardingMetrics.maxContentWidth)
+                    .readableFrame()
                     .padding(.top, OnboardingMetrics.topPaddingToNavigationBar)
                     .padding(.bottom, 8)
                     .padding(.horizontal, 16)
                 }
-                .frame(maxWidth: .infinity)
                 
                 serverFooter
                     .padding(.horizontal, 16)
@@ -128,7 +127,9 @@ struct OnboardingUseCase_Previews: PreviewProvider {
     static var previews: some View {
         stateRenderer.screenGroup(addNavigation: true)
             .theme(.light).preferredColorScheme(.light)
+            .navigationViewStyle(.stack)
         stateRenderer.screenGroup(addNavigation: true)
             .theme(.dark).preferredColorScheme(.dark)
+            .navigationViewStyle(.stack)
     }
 }

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseSelectionScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseSelectionScreen.swift
@@ -37,10 +37,12 @@ struct OnboardingUseCaseSelectionScreen: View {
             
             Text(VectorL10n.onboardingUseCaseTitle)
                 .font(theme.fonts.title2B)
+                .multilineTextAlignment(.center)
                 .foregroundColor(theme.colors.primaryContent)
             
             Text(VectorL10n.onboardingUseCaseMessage)
                 .font(theme.fonts.body)
+                .multilineTextAlignment(.center)
                 .foregroundColor(theme.colors.secondaryContent)
         }
     }
@@ -68,6 +70,8 @@ struct OnboardingUseCaseSelectionScreen: View {
                 viewModel.send(viewAction: .answer(.skipped))
             }
             .font(theme.fonts.subheadline)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
             .foregroundColor(theme.colors.tertiaryContent)
             .padding(.top, 8)
         }
@@ -78,6 +82,7 @@ struct OnboardingUseCaseSelectionScreen: View {
         VStack(spacing: 14) {
             Text(VectorL10n.onboardingUseCaseExistingServerMessage)
                 .font(theme.fonts.subheadline)
+                .multilineTextAlignment(.center)
                 .foregroundColor(theme.colors.tertiaryContent)
             
             Button { viewModel.send(viewAction: .answer(.customServer)) } label: {
@@ -99,12 +104,14 @@ struct OnboardingUseCaseSelectionScreen: View {
                     }
                     .frame(maxWidth: OnboardingMetrics.maxContentWidth)
                     .padding(.top, OnboardingMetrics.topPaddingToNavigationBar)
+                    .padding(.bottom, 8)
                     .padding(.horizontal, 16)
                 }
                 .frame(maxWidth: .infinity)
                 
                 serverFooter
                     .padding(.horizontal, 16)
+                    .padding(.top, 8)
                     .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 20 : 36)
             }
         }

--- a/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseSelectionScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/UseCase/View/OnboardingUseCaseSelectionScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// The screen shown to a new user to select their use case for the app.
 struct OnboardingUseCaseSelectionScreen: View {
 
@@ -116,7 +115,6 @@ struct OnboardingUseCaseSelectionScreen: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct OnboardingUseCase_Previews: PreviewProvider {
     static let stateRenderer = MockOnboardingUseCaseSelectionScreenState.stateRenderer
     

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Coordinator/TemplateSimpleScreenCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Coordinator/TemplateSimpleScreenCoordinator.swift
@@ -42,7 +42,6 @@ final class TemplateSimpleScreenCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: TemplateSimpleScreenCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/MockTemplateSimpleScreenScreenState.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/MockTemplateSimpleScreenScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockTemplateSimpleScreenScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModel.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModel.swift
@@ -16,11 +16,10 @@
 
 import SwiftUI
 
-@available(iOS 14, *)
 typealias TemplateSimpleScreenViewModelType = StateStoreViewModel<TemplateSimpleScreenViewState,
                                                                   Never,
                                                                   TemplateSimpleScreenViewAction>
-@available(iOS 14, *)
+
 class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, TemplateSimpleScreenViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/TemplateSimpleScreenViewModelProtocol.swift
@@ -19,6 +19,5 @@ import Foundation
 protocol TemplateSimpleScreenViewModelProtocol {
     
     var completion: ((TemplateSimpleScreenViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: TemplateSimpleScreenViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/UI/TemplateSimpleScreenUITests.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/UI/TemplateSimpleScreenUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateSimpleScreenUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/Unit/TemplateSimpleScreenViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/Test/Unit/TemplateSimpleScreenViewModelTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateSimpleScreenViewModelTests: XCTestCase {
     private enum Constants {
         static let counterInitialValue = 0

--- a/RiotSwiftUI/Modules/Template/SimpleScreenExample/View/TemplateSimpleScreen.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleScreenExample/View/TemplateSimpleScreen.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateSimpleScreen: View {
 
     // MARK: - Properties
@@ -104,7 +103,6 @@ struct TemplateSimpleScreen: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateSimpleScreen_Previews: PreviewProvider {
     static let stateRenderer = MockTemplateSimpleScreenScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Coordinator/TemplateUserProfileCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Coordinator/TemplateUserProfileCoordinator.swift
@@ -42,7 +42,6 @@ final class TemplateUserProfileCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: TemplateUserProfileCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = TemplateUserProfileViewModel.makeTemplateUserProfileViewModel(templateUserProfileService: TemplateUserProfileService(session: parameters.session))

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/MockTemplateUserProfileScreenState.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/MockTemplateUserProfileScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockTemplateUserProfileScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Service/MatrixSDK/TemplateUserProfileService.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Service/MatrixSDK/TemplateUserProfileService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class TemplateUserProfileService: TemplateUserProfileServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Service/Mock/MockTemplateUserProfileService.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Service/Mock/MockTemplateUserProfileService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockTemplateUserProfileService: TemplateUserProfileServiceProtocol {
     var presenceSubject: CurrentValueSubject<TemplateUserProfilePresence, Never>
     

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Service/TemplateUserProfileServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Service/TemplateUserProfileServiceProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol TemplateUserProfileServiceProtocol: Avatarable {
     var userId: String { get }
     var displayName: String? { get }
@@ -27,7 +26,6 @@ protocol TemplateUserProfileServiceProtocol: Avatarable {
 
 // MARK: Avatarable
 
-@available(iOS 14.0, *)
 extension TemplateUserProfileServiceProtocol {
     var mxContentUri: String? {
         avatarUrl

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/TemplateUserProfileViewModel.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/TemplateUserProfileViewModel.swift
@@ -17,11 +17,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias TemplateUserProfileViewModelType = StateStoreViewModel<TemplateUserProfileViewState,
                                                                  Never,
                                                                  TemplateUserProfileViewAction>
-@available(iOS 14, *)
+
 class TemplateUserProfileViewModel: TemplateUserProfileViewModelType, TemplateUserProfileViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/TemplateUserProfileViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/TemplateUserProfileViewModelProtocol.swift
@@ -19,8 +19,6 @@ import Foundation
 protocol TemplateUserProfileViewModelProtocol {
     
     var completion: ((TemplateUserProfileViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     static func makeTemplateUserProfileViewModel(templateUserProfileService: TemplateUserProfileServiceProtocol) -> TemplateUserProfileViewModelProtocol
-    @available(iOS 14, *)
     var context: TemplateUserProfileViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Test/UI/TemplateUserProfileUITests.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Test/UI/TemplateUserProfileUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateUserProfileUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Test/Unit/TemplateUserProfileViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/Test/Unit/TemplateUserProfileViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateUserProfileViewModelTests: XCTestCase {
     private enum Constants {
         static let presenceInitialValue: TemplateUserProfilePresence = .offline

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfile.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfile.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateUserProfile: View {
 
     // MARK: - Properties
@@ -70,7 +69,6 @@ struct TemplateUserProfile: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateUserProfile_Previews: PreviewProvider {
     static let stateRenderer = MockTemplateUserProfileScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfileHeader.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfileHeader.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateUserProfileHeader: View {
     
     // MARK: - Properties
@@ -49,7 +48,6 @@ struct TemplateUserProfileHeader: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateUserProfileHeader_Previews: PreviewProvider {
     static var previews: some View {
         TemplateUserProfileHeader(avatar: MockAvatarInput.example, displayName: "Alice", presence: .online)

--- a/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfilePresenceView.swift
+++ b/RiotSwiftUI/Modules/Template/SimpleUserProfileExample/View/TemplateUserProfilePresenceView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateUserProfilePresenceView: View {
     
     // MARK: - Properties
@@ -53,7 +52,6 @@ struct TemplateUserProfilePresenceView: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateUserProfilePresenceView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment:.leading){

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/Coordinator/TemplateRoomsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/Coordinator/TemplateRoomsCoordinator.swift
@@ -46,21 +46,19 @@ final class TemplateRoomsCoordinator: Coordinator, Presentable {
     
     
     func start() {
-        if #available(iOS 14.0, *) {
-            MXLog.debug("[TemplateRoomsCoordinator] did start.")
-            let rootCoordinator = self.createTemplateRoomListCoordinator()
-            rootCoordinator.start()
-            
-            self.add(childCoordinator: rootCoordinator)
-            
-            if self.navigationRouter.modules.isEmpty == false {
-                self.navigationRouter.push(rootCoordinator, animated: true, popCompletion: { [weak self] in
-                    self?.remove(childCoordinator: rootCoordinator)
-                })
-            } else {
-                self.navigationRouter.setRootModule(rootCoordinator) { [weak self] in
-                    self?.remove(childCoordinator: rootCoordinator)
-                }
+        MXLog.debug("[TemplateRoomsCoordinator] did start.")
+        let rootCoordinator = self.createTemplateRoomListCoordinator()
+        rootCoordinator.start()
+        
+        self.add(childCoordinator: rootCoordinator)
+        
+        if self.navigationRouter.modules.isEmpty == false {
+            self.navigationRouter.push(rootCoordinator, animated: true, popCompletion: { [weak self] in
+                self?.remove(childCoordinator: rootCoordinator)
+            })
+        } else {
+            self.navigationRouter.setRootModule(rootCoordinator) { [weak self] in
+                self?.remove(childCoordinator: rootCoordinator)
             }
         }
     }
@@ -71,7 +69,6 @@ final class TemplateRoomsCoordinator: Coordinator, Presentable {
     
     // MARK: - Private
     
-    @available(iOS 14.0, *)
     private func createTemplateRoomListCoordinator() -> TemplateRoomListCoordinator {
         let coordinator: TemplateRoomListCoordinator = TemplateRoomListCoordinator(parameters: TemplateRoomListCoordinatorParameters(session: parameters.session))
         
@@ -88,13 +85,11 @@ final class TemplateRoomsCoordinator: Coordinator, Presentable {
         return coordinator
     }
     
-    @available(iOS 14.0, *)
     private func createTemplateRoomChatCoordinator(room: MXRoom) -> TemplateRoomChatCoordinator {
         let coordinator: TemplateRoomChatCoordinator = TemplateRoomChatCoordinator(parameters: TemplateRoomChatCoordinatorParameters(room: room))
         return coordinator
     }
     
-    @available(iOS 14.0, *)
     func showTemplateRoomChat(roomId: String) {
         guard let room = parameters.session.room(withRoomId: roomId) else {
             MXLog.error("[TemplateRoomsCoordinator] Failed to find room by selected Id.")

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Coordinator/TemplateRoomChatCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Coordinator/TemplateRoomChatCoordinator.swift
@@ -38,7 +38,6 @@ final class TemplateRoomChatCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: TemplateRoomChatCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = TemplateRoomChatViewModel(templateRoomChatService: TemplateRoomChatService(room: parameters.room))

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/MockTemplateRoomChatScreenState.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/MockTemplateRoomChatScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockTemplateRoomChatScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/MatrixSDK/TemplateRoomChatService.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/MatrixSDK/TemplateRoomChatService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class TemplateRoomChatService: TemplateRoomChatServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/Mock/MockTemplateRoomChatService.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/Mock/MockTemplateRoomChatService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockTemplateRoomChatService: TemplateRoomChatServiceProtocol {
     
     let roomName: String? = "New Vector"

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/TemplateRoomChatServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/TemplateRoomChatServiceProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol TemplateRoomChatServiceProtocol {
     var roomInitializationStatus: CurrentValueSubject<TemplateRoomChatRoomInitializationStatus, Never> { get }
     var chatMessagesSubject: CurrentValueSubject<[TemplateRoomChatMessage], Never> { get }

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/TemplateRoomChatViewModel.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/TemplateRoomChatViewModel.swift
@@ -17,12 +17,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias TemplateRoomChatViewModelType = StateStoreViewModel<TemplateRoomChatViewState,
                                                               Never,
                                                               TemplateRoomChatViewAction>
 
-@available(iOS 14, *)
 class TemplateRoomChatViewModel: TemplateRoomChatViewModelType, TemplateRoomChatViewModelProtocol {
     
     enum Constants {

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Test/UI/TemplateRoomChatUITests.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Test/UI/TemplateRoomChatUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateRoomChatUITests: MockScreenTest {
     
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Test/Unit/TemplateRoomChatViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Test/Unit/TemplateRoomChatViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateRoomChatViewModelTests: XCTestCase {
 
     var service: MockTemplateRoomChatService!

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChat.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChat.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14.0, *)
 struct TemplateRoomChat: View {
     
     // MARK: - Properties
@@ -127,7 +126,6 @@ struct TemplateRoomChat: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomChat_Previews: PreviewProvider {
     static let stateRenderer = MockTemplateRoomChatScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleContentView.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleContentView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleContentView: View {
     
     // MARK: - Properties
@@ -44,7 +43,6 @@ struct TemplateRoomChatBubbleContentView: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleItemView_Previews: PreviewProvider {
     static var previews: some View {
         EmptyView()

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleImage.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleImage.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleImage: View {
 
     // MARK: - Properties
@@ -36,7 +35,6 @@ struct TemplateRoomChatBubbleImage: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleImage_Previews: PreviewProvider {
     static var previews: some View {
         EmptyView()

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleMessage.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleMessage.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleMessage: View {
 
     // MARK: - Properties
@@ -39,7 +38,6 @@ struct TemplateRoomChatBubbleMessage: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleMessage_Previews: PreviewProvider {
     static let message = TemplateRoomChatMessageTextContent(body: "Hello")
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleView.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/View/TemplateRoomChatBubbleView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleView: View {
 
     // MARK: - Properties
@@ -52,7 +51,6 @@ struct TemplateRoomChatBubbleView: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomChatBubbleView_Previews: PreviewProvider {
     static let bubble = TemplateRoomChatBubble(
         id: "111",

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Coordinator/TemplateRoomListCoordinator.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Coordinator/TemplateRoomListCoordinator.swift
@@ -38,7 +38,6 @@ final class TemplateRoomListCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: TemplateRoomListCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = TemplateRoomListViewModel(templateRoomListService: TemplateRoomListService(session: parameters.session))

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/MockTemplateRoomListScreenState.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/MockTemplateRoomListScreenState.swift
@@ -20,7 +20,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockTemplateRoomListScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/MatrixSDK/TemplateRoomListService.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/MatrixSDK/TemplateRoomListService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class TemplateRoomListService: TemplateRoomListServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/Mock/MockTemplateRoomListService.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/Mock/MockTemplateRoomListService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockTemplateRoomListService: TemplateRoomListServiceProtocol {
     
     static let mockRooms = [

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/TemplateRoomListServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/TemplateRoomListServiceProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol TemplateRoomListServiceProtocol {
     var roomsSubject: CurrentValueSubject<[TemplateRoomListRoom], Never> { get }
 }

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/TemplateRoomListViewModel.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/TemplateRoomListViewModel.swift
@@ -16,12 +16,11 @@
 
 import SwiftUI
 import Combine
-    
-@available(iOS 14, *)
+
 typealias TemplateRoomListViewModelType = StateStoreViewModel<TemplateRoomListViewState,
                                                               Never,
                                                               TemplateRoomListViewAction>
-@available(iOS 14.0, *)
+
 class TemplateRoomListViewModel: TemplateRoomListViewModelType, TemplateRoomListViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/TemplateRoomListViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/TemplateRoomListViewModelProtocol.swift
@@ -18,6 +18,5 @@ import Foundation
 
 protocol TemplateRoomListViewModelProtocol {
     var callback: ((TemplateRoomListViewModelAction) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: TemplateRoomListViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Test/UI/TemplateRoomListUITests.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Test/UI/TemplateRoomListUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateRoomListUITests: MockScreenTest {
     
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Test/Unit/TemplateRoomListViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Test/Unit/TemplateRoomListViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TemplateRoomListViewModelTests: XCTestCase {
     private enum Constants {
     }

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/View/TemplateRoomList.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/View/TemplateRoomList.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateRoomList: View {
     
     // MARK: - Properties
@@ -66,7 +65,6 @@ struct TemplateRoomList: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomList_Previews: PreviewProvider {
     
     static let stateRenderer = MockTemplateRoomListScreenState.stateRenderer

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/View/TemplateRoomListRow.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/View/TemplateRoomListRow.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TemplateRoomListRow: View {
 
     // MARK: - Properties
@@ -47,7 +46,6 @@ struct TemplateRoomListRow: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TemplateRoomListRow_Previews: PreviewProvider {
     static var previews: some View {
         TemplateRoomListRow(avatar: MockAvatarInput.example, displayName: "Alice")

--- a/changelog.d/pr-6139.wip
+++ b/changelog.d/pr-6139.wip
@@ -1,0 +1,1 @@
+Onboarding: Tidy up SwiftUI and Onboarding screens.


### PR DESCRIPTION
This PR touches a lot of files, and is probably easier to review the commits in order. They do as follows:

- Drops all iOS 13/14 availability checks across the onboarding flow and templates.
- Simplifies the FontValues struct
- Fixes alignment and truncating of localised strings on the Use Case screen on small devices.
- Uses the `readableFrame` modifier and `OnboardingIconImage` in the places that were using standard view modifiers.

Note: The last step to follow on the Use Case screen will hopefully be adding a blur to the footer when there is content behind it in a similar style to a navigation/tab bar.

| Use case screen top | Use case screen bottom |
| - | - |
| ![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-10 at 15 50 52](https://user-images.githubusercontent.com/6060466/167657778-b14d2132-2d80-4861-8c00-2832cea5815f.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-10 at 15 50 55](https://user-images.githubusercontent.com/6060466/167657789-91f0a0a9-6853-423e-87ee-19fe6632926d.png) |

