### PR TITLE
Fix composer text coloration

### DIFF
--- a/Riot/Modules/Room/RoomViewController.swift
+++ b/Riot/Modules/Room/RoomViewController.swift
@@ -33,13 +33,9 @@ extension RoomViewController {
             } else {
                 newAttributedString.appendString(roomMember.displayname.count > 0 ? roomMember.displayname : roomMember.userId)
             }
-            let empty = NSAttributedString(string: " ",
-                                           attributes: [.font: inputToolbar.textDefaultFont])
-            newAttributedString.append(empty)
+            newAttributedString.appendString(" ")
         } else if roomMember.userId == self.mainSession.myUser.userId {
-            let selfMentionString = NSAttributedString(string: "/me ",
-                                                       attributes: [.font: inputToolbar.textDefaultFont])
-            newAttributedString.append(selfMentionString)
+            newAttributedString.appendString("/me ")
         } else {
             if #available(iOS 15.0, *) {
                 newAttributedString.append(PillsFormatter.mentionPill(withRoomMember: roomMember,
@@ -48,9 +44,7 @@ extension RoomViewController {
             } else {
                 newAttributedString.appendString(roomMember.displayname.count > 0 ? roomMember.displayname : roomMember.userId)
             }
-            let colon = NSAttributedString(string: ": ",
-                                           attributes: [.font: inputToolbar.textDefaultFont])
-            newAttributedString.append(colon)
+            newAttributedString.appendString(": ")
         }
 
         inputToolbar.attributedTextMessage = newAttributedString

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -167,11 +167,16 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
 
 - (void)setAttributedTextMessage:(NSAttributedString *)attributedTextMessage
 {
-    NSMutableAttributedString *mutableTextMessage = [[NSMutableAttributedString alloc] initWithAttributedString:attributedTextMessage];
-    [mutableTextMessage addAttributes:@{ NSForegroundColorAttributeName: ThemeService.shared.theme.textPrimaryColor,
-                                         NSFontAttributeName: self.textDefaultFont }
-                                range:NSMakeRange(0, mutableTextMessage.length)];
-    self.textView.attributedText = mutableTextMessage;
+    if (attributedTextMessage)
+    {
+        NSMutableAttributedString *mutableTextMessage = [[NSMutableAttributedString alloc] initWithAttributedString:attributedTextMessage];
+        [mutableTextMessage addAttributes:@{ NSForegroundColorAttributeName: ThemeService.shared.theme.textPrimaryColor,
+                                             NSFontAttributeName: self.textDefaultFont }
+                                    range:NSMakeRange(0, mutableTextMessage.length)];
+        attributedTextMessage = mutableTextMessage;
+    }
+
+    self.textView.attributedText = attributedTextMessage;
     [self updateUIWithAttributedTextMessage:attributedTextMessage animated:YES];
     [self textViewDidChange:self.textView];
 }

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -117,6 +117,11 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
     self.textView.tintColor = ThemeService.shared.theme.tintColor;
     self.textView.placeholderColor = ThemeService.shared.theme.textTertiaryColor;
     self.textView.showsVerticalScrollIndicator = NO;
+
+    // Trigger textView redraw using proper color/font.
+    NSAttributedString *newText = self.textView.attributedText;
+    self.textView.attributedText = nil;
+    self.textView.attributedText = newText;
     
     self.textView.keyboardAppearance = ThemeService.shared.theme.keyboardAppearance;
     if (self.textView.isFirstResponder)
@@ -162,7 +167,11 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
 
 - (void)setAttributedTextMessage:(NSAttributedString *)attributedTextMessage
 {
-    self.textView.attributedText = attributedTextMessage;
+    NSMutableAttributedString *mutableTextMessage = [[NSMutableAttributedString alloc] initWithAttributedString:attributedTextMessage];
+    [mutableTextMessage addAttributes:@{ NSForegroundColorAttributeName: ThemeService.shared.theme.textPrimaryColor,
+                                         NSFontAttributeName: self.textDefaultFont }
+                                range:NSMakeRange(0, mutableTextMessage.length)];
+    self.textView.attributedText = mutableTextMessage;
     [self updateUIWithAttributedTextMessage:attributedTextMessage animated:YES];
     [self textViewDidChange:self.textView];
 }

--- a/RiotTests/PillsFormatterTests.swift
+++ b/RiotTests/PillsFormatterTests.swift
@@ -80,7 +80,7 @@ private class FakeMXSession: MXSession {
     }
 
     override var myUserId: String! {
-        return Inputs.aliceMember.userId
+        return mockMyUserId
     }
 }
 


### PR DESCRIPTION
Fixes issue where composer won't use default text primary color after using a pill.

Also moves all the font/color attributes updates to the toolbar attributedText setter.

#3526 