### PR TITLE
Flush pills on text view updates

### DIFF
--- a/Riot/Modules/MatrixKit/Views/MXKMessageTextView.h
+++ b/Riot/Modules/MatrixKit/Views/MXKMessageTextView.h
@@ -26,6 +26,14 @@ NS_ASSUME_NONNULL_BEGIN
 // The last hit test location received by the view.
 @property (nonatomic, readonly) CGPoint lastHitTestLocation;
 
+
+/// Register a view that has been added as a pill to this text view.
+/// This is needed in order to flush pills that are not always removed properly by the system.
+/// All registered views will be manually removed from hierarchy on attributedText or text updates.
+///
+/// @param pillView pill view to register
+- (void)registerPillView:(UIView *)pillView API_AVAILABLE(ios(15));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
+++ b/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
@@ -20,6 +20,7 @@
 @interface MXKMessageTextView()
 
 @property (nonatomic, readwrite) CGPoint lastHitTestLocation;
+@property (nonatomic) NSArray *pillViews;
 
 @end
 
@@ -52,6 +53,42 @@
     }
     
     return [self isThereALinkNearLocation:point];
+}
+
+#pragma mark - Pills Flushing
+
+- (void)setText:(NSString *)text
+{
+    if (@available(iOS 15.0, *)) {
+        [self flushPills];
+    }
+    [super setText:text];
+}
+
+- (void)setAttributedText:(NSAttributedString *)attributedText
+{
+    if (@available(iOS 15.0, *)) {
+        [self flushPills];
+    }
+    [super setAttributedText:attributedText];
+}
+
+- (void)registerPillView:(UIView *)pillView
+{
+    NSMutableArray *pills = [NSMutableArray arrayWithArray:self.pillViews];
+    [pills addObject:pillView];
+    self.pillViews = pills;
+}
+
+/// Flushes all previously registered Pills from their hierarchy.
+- (void)flushPills API_AVAILABLE(ios(15))
+{
+    for (UIView* view in self.pillViews)
+    {
+        view.alpha = 0.0;
+        [view removeFromSuperview];
+    }
+    self.pillViews = [NSArray new];
 }
 
 @end

--- a/Riot/Modules/Pills/PillAttachmentView.swift
+++ b/Riot/Modules/Pills/PillAttachmentView.swift
@@ -90,6 +90,7 @@ class PillAttachmentView: UIView {
         pillBackgroundView.layer.cornerRadius = sizes.pillBackgroundHeight / 2.0
 
         self.addSubview(pillBackgroundView)
+        self.alpha = pillData.alpha
     }
 
     // MARK: - Override

--- a/Riot/Modules/Pills/PillAttachmentViewProvider.swift
+++ b/Riot/Modules/Pills/PillAttachmentViewProvider.swift
@@ -19,9 +19,18 @@ import UIKit
 /// Provider for mention Pills attachment view.
 @available(iOS 15.0, *)
 @objc class PillAttachmentViewProvider: NSTextAttachmentViewProvider {
+    // MARK: - Properties
     private static let pillAttachmentViewSizes = PillAttachmentView.Sizes(verticalMargin: 2.0,
                                                                           horizontalMargin: 4.0,
                                                                           avatarSideLength: 16.0)
+    private var messageTextView: MXKMessageTextView?
+
+    // MARK: - Override
+    override init(textAttachment: NSTextAttachment, parentView: UIView?, textLayoutManager: NSTextLayoutManager?, location: NSTextLocation) {
+        super.init(textAttachment: textAttachment, parentView: parentView, textLayoutManager: textLayoutManager, location: location)
+
+        self.messageTextView = parentView?.superview as? MXKMessageTextView
+    }
 
     override func loadView() {
         super.loadView()
@@ -38,13 +47,14 @@ import UIKit
 
         let mainSession = AppDelegate.theDelegate().mxSessions.first as? MXSession
 
-        view = PillAttachmentView(frame: CGRect(origin: .zero, size: Self.size(forDisplayText: pillData.displayText,
-                                                                               andFont: pillData.font)),
-                                  sizes: Self.pillAttachmentViewSizes,
-                                  theme: ThemeService.shared().theme,
-                                  mediaManager: mainSession?.mediaManager,
-                                  andPillData: pillData)
-        view?.alpha = pillData.alpha
+        let pillView = PillAttachmentView(frame: CGRect(origin: .zero, size: Self.size(forDisplayText: pillData.displayText,
+                                                                                       andFont: pillData.font)),
+                                          sizes: Self.pillAttachmentViewSizes,
+                                          theme: ThemeService.shared().theme,
+                                          mediaManager: mainSession?.mediaManager,
+                                          andPillData: pillData)
+        view = pillView
+        messageTextView?.registerPillView(pillView)
     }
 }
 


### PR DESCRIPTION
Fixes an issue where pills are not properly cleared from hierarchy on text view content updates. (easily noticeable through live edits) 