### PR TITLE
Hide the hidden album's thumbnail.

### DIFF
--- a/Riot/Modules/MediaPicker/MediaPickerViewController.m
+++ b/Riot/Modules/MediaPicker/MediaPickerViewController.m
@@ -951,8 +951,9 @@
         PHFetchResult *assets = [PHAsset fetchAssetsInAssetCollection:collection options:options];
         cell.albumCountLabel.text = [NSString stringWithFormat:@"%tu", assets.count];
         
-        // Report first asset thumbnail (except for 'Recently Deleted' album)
-        if (assets.count && collection.assetCollectionSubtype != 1000000201)
+        // Report first asset thumbnail (except for 'Recently Deleted' and 'Hidden' albums)
+        BOOL isSensitiveCollection = collection.assetCollectionSubtype == 1000000201 || collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumAllHidden;
+        if (assets.count && !isSensitiveCollection)
         {
             PHAsset *asset = assets[0];
             

--- a/changelog.d/6096.bugfix
+++ b/changelog.d/6096.bugfix
@@ -1,0 +1,1 @@
+Media gallery: Don't show a thumbnail for the hidden album.


### PR DESCRIPTION
Fixes #6096 by handling the Hidden album in the same way as the Recently Delete album:

![IMG_0391](https://user-images.githubusercontent.com/6060466/167803837-177f1cd6-1df3-4ea2-82c4-f4f3dea51f7b.PNG)