### PR TITLE
Presence: fix live updates on Home & DM list

### DIFF
--- a/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -93,6 +93,11 @@
     return roomSummary.avatar;
 }
 
+- (NSString *)directUserId
+{
+    return self.roomSummary.directUserId;
+}
+
 - (MXPresence)presence
 {
     if (self.roomSummary.isDirect)

--- a/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellDataStoring.h
+++ b/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellDataStoring.h
@@ -44,6 +44,7 @@
 @property (nonatomic, readonly) NSString *roomIdentifier;
 @property (nonatomic, readonly) NSString *roomDisplayname;
 @property (nonatomic, readonly) NSString *avatarUrl;
+@property (nonatomic, readonly) NSString *directUserId;
 @property (nonatomic, readonly) MXPresence presence;
 @property (nonatomic, readonly) NSString *lastEventTextMessage;
 @property (nonatomic, readonly) NSString *lastEventDate;

--- a/changelog.d/6144.bugfix
+++ b/changelog.d/6144.bugfix
@@ -1,0 +1,1 @@
+Presence: fix live updates on Home & DM list


### PR DESCRIPTION
Fixes #6144 

Open to discussion around this solution :) 

Advantages: 
- Built around already in place Presence NSNotification solution
- Doesn't require reloadData anytime someone's Presence updates

Drawback:
- Adds a bit of intelligence inside cells

The other solution would require a few changes on both application and SDK, including : 
* Storing a `directUserPresence` on `MXRoomSummaryMO` so the fetchers can trigger room list updates accordingly
* Having a way smarter approach towards table view / collection view updates for Home & DM 