### PR TITLE
Userinterface for discard session command line option as in Android.

### DIFF
--- a/Riot/Modules/Room/RoomInfo/RoomInfoCoordinator.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoCoordinator.swift
@@ -199,7 +199,7 @@ extension RoomInfoCoordinator: RoomInfoListCoordinatorDelegate {
     }
     
     func roomInfoListCoordinatorDidCancel(_ coordinator: RoomInfoListCoordinatorType) {
-        self.delegate?.roomInfoCoordinatorDidComplete(self)
+        self.delegate?.roomInfoCoordinatorResetRoomSession(self)
     }
     
     func roomInfoListCoordinatorDidLeaveRoom(_ coordinator: RoomInfoListCoordinatorType) {

--- a/Riot/Modules/Room/RoomInfo/RoomInfoCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoCoordinatorBridgePresenter.swift
@@ -23,6 +23,7 @@ import Foundation
     func roomInfoCoordinatorBridgePresenter(_ coordinatorBridgePresenter: RoomInfoCoordinatorBridgePresenter, didRequestMentionForMember member: MXRoomMember)
     func roomInfoCoordinatorBridgePresenterDelegateDidLeaveRoom(_ coordinatorBridgePresenter: RoomInfoCoordinatorBridgePresenter)
     func roomInfoCoordinatorBridgePresenter(_ coordinatorBridgePresenter: RoomInfoCoordinatorBridgePresenter, didReplaceRoomWithReplacementId roomId: String)
+    func roomInfoCoordinatorBridgePresenterDelegateResetRoomSession(_ coordinatorBridgePresenter: RoomInfoCoordinatorBridgePresenter)
 }
 
 /// RoomInfoCoordinatorBridgePresenter enables to start RoomInfoCoordinator from a view controller.
