### PR TITLE
Rename completion to callback and simplify actor usage.

### DIFF
--- a/Riot/Modules/Onboarding/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Onboarding/AuthenticationCoordinator.swift
@@ -131,7 +131,7 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
         let parameters = AuthenticationServerSelectionCoordinatorParameters(authenticationService: authenticationService,
                                                                             hasModalPresentation: false)
         let coordinator = AuthenticationServerSelectionCoordinator(parameters: parameters)
-        coordinator.completion = { [weak self, weak coordinator] result in
+        coordinator.callback = { [weak self, weak coordinator] result in
             guard let self = self, let coordinator = coordinator else { return }
             self.serverSelectionCoordinator(coordinator, didCompleteWith: result)
         }
@@ -168,7 +168,7 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
                                                                          registrationFlow: homeserver.registrationFlow,
                                                                          loginMode: homeserver.preferredLoginMode)
         let coordinator = AuthenticationRegistrationCoordinator(parameters: parameters)
-        coordinator.completion = { [weak self, weak coordinator] result in
+        coordinator.callback = { [weak self, weak coordinator] result in
             guard let self = self, let coordinator = coordinator else { return }
             self.registrationCoordinator(coordinator, didCompleteWith: result)
         }
@@ -189,8 +189,6 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     @MainActor private func registrationCoordinator(_ coordinator: AuthenticationRegistrationCoordinator,
                                                     didCompleteWith result: AuthenticationRegistrationCoordinatorResult) {
         switch result {
-        case .selectServer:
-            showServerSelectionScreen()
         case .completed(let result):
             handleRegistrationResult(result)
         }

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -437,7 +437,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         let parameters = OnboardingAvatarCoordinatorParameters(userSession: userSession, avatar: selectedAvatar)
         let coordinator = OnboardingAvatarCoordinator(parameters: parameters)
         
-        coordinator.completion = { [weak self, weak coordinator] result in
+        coordinator.callback = { [weak self, weak coordinator] result in
             guard let self = self, let coordinator = coordinator else { return }
             
             switch result {

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModelProtocol.swift
@@ -18,7 +18,7 @@ import Foundation
 
 protocol AuthenticationRegistrationViewModelProtocol {
     
-    @MainActor var completion: ((AuthenticationRegistrationViewModelResult) -> Void)? { get set }
+    @MainActor var callback: ((AuthenticationRegistrationViewModelResult) -> Void)? { get set }
     var context: AuthenticationRegistrationViewModelType.Context { get }
     
     /// Update the view with new homeserver information.

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModel.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModel.swift
@@ -28,7 +28,7 @@ class AuthenticationServerSelectionViewModel: AuthenticationServerSelectionViewM
 
     // MARK: Public
 
-    var completion: ((AuthenticationServerSelectionViewModelResult) -> Void)?
+    @MainActor var callback: ((AuthenticationServerSelectionViewModelResult) -> Void)?
 
     // MARK: - Setup
 
@@ -41,20 +41,15 @@ class AuthenticationServerSelectionViewModel: AuthenticationServerSelectionViewM
     // MARK: - Public
 
     override func process(viewAction: AuthenticationServerSelectionViewAction) {
-        Task {
-            await MainActor.run {
-                switch viewAction {
-                case .confirm:
-                    completion?(.confirm(homeserverAddress: state.bindings.homeserverAddress))
-                case .dismiss:
-                    completion?(.dismiss)
-                case .getInTouch:
-                    getInTouch()
-                case .clearFooterError:
-                    guard state.footerErrorMessage != nil else { return }
-                    withAnimation { state.footerErrorMessage = nil }
-                }
-            }
+        switch viewAction {
+        case .confirm:
+            Task { await callback?(.confirm(homeserverAddress: state.bindings.homeserverAddress)) }
+        case .dismiss:
+            Task { await callback?(.dismiss) }
+        case .getInTouch:
+            Task { await getInTouch() }
+        case .clearFooterError:
+            Task { await clearFooterError() }
         }
     }
     
@@ -70,6 +65,12 @@ class AuthenticationServerSelectionViewModel: AuthenticationServerSelectionViewM
     }
     
     // MARK: - Private
+    
+    /// Clear any errors shown in the text field footer.
+    @MainActor private func clearFooterError() {
+        guard state.footerErrorMessage != nil else { return }
+        withAnimation { state.footerErrorMessage = nil }
+    }
     
     /// Opens the EMS link in the user's browser.
     @MainActor private func getInTouch() {

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/AuthenticationServerSelectionViewModelProtocol.swift
@@ -18,7 +18,7 @@ import Foundation
 
 protocol AuthenticationServerSelectionViewModelProtocol {
     
-    @MainActor var completion: ((AuthenticationServerSelectionViewModelResult) -> Void)? { get set }
+    @MainActor var callback: ((AuthenticationServerSelectionViewModelResult) -> Void)? { get set }
     var context: AuthenticationServerSelectionViewModelType.Context { get }
     
     /// Displays an error to the user.

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/Coordinator/OnboardingAvatarCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/Coordinator/OnboardingAvatarCoordinator.swift
@@ -24,7 +24,8 @@ struct OnboardingAvatarCoordinatorParameters {
 }
 
 enum OnboardingAvatarCoordinatorResult {
-    /// The user has chosen an image (but hasn't yet saved it).
+    /// The user has chosen an image (but it won't be uploaded until `.complete` is sent).
+    /// This result is to cache the image in the flow coordinator so it can be restored if the user was to navigate backwards.
     case selectedAvatar(UIImage?)
     /// The screen is finished and the next one can be shown.
     case complete(UserSession)
@@ -63,7 +64,7 @@ final class OnboardingAvatarCoordinator: Coordinator, Presentable {
 
     // Must be used only internally
     var childCoordinators: [Coordinator] = []
-    var completion: ((OnboardingAvatarCoordinatorResult) -> Void)?
+    var callback: ((OnboardingAvatarCoordinatorResult) -> Void)?
     
     // MARK: - Setup
     
@@ -88,7 +89,7 @@ final class OnboardingAvatarCoordinator: Coordinator, Presentable {
     
     func start() {
         MXLog.debug("[OnboardingAvatarCoordinator] did start.")
-        onboardingAvatarViewModel.completion = { [weak self] result in
+        onboardingAvatarViewModel.callback = { [weak self] result in
             guard let self = self else { return }
             MXLog.debug("[OnboardingAvatarCoordinator] OnboardingAvatarViewModel did complete with result: \(result).")
             switch result {
@@ -99,7 +100,7 @@ final class OnboardingAvatarCoordinator: Coordinator, Presentable {
             case .save(let avatar):
                 self.setAvatar(avatar)
             case .skip:
-                self.completion?(.complete(self.parameters.userSession))
+                self.callback?(.complete(self.parameters.userSession))
             }
         }
     }
@@ -161,7 +162,7 @@ final class OnboardingAvatarCoordinator: Coordinator, Presentable {
             self.parameters.userSession.account.setUserAvatarUrl(urlString) { [weak self] in
                 guard let self = self else { return }
                 self.stopWaiting()
-                self.completion?(.complete(self.parameters.userSession))
+                self.callback?(.complete(self.parameters.userSession))
             } failure: { [weak self] error in
                 guard let self = self else { return }
                 self.stopWaiting()
@@ -182,7 +183,7 @@ extension OnboardingAvatarCoordinator: MediaPickerPresenterDelegate {
     /// so whilst this method may not appear to be called, everything works fine when run on a device.
     func mediaPickerPresenter(_ presenter: MediaPickerPresenter, didPickImage image: UIImage) {
         onboardingAvatarViewModel.updateAvatarImage(with: image)
-        completion?(.selectedAvatar(image))
+        callback?(.selectedAvatar(image))
         presenter.dismiss(animated: true, completion: nil)
     }
     
@@ -196,7 +197,7 @@ extension OnboardingAvatarCoordinator: MediaPickerPresenterDelegate {
 extension OnboardingAvatarCoordinator: CameraPresenterDelegate {
     func cameraPresenter(_ presenter: CameraPresenter, didSelectImage image: UIImage) {
         onboardingAvatarViewModel.updateAvatarImage(with: image)
-        completion?(.selectedAvatar(image))
+        callback?(.selectedAvatar(image))
         presenter.dismiss(animated: true, completion: nil)
     }
     

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModel.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModel.swift
@@ -29,7 +29,7 @@ class OnboardingAvatarViewModel: OnboardingAvatarViewModelType, OnboardingAvatar
 
     // MARK: Public
 
-    var completion: ((OnboardingAvatarViewModelResult) -> Void)?
+    var callback: ((OnboardingAvatarViewModelResult) -> Void)?
 
     // MARK: - Setup
 
@@ -46,13 +46,13 @@ class OnboardingAvatarViewModel: OnboardingAvatarViewModelType, OnboardingAvatar
     override func process(viewAction: OnboardingAvatarViewAction) {
         switch viewAction {
         case .pickImage:
-            completion?(.pickImage)
+            callback?(.pickImage)
         case .takePhoto:
-            completion?(.takePhoto)
+            callback?(.takePhoto)
         case .save:
-            completion?(.save(state.avatar))
+            callback?(.save(state.avatar))
         case .skip:
-            completion?(.skip)
+            callback?(.skip)
         }
     }
     

--- a/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Avatar/OnboardingAvatarViewModelProtocol.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 protocol OnboardingAvatarViewModelProtocol {
     
-    var completion: ((OnboardingAvatarViewModelResult) -> Void)? { get set }
+    var callback: ((OnboardingAvatarViewModelResult) -> Void)? { get set }
     var context: OnboardingAvatarViewModelType.Context { get }
     
     /// Update the view model to show the image that the user has picked.

--- a/changelog.d/pr-6141.wip
+++ b/changelog.d/pr-6141.wip
@@ -1,0 +1,1 @@
+Onboarding: Rename completion to callback and simplify actor usage


### PR DESCRIPTION
A small tidy up following on from #6056 and #6048.

- Completion handlers that are called more than once in the onboarding flow are renamed to `callback`.
- Actor usage is simplified in `start` and `process(viewAction:)` to align with Email/Terms/ReCaptcha screens.

