### PR TITLE
Construct formatted body from replied event

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
@@ -241,6 +241,13 @@ typedef enum : NSUInteger {
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState isEditMode:(BOOL)isEditMode;
 
 /**
+ Defines the replacement attributed string for a redacted message.
+
+ @return attributed string describing redacted message.
+ */
+- (NSAttributedString*)redactedMessageReplacementAttributedString;
+
+/**
  Same as [self renderString:forEvent:] but add a prefix.
  The prefix will be rendered with 'prefixTextFont' and 'prefixTextColor'.
  

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1912,7 +1912,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
         }
     }
 
-    if (eventContent)
+    if (eventContent && repliedEvent.sender)
     {
         html = [NSString stringWithFormat:@"<mx-reply><blockquote><a href=\"%@\">In reply to</a> <a href=\"%@\">%@</a><br>%@</blockquote></mx-reply>%@",
                 [MXTools permalinkToEvent:repliedEvent.eventId inRoom:repliedEvent.roomId],

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1884,7 +1884,8 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
                 MXJSONModelSetString(repliedEventContent, repliedEvent.content[kMXMessageContentKeyNewContent][kMXMessageBodyKey]);
             }
         }
-        else {
+        else
+        {
             MXJSONModelSetString(repliedEventContent, repliedEvent.content[@"formatted_body"]);
             if (!repliedEventContent)
             {

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1757,11 +1757,19 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState isEditMode:(BOOL)isEditMode
 {
     NSString *html = htmlString;
+    MXEvent *repliedEvent;
 
     // Special treatment for "In reply to" message
     // Note: `isEditMode` fixes an issue where editing a reply would display an "In reply to" span instead of a mention.
     if (!isEditMode && (event.isReplyEvent || (!RiotSettings.shared.enableThreads && event.isInThread)))
     {
+        repliedEvent = [self->mxSession.store eventWithEventId:event.relatesTo.inReplyTo.eventId inRoom:roomState.roomId];
+        if (repliedEvent)
+        {
+            // Try to construct rich reply.
+            html = [self buildHTMLStringForEvent:event inReplyToEvent:repliedEvent] ?: html;
+        }
+
         html = [self renderReplyTo:html withRoomState:roomState];
     }
 
@@ -1804,6 +1812,18 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     // Finalize HTML blockquote blocks marking
     str = [MXKTools removeMarkedBlockquotesArtifacts:str];
 
+    if (repliedEvent && repliedEvent.isRedactedEvent)
+    {
+        // Replace the description of an empty replied event
+        NSMutableAttributedString *mutableStr = [[NSMutableAttributedString alloc] initWithAttributedString:str];
+        NSRange nullRange = [mutableStr.string rangeOfString:@"(null)"];
+        if (nullRange.location != NSNotFound)
+        {
+            [mutableStr replaceCharactersInRange:nullRange withAttributedString:[self redactedMessageReplacementAttributedString]];
+            str = mutableStr;
+        }
+    }
+
     UIFont *fontForBody = [self fontForEvent:event string:nil];
     if ([fontForWholeString isEqual:fontForBody])
     {
@@ -1830,6 +1850,83 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     NSMutableAttributedString *mutableStr = [str mutableCopy];
     [mutableStr addAttribute:NSFontAttributeName value:fontForBody range:bodyRange];
     return mutableStr;
+}
+
+- (NSAttributedString*)redactedMessageReplacementAttributedString
+{
+    return [[NSAttributedString alloc] initWithString:VectorL10n.eventFormatterMessageDeleted];
+}
+
+/**
+ Build the HTML body of a reply from its related event (rich replies).
+
+ @param event the reply event.
+ @param repliedEvent the event it replies to.
+ @return an html string containing the updated content of both events.
+ */
+- (NSString*)buildHTMLStringForEvent:(MXEvent*)event inReplyToEvent:(MXEvent*)repliedEvent
+{
+    NSString *repliedEventContent;
+    NSString *eventContent;
+    NSString *html;
+
+    if (repliedEvent.isRedactedEvent)
+    {
+        repliedEventContent = nil;
+    }
+    else
+    {
+        if (repliedEvent.content[kMXMessageContentKeyNewContent])
+        {
+            MXJSONModelSetString(repliedEventContent, repliedEvent.content[kMXMessageContentKeyNewContent][@"formatted_body"]);
+            if (!repliedEventContent)
+            {
+                MXJSONModelSetString(repliedEventContent, repliedEvent.content[kMXMessageContentKeyNewContent][kMXMessageBodyKey]);
+            }
+        }
+        else {
+            MXJSONModelSetString(repliedEventContent, repliedEvent.content[@"formatted_body"]);
+            if (!repliedEventContent)
+            {
+                MXJSONModelSetString(repliedEventContent, repliedEvent.content[kMXMessageBodyKey]);
+            }
+        }
+    }
+
+    if (event.content[kMXMessageContentKeyNewContent])
+    {
+        MXJSONModelSetString(eventContent, event.content[kMXMessageContentKeyNewContent][@"formatted_body"]);
+        if (!eventContent)
+        {
+            MXJSONModelSetString(eventContent, event.content[kMXMessageContentKeyNewContent][kMXMessageBodyKey]);
+        }
+    }
+    else
+    {
+        MXReplyEventParser *parser = [[MXReplyEventParser alloc] init];
+        MXReplyEventParts *parts = [parser parse:event];
+        MXJSONModelSetString(eventContent, parts.formattedBodyParts.replyText)
+        if (!eventContent)
+        {
+            MXJSONModelSetString(eventContent, parts.bodyParts.replyText)
+        }
+    }
+
+    if (eventContent)
+    {
+        html = [NSString stringWithFormat:@"<mx-reply><blockquote><a href=\"%@\">In reply to</a> <a href=\"%@\">%@</a><br>%@</blockquote></mx-reply>%@",
+                [MXTools permalinkToEvent:repliedEvent.eventId inRoom:repliedEvent.roomId],
+                [MXTools permalinkToUserWithUserId:repliedEvent.sender],
+                repliedEvent.sender,
+                repliedEventContent,
+                eventContent];
+    }
+    else
+    {
+        MXLogDebug(@"[MXKEventFormatter] Unable to build reply event %@", event.description)
+    }
+
+    return html;
 }
 
 /**

--- a/Riot/Modules/Room/DataSources/RoomDataSource.swift
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.swift
@@ -155,10 +155,18 @@ extension RoomDataSource {
         let editableTextMessage: NSAttributedString?
 
         if event.isReply() {
-            let parser = MXReplyEventParser()
-            let replyEventParts = parser.parse(event)
+            let body: String
+            if let newContent = event.content[kMXMessageContentKeyNewContent] as? [String:Any] {
+                // Use new content if available.
+                body = newContent["formatted_body"] as? String ?? newContent[kMXMessageBodyKey] as? String ?? ""
+            } else {
+                // Otherwise parse MXReply.
+                let parser = MXReplyEventParser()
+                let replyEventParts = parser.parse(event)
 
-            let body: String = replyEventParts?.formattedBodyParts?.replyText ?? replyEventParts?.bodyParts.replyText ?? ""
+                body = replyEventParts?.formattedBodyParts?.replyText ?? replyEventParts?.bodyParts.replyText ?? ""
+            }
+
             let attributed = eventFormatter.renderHTMLString(body, for: event, with: self.roomState, isEditMode: true)
             if let attributed = attributed, #available(iOS 15.0, *) {
                 editableTextMessage = PillsFormatter.insertPills(in: attributed,

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -143,23 +143,7 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
         if ((RiotSettings.shared.enableThreads && [mxSession.threadingService isEventThreadRoot:event])
             || self.settings.showRedactionsInRoomHistory)
         {
-            UIFont *font = self.defaultTextFont;
-            UIColor *color = ThemeService.shared.theme.colors.secondaryContent;
-            NSString *string = [NSString stringWithFormat:@" %@", VectorL10n.eventFormatterMessageDeleted];
-            NSAttributedString *attrString = [[NSAttributedString alloc] initWithString:string
-                                                                             attributes:@{
-                                                                                 NSFontAttributeName: font,
-                                                                                 NSForegroundColorAttributeName: color
-                                                                             }];
-            
-            CGSize imageSize = CGSizeMake(20, 20);
-            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.image = [[AssetImages.roomContextMenuDelete.image vc_resizedWith:imageSize] vc_tintedImageUsingColor:color];
-            attachment.bounds = CGRectMake(0, font.descender, imageSize.width, imageSize.height);
-            NSAttributedString *imageString = [NSAttributedString attributedStringWithAttachment:attachment];
-            
-            NSMutableAttributedString *result = [[NSMutableAttributedString alloc] initWithAttributedString:imageString];
-            [result appendAttributedString:attrString];
+            NSAttributedString *result = [self redactedMessageReplacementAttributedString];
             
             if (error)
             {
@@ -537,6 +521,29 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
     }
     
     return updated;
+}
+
+- (NSAttributedString *)redactedMessageReplacementAttributedString
+{
+    UIFont *font = self.defaultTextFont;
+    UIColor *color = ThemeService.shared.theme.colors.secondaryContent;
+    NSString *string = [NSString stringWithFormat:@" %@", VectorL10n.eventFormatterMessageDeleted];
+    NSAttributedString *attrString = [[NSAttributedString alloc] initWithString:string
+                                                                     attributes:@{
+                                                                         NSFontAttributeName: font,
+                                                                         NSForegroundColorAttributeName: color
+                                                                     }];
+
+    CGSize imageSize = CGSizeMake(20, 20);
+    NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+    attachment.image = [[AssetImages.roomContextMenuDelete.image vc_resizedWith:imageSize] vc_tintedImageUsingColor:color];
+    attachment.bounds = CGRectMake(0, font.descender, imageSize.width, imageSize.height);
+    NSAttributedString *imageString = [NSAttributedString attributedStringWithAttachment:attachment];
+
+    NSMutableAttributedString *result = [[NSMutableAttributedString alloc] initWithAttributedString:imageString];
+    [result appendAttributedString:attrString];
+
+    return result;
 }
 
 - (BOOL)session:(MXSession *)session updateRoomSummary:(MXRoomSummary *)summary withServerRoomSummary:(MXRoomSyncSummary *)serverRoomSummary roomState:(MXRoomState *)roomState

--- a/changelog.d/pr-6155.change
+++ b/changelog.d/pr-6155.change
@@ -1,0 +1,1 @@
+Partial implementation of rich replies


### PR DESCRIPTION
This is a partial implementation of [rich replies](https://matrix.org/docs/spec/client_server/r0.4.0.html#rich-replies)
It constructs the reply body directly from the related event, but only if it is available in the local DB.
Replies to unavailable events will fallback to the current behaviour.

It is therefore a partial fix for https://github.com/vector-im/element-ios/issues/3828 https://github.com/vector-im/element-ios/issues/3517 https://github.com/vector-im/element-ios/issues/4586 https://github.com/vector-im/element-ios/issues/5479 https://github.com/vector-im/element-ios/issues/5823 

https://user-images.githubusercontent.com/80891108/171646377-14111c89-1f34-41fb-afd2-55183fddfce5.mp4