@@ -113,6 +114,9 @@ final class RoomInfoCoordinatorBridgePresenter: NSObject {
 
 // MARK: - RoomInfoCoordinatorDelegate
 extension RoomInfoCoordinatorBridgePresenter: RoomInfoCoordinatorDelegate {
+    func roomInfoCoordinatorResetRoomSession(_ coordinator: RoomInfoCoordinatorType) {
+        self.delegate?.roomInfoCoordinatorBridgePresenterDelegateResetRoomSession(self)
+    }
     
     func roomInfoCoordinatorDidComplete(_ coordinator: RoomInfoCoordinatorType) {
         self.delegate?.roomInfoCoordinatorBridgePresenterDelegateDidComplete(self)

--- a/Riot/Modules/Room/RoomInfo/RoomInfoCoordinatorType.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoCoordinatorType.swift
@@ -23,6 +23,7 @@ protocol RoomInfoCoordinatorDelegate: AnyObject {
     func roomInfoCoordinator(_ coordinator: RoomInfoCoordinatorType, didRequestMentionForMember member: MXRoomMember)
     func roomInfoCoordinatorDidLeaveRoom(_ coordinator: RoomInfoCoordinatorType)
     func roomInfoCoordinator(_ coordinator: RoomInfoCoordinatorType, didReplaceRoomWithReplacementId roomId: String)
+    func roomInfoCoordinatorResetRoomSession(_ coordinator: RoomInfoCoordinatorType)
 }
 
 /// `RoomInfoCoordinatorType` is a protocol describing a Coordinator that handle keybackup setup navigation flow.

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListCoordinator.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListCoordinator.swift
@@ -62,6 +62,9 @@ final class RoomInfoListCoordinator: RoomInfoListCoordinatorType {
 
 // MARK: - RoomInfoListViewModelCoordinatorDelegate
 extension RoomInfoListCoordinator: RoomInfoListViewModelCoordinatorDelegate {
+    func roomInfoListViewModelResetRoomSession(_ viewModel: RoomInfoListViewModelType) {
+        self.delegate?.roomInfoListCoordinatorDidCancel(self)
+    }
     
     func roomInfoListViewModel(_ viewModel: RoomInfoListViewModelType, wantsToNavigateTo target: RoomInfoListTarget) {
         self.delegate?.roomInfoListCoordinator(self, wantsToNavigateTo: target)
@@ -74,5 +77,5 @@ extension RoomInfoListCoordinator: RoomInfoListViewModelCoordinatorDelegate {
     func roomInfoListViewModelDidLeaveRoom(_ viewModel: RoomInfoListViewModelType) {
         self.delegate?.roomInfoListCoordinatorDidLeaveRoom(self)
     }
-
+    
 }

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewAction.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewAction.swift
@@ -47,4 +47,5 @@ enum RoomInfoListViewAction {
     case navigate(target: RoomInfoListTarget)
     case leave
     case cancel
+    case resetSession
 }

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
@@ -205,13 +205,21 @@ final class RoomInfoListViewController: UIViewController {
         let rowLeave = Row(type: .destructive, icon: Asset.Images.roomActionLeave.image, text: leaveTitle, accessoryType: .none) {
             self.present(self.leaveAlertController, animated: true, completion: nil)
         }
+        let rowResetSession = Row(type: .default, icon: Asset.Images.roomContextMenuRetry.image, text: VectorL10n.widgetMenuRefresh, accessoryType: .none) {
+            self.viewModel.process(viewAction: .resetSession)
+        }
         let sectionLeave = Section(header: nil,
                                    rows: [rowLeave],
                                    footer: nil)
         
-        tmpSections.append(sectionSettings)
-        tmpSections.append(sectionLeave)
+        let sectionRefresh = Section(header: nil,
+                                   rows: [rowResetSession],
+                                   footer: nil)
         
+        tmpSections.append(sectionSettings)
+        tmpSections.append(sectionRefresh)
+        tmpSections.append(sectionLeave)
+
         sections = tmpSections
     }
     

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewModel.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewModel.swift
@@ -78,6 +78,8 @@ final class RoomInfoListViewModel: NSObject, RoomInfoListViewModelType {
             self.leave()
         case .cancel:
             self.coordinatorDelegate?.roomInfoListViewModelDidCancel(self)
+        case .resetSession:
+            self.coordinatorDelegate?.roomInfoListViewModelResetRoomSession(self)
         }
     }
     

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewModelType.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewModelType.swift
@@ -25,6 +25,7 @@ protocol RoomInfoListViewModelViewDelegate: AnyObject {
 protocol RoomInfoListViewModelCoordinatorDelegate: AnyObject {
     func roomInfoListViewModelDidCancel(_ viewModel: RoomInfoListViewModelType)
     func roomInfoListViewModelDidLeaveRoom(_ viewModel: RoomInfoListViewModelType)
+    func roomInfoListViewModelResetRoomSession(_ viewModel: RoomInfoListViewModelType)
     func roomInfoListViewModel(_ viewModel: RoomInfoListViewModelType, wantsToNavigateTo target: RoomInfoListTarget)
 }
 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -7357,6 +7357,12 @@ static CGSize kThreadListBarButtonItemImageSize;
     }
 }
 
+- (void)roomInfoCoordinatorBridgePresenterDelegateResetRoomSession:(RoomInfoCoordinatorBridgePresenter *)coordinatorBridgePresenter {
+    [self.mainSession.crypto discardOutboundGroupSessionForRoomWithRoomId:self.roomDataSource.roomId onComplete:^{
+        
+    }];
+}
+
 #pragma mark - RemoveJitsiWidgetViewDelegate
 
 - (void)removeJitsiWidgetViewDidCompleteSliding:(RemoveJitsiWidgetView *)view

--- a/changelog.d/6172.misc
+++ b/changelog.d/6172.misc
@@ -1,0 +1,1 @@
+Discard session option for iOS


### PR DESCRIPTION
User interface for discard session command line option in android equivalent. 
This option is useful when message is unable decrypted in iOS when sender is not online, but decrypted in Android, web.

Related to issue [Unexpected "Duplicate message index" error ](https://github.com/vector-im/element-ios/issues/1151)
and
Related to [Discard session option for iOS ](https://github.com/vector-im/element-ios/issues/6172)

<img width="414" alt="Discard" src="https://user-images.githubusercontent.com/665295/168027849-56ab837f-d75c-4360-a84c-734b09e464df.png">



### Pull Request Checklist

- [x ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ x] Accessibility has been taken into account.
* [x ] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ x] You've made a self review of your PR
- [x ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
