### PR TITLE
Implement LoginWizard and add AuthenticationRestClient protocol

### DIFF
--- a/Riot/Categories/MXRestClient+Async.swift
+++ b/Riot/Categories/MXRestClient+Async.swift
@@ -35,14 +35,33 @@ extension MXRestClient {
         }
     }
     
-    /// An async version of `getRegisterSession(completion:)`.
-    func getRegisterSession() async throws -> MXAuthenticationSession {
-        try await getResponse(getRegisterSession)
-    }
+    // MARK: - Login
     
     /// An async version of `getLoginSession(completion:)`.
     func getLoginSession() async throws -> MXAuthenticationSession {
         try await getResponse(getLoginSession)
+    }
+    
+    /// An async version of `login(parameters:completion:)`, that takes a value that conforms to `LoginParameters`.
+    func login(parameters: LoginParameters) async throws -> MXCredentials {
+        let dictionary = try parameters.dictionary()
+        return try await login(parameters: dictionary)
+    }
+    
+    /// An async version of `login(parameters:completion:)`.
+    func login(parameters: [String: Any]) async throws -> MXCredentials {
+        let jsonDictionary = try await getResponse { completion in
+            login(parameters: parameters, completion: completion)
+        }
+        guard let loginResponse = MXLoginResponse(fromJSON: jsonDictionary) else { throw ClientError.decodingError }
+        return MXCredentials(loginResponse: loginResponse, andDefaultCredentials: credentials)
+    }
+    
+    // MARK: - Registration
+    
+    /// An async version of `getRegisterSession(completion:)`.
+    func getRegisterSession() async throws -> MXAuthenticationSession {
+        try await getResponse(getRegisterSession)
     }
     
     /// An async version of `isUsernameAvailable(_:completion:)`.
@@ -101,7 +120,35 @@ extension MXRestClient {
         }
     }
     
-    // MARK: Private
+    // MARK: - Reset Password
+    
+    /// An async version of `resetPassword(parameters:completion:)`, that takes a `CheckResetPasswordParameters` value instead of a dictionary.
+    func resetPassword(parameters: CheckResetPasswordParameters) async throws {
+        let dictionary = try parameters.dictionary()
+        try await resetPassword(parameters: dictionary)
+    }
+    
+    /// An async version of `resetPassword(parameters:completion:)`.
+    func resetPassword(parameters: [String: Any]) async throws {
+        try await getResponse { completion in
+            resetPassword(parameters: parameters, completion: completion)
+        }
+    }
+    
+    /// An async version of `forgetPassword(forEmail:clientSecret:sendAttempt:success:failure:)`.
+    /// - Returns: The session ID to be included when calling `resetPassword(parameters:)`.
+    func forgetPassword(for email: String, clientSecret: String, sendAttempt: UInt) async throws -> String {
+        try await getResponse { success, failure in
+            forgetPassword(forEmail: email,
+                           clientSecret: clientSecret,
+                           sendAttempt: sendAttempt,
+                           success: success,
+                           failure: failure)
+        }
+    }
+    
+    
+    // MARK: - Private
     
     private func getResponse<T>(_ callback: (@escaping (MXResponse<T>) -> Void) -> MXHTTPOperation) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in

--- a/Riot/Categories/MXRestClient+Async.swift
+++ b/Riot/Categories/MXRestClient+Async.swift
@@ -122,19 +122,6 @@ extension MXRestClient {
     
     // MARK: - Reset Password
     
-    /// An async version of `resetPassword(parameters:completion:)`, that takes a `CheckResetPasswordParameters` value instead of a dictionary.
-    func resetPassword(parameters: CheckResetPasswordParameters) async throws {
-        let dictionary = try parameters.dictionary()
-        try await resetPassword(parameters: dictionary)
-    }
-    
-    /// An async version of `resetPassword(parameters:completion:)`.
-    func resetPassword(parameters: [String: Any]) async throws {
-        try await getResponse { completion in
-            resetPassword(parameters: parameters, completion: completion)
-        }
-    }
-    
     /// An async version of `forgetPassword(forEmail:clientSecret:sendAttempt:success:failure:)`.
     /// - Returns: The session ID to be included when calling `resetPassword(parameters:)`.
     func forgetPassword(for email: String, clientSecret: String, sendAttempt: UInt) async throws -> String {
@@ -147,6 +134,18 @@ extension MXRestClient {
         }
     }
     
+    /// An async version of `resetPassword(parameters:completion:)`, that takes a `CheckResetPasswordParameters` value instead of a dictionary.
+    func resetPassword(parameters: CheckResetPasswordParameters) async throws {
+        let dictionary = try parameters.dictionary()
+        try await resetPassword(parameters: dictionary)
+    }
+    
+    /// An async version of `resetPassword(parameters:completion:)`.
+    func resetPassword(parameters: [String: Any]) async throws {
+        try await getResponse { completion in
+            resetPassword(parameters: parameters, completion: completion)
+        }
+    }
     
     // MARK: - Private
     

--- a/Riot/Utils/DictionaryEncodable.swift
+++ b/Riot/Utils/DictionaryEncodable.swift
@@ -31,7 +31,7 @@ extension DictionaryEncodable {
         let object = try JSONSerialization.jsonObject(with: jsonData)
         
         guard let dictionary = object as? [String: Any] else {
-            MXLog.error("[RegistrationParameters] dictionary: Unexpected type decoded \(type(of: object)). Expected a Dictionary.")
+            MXLog.error("[DictionaryEncodable] Unexpected type decoded \(type(of: object)). Expected a Dictionary.")
             throw DictionaryEncodableError.typeError
         }
         

--- a/Riot/Utils/DictionaryEncodable.swift
+++ b/Riot/Utils/DictionaryEncodable.swift
@@ -1,0 +1,40 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// A type that can encode itself into a `[String: Any]` JSON dictionary.
+protocol DictionaryEncodable: Encodable { }
+
+enum DictionaryEncodableError: Error {
+    /// The value returned an unexpected type from `JSONSerialization`.
+    case typeError
+}
+
+extension DictionaryEncodable {
+    /// Returns self encoded as a JSON dictionary.
+    func dictionary() throws -> [String: Any] {
+        let jsonData = try JSONEncoder().encode(self)
+        let object = try JSONSerialization.jsonObject(with: jsonData)
+        
+        guard let dictionary = object as? [String: Any] else {
+            MXLog.error("[RegistrationParameters] dictionary: Unexpected type decoded \(type(of: object)). Expected a Dictionary.")
+            throw DictionaryEncodableError.typeError
+        }
+        
+        return dictionary
+    }
+}

--- a/RiotSwiftUI/Modules/Authentication/Common/AuthenticationModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/AuthenticationModels.swift
@@ -34,8 +34,6 @@ enum AuthenticationType {
 
 /// Errors that can be thrown from `AuthenticationService`.
 enum AuthenticationError: String, LocalizedError {
-    /// A failure to convert a struct into a dictionary.
-    case dictionaryError
     case invalidHomeserver
     case loginFlowNotCalled
     case missingMXRestClient
@@ -72,7 +70,7 @@ enum RegistrationError: String, LocalizedError {
 
 /// Errors that can be thrown from `LoginWizard`
 enum LoginError: String, Error {
-    case unimplemented
+    case resetPasswordNotStarted
 }
 
 /// Represents an SSO Identity Provider as provided in a login flow.

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationRestClient.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationRestClient.swift
@@ -1,0 +1,45 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol AuthenticationRestClient {
+    // MARK: Configuration
+    var credentials: MXCredentials! { get }
+    var identityServer: String! { get }
+    
+    // MARK: Login
+    var loginFallbackURL: URL { get }
+    func wellKnown() async throws -> MXWellKnown
+    func getLoginSession() async throws -> MXAuthenticationSession
+    func login(parameters: LoginParameters) async throws -> MXCredentials
+    func login(parameters: [String : Any]) async throws -> MXCredentials
+    
+    // MARK: Registration
+    var registerFallbackURL: URL { get }
+    func getRegisterSession() async throws -> MXAuthenticationSession
+    func isUsernameAvailable(_ username: String) async throws -> Bool
+    func register(parameters: RegistrationParameters) async throws -> MXLoginResponse
+    func register(parameters: [String : Any]) async throws -> MXLoginResponse
+    func requestTokenDuringRegistration(for threePID: RegisterThreePID, clientSecret: String, sendAttempt: UInt) async throws -> RegistrationThreePIDTokenResponse
+    
+    // MARK: Forgot Password
+    func forgetPassword(for email: String, clientSecret: String, sendAttempt: UInt) async throws -> String
+    func resetPassword(parameters: CheckResetPasswordParameters) async throws
+    func resetPassword(parameters: [String : Any]) async throws
+}
+
+extension MXRestClient: AuthenticationRestClient { }

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
@@ -93,7 +93,7 @@ class AuthenticationService: NSObject {
                                  preferredLoginMode: loginFlows.loginMode,
                                  loginModeSupportedTypes: loginFlows.supportedLoginTypes)
         
-        let loginWizard = LoginWizard()
+        let loginWizard = LoginWizard(client: client)
         self.loginWizard = loginWizard
         
         if flow == .register {

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
@@ -30,7 +30,7 @@ class AuthenticationService: NSObject {
     // MARK: Private
     
     /// The rest client used to make authentication requests.
-    private var client: MXRestClient
+    private var client: AuthenticationRestClient
     /// The object used to create a new `MXSession` when authentication has completed.
     private var sessionCreator = SessionCreator()
     
@@ -141,7 +141,7 @@ class AuthenticationService: NSObject {
         let address = state.homeserver.addressFromUser ?? state.homeserver.address
         self.state = AuthenticationState(flow: .login, homeserverAddress: address)
     }
-
+    
     /// Create a session after a SSO successful login
     func makeSessionFromSSO(credentials: MXCredentials) -> MXSession {
         sessionCreator.createSession(credentials: credentials, client: client)

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginModels.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 
+/// The result returned when querying a homeserver's available login flows.
 struct LoginFlowResult {
     let supportedLoginTypes: [MXLoginFlow]
     let ssoIdentityProviders: [SSOIdentityProvider]
@@ -35,11 +36,17 @@ struct LoginFlowResult {
     }
 }
 
+/// The supported forms of login that a homeserver allows.
 enum LoginMode {
+    /// The login mode hasn't been determined yet.
     case unknown
+    /// The homeserver supports login with a password.
     case password
+    /// The homeserver supports login via one or more SSO providers.
     case sso(ssoIdentityProviders: [SSOIdentityProvider])
+    /// The homeserver supports login with either a password or via an SSO provider.
     case ssoAndPassword(ssoIdentityProviders: [SSOIdentityProvider])
+    /// The homeserver only allows login with unsupported mechanisms. Use fallback instead.
     case unsupported
     
     var ssoIdentityProviders: [SSOIdentityProvider]? {
@@ -60,7 +67,7 @@ enum LoginMode {
         }
     }
     
-    var supportsSignModeScreen: Bool {
+    var supportsPasswordFlow: Bool {
         switch self {
         case .password, .ssoAndPassword:
             return true
@@ -69,3 +76,11 @@ enum LoginMode {
         }
     }
 }
+
+/// Data obtained when calling `LoginWizard.resetPassword` that will be used
+/// when calling `LoginWizard.checkResetPasswordMailConfirmed`.
+struct ResetPasswordData {
+    let newPassword: String
+    let addThreePIDSessionID: String
+}
+

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginParameters.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginParameters.swift
@@ -1,0 +1,114 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// An `Encodable` type that can be used as the parameters of a login request.
+protocol LoginParameters: DictionaryEncodable {
+    var type: String { get }
+}
+
+/// The parameters used for a login request with a token.
+struct LoginTokenParameters: LoginParameters {
+    let type = kMXLoginFlowTypeToken
+    let token: String
+}
+
+/// The parameters used for a login request with an ID and password.
+struct LoginPasswordParameters: LoginParameters {
+    let id: Identifier
+    let password: String
+    let type: String = kMXLoginFlowTypePassword
+    let deviceDisplayName: String?
+    let deviceID: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "identifier"
+        case password
+        case type
+        case deviceDisplayName = "initial_device_display_name"
+        case deviceID = "device_id"
+    }
+    
+    enum ThreePIDMedium: String { case email, msisdn }
+    
+    enum Identifier: Encodable {
+        case user(String)
+        case thirdParty(medium: ThreePIDMedium, address: String)
+        case phone(country: String, phone: String)
+        
+        private enum Constants {
+            static let typeKey = "type"
+            static let userType = "m.id.user"
+            static let thirdPartyType = "m.id.thirdparty"
+            static let phoneType = "m.id.phone"
+            
+            static let userKey = "user"
+            
+            static let mediumKey = "medium"
+            static let addressKey = "address"
+            
+            static let countryKey = "country"
+            static let phoneKey = "phone"
+        }
+        
+        var dictionary: [String: String] {
+            switch self {
+            case .user(let user):
+                return [
+                    Constants.typeKey: Constants.userType,
+                    Constants.userKey: user
+                ]
+            case .thirdParty(let medium, let address):
+                return [
+                    Constants.typeKey: Constants.thirdPartyType,
+                    Constants.mediumKey: medium.rawValue,
+                    Constants.addressKey: address
+                ]
+            case .phone(let country, let phone):
+                return [
+                    Constants.typeKey: Constants.phoneType,
+                    Constants.countryKey: country,
+                    Constants.phoneKey: phone
+                ]
+            }
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(dictionary)
+        }
+    }
+}
+
+/// The parameters used when checking the user has confirmed their email to reset their password.
+struct CheckResetPasswordParameters: DictionaryEncodable {
+    /// Authentication parameters
+    let auth: AuthenticationParameters
+    
+    /// The new password
+    let newPassword: String
+    
+    enum CodingKeys: String, CodingKey {
+        case auth
+        case newPassword = "new_password"
+    }
+    
+    init(clientSecret: String, sessionID: String, newPassword: String) {
+        self.auth = AuthenticationParameters.resetPasswordParameters(clientSecret: clientSecret, sessionID: sessionID)
+        self.newPassword = newPassword
+    }
+}

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginParameters.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginParameters.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-/// An `Encodable` type that can be used as the parameters of a login request.
+/// A `DictionaryEncodable` type that can be used as the parameters of a login request.
 protocol LoginParameters: DictionaryEncodable {
     var type: String { get }
 }
@@ -94,11 +94,10 @@ struct LoginPasswordParameters: LoginParameters {
     }
 }
 
-/// The parameters used when checking the user has confirmed their email to reset their password.
+/// The parameters used when checking that the user has confirmed their email in order to reset their password.
 struct CheckResetPasswordParameters: DictionaryEncodable {
     /// Authentication parameters
     let auth: AuthenticationParameters
-    
     /// The new password
     let newPassword: String
     

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
@@ -30,12 +30,12 @@ class LoginWizard {
         var sendAttempt: UInt = 0
     }
     
-    let client: MXRestClient
+    let client: AuthenticationRestClient
     let sessionCreator: SessionCreator
     
     private(set) var state: State
     
-    init(client: MXRestClient, sessionCreator: SessionCreator = SessionCreator()) {
+    init(client: AuthenticationRestClient, sessionCreator: SessionCreator = SessionCreator()) {
         self.client = client
         self.sessionCreator = sessionCreator
         
@@ -111,8 +111,8 @@ class LoginWizard {
         }
         
         let parameters = CheckResetPasswordParameters(clientSecret: state.clientSecret,
-                                                 sessionID: resetPasswordData.addThreePIDSessionID,
-                                                 newPassword: resetPasswordData.newPassword)
+                                                      sessionID: resetPasswordData.addThreePIDSessionID,
+                                                      newPassword: resetPasswordData.newPassword)
         
         try await client.resetPassword(parameters: parameters)
         

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
@@ -16,16 +16,106 @@
 
 import Foundation
 
+/// Set of methods to be able to login to an existing account on a homeserver.
+///
+/// More documentation can be found in the file https://github.com/vector-im/element-android/blob/main/docs/signin.md
 class LoginWizard {
     struct State {
         /// For SSO session recovery
         var deviceId: String?
         var resetPasswordEmail: String?
-        // var resetPasswordData: ResetPasswordData?
+        var resetPasswordData: ResetPasswordData?
         
         var clientSecret = UUID().uuidString
         var sendAttempt: UInt = 0
     }
     
-    // TODO
+    let client: MXRestClient
+    let sessionCreator: SessionCreator
+    
+    private(set) var state: State
+    
+    init(client: MXRestClient, sessionCreator: SessionCreator = SessionCreator()) {
+        self.client = client
+        self.sessionCreator = sessionCreator
+        
+        self.state = State()
+    }
+    
+//    /// Get some information about a matrixId: displayName and avatar url
+//    func profileInfo(for matrixID: String) async -> LoginProfileInfo {
+//
+//    }
+    
+    /// Login to the homeserver.
+    /// - Parameters:
+    ///   - login: The login field. Can be a user name, or a msisdn (email or phone number) associated to the account.
+    ///   - password: The password of the account.
+    ///   - initialDeviceName: The initial device name.
+    ///   - deviceID: The device ID, optional. If not provided or nil, the server will generate one.
+    /// - Returns: An `MXSession` if the login is successful.
+    func login(login: String, password: String, initialDeviceName: String, deviceID: String? = nil) async throws -> MXSession {
+        let parameters: LoginPasswordParameters
+        
+        if MXTools.isEmailAddress(login) {
+            parameters = LoginPasswordParameters(id: .thirdParty(medium: .email, address: login),
+                                                 password: password,
+                                                 deviceDisplayName: initialDeviceName,
+                                                 deviceID: deviceID)
+        } else {
+            parameters = LoginPasswordParameters(id: .user(login),
+                                                 password: password,
+                                                 deviceDisplayName: initialDeviceName,
+                                                 deviceID: deviceID)
+        }
+        
+        let credentials = try await client.login(parameters: parameters)
+        return sessionCreator.createSession(credentials: credentials, client: client)
+    }
+    
+    /// Exchange a login token to an access token.
+    /// - Parameter loginToken: A login token, obtained when login has happened in a WebView, using SSO.
+    /// - Returns: An `MXSession` if the login is successful.
+    func login(with token: String) async throws -> MXSession {
+        let parameters = LoginTokenParameters(token: token)
+        let credentials = try await client.login(parameters: parameters)
+        return sessionCreator.createSession(credentials: credentials, client: client)
+    }
+    
+//    /// Login to the homeserver by sending a custom JsonDict.
+//    /// The data should contain at least one entry `type` with a String value.
+//    func loginCustom(data: Codable) async -> MXSession {
+//
+//    }
+    
+    /// Ask the homeserver to reset the user password. The password will not be
+    /// reset until `checkResetPasswordMailConfirmed` is successfully called.
+    /// - Parameters:
+    ///   - email: An email previously associated to the account the user wants the password to be reset.
+    ///   - newPassword: The desired new password
+    func resetPassword(email: String, newPassword: String) async throws {
+        let result = try await client.forgetPassword(for: email,
+                                                     clientSecret: state.clientSecret,
+                                                     sendAttempt: state.sendAttempt)
+
+        state.sendAttempt += 1
+        state.resetPasswordData = ResetPasswordData(newPassword: newPassword, addThreePIDSessionID: result)
+    }
+    
+    /// Confirm the new password, once the user has checked their email.
+    /// When this method succeeds, the account password will be effectively modified.
+    func checkResetPasswordMailConfirmed() async throws {
+        guard let resetPasswordData = state.resetPasswordData else {
+            MXLog.error("[LoginWizard] resetPasswordMailConfirmed: Reset password data missing. Call resetPassword first.")
+            throw LoginError.resetPasswordNotStarted
+        }
+        
+        let parameters = CheckResetPasswordParameters(clientSecret: state.clientSecret,
+                                                 sessionID: resetPasswordData.addThreePIDSessionID,
+                                                 newPassword: resetPasswordData.newPassword)
+        
+        try await client.resetPassword(parameters: parameters)
+        
+        state.resetPasswordData = nil
+    }
 }

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationParameters.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationParameters.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// The parameters used for registration requests.
-struct RegistrationParameters: Codable {
+struct RegistrationParameters: DictionaryEncodable {
     /// Authentication parameters
     var auth: AuthenticationParameters?
     
@@ -41,22 +41,10 @@ struct RegistrationParameters: Codable {
         case initialDeviceDisplayName = "initial_device_display_name"
         case xShowMSISDN = "x_show_msisdn"
     }
-    
-    /// The parameters as a JSON dictionary for use in MXRestClient.
-    func dictionary() throws -> [String: Any] {
-        let jsonData = try JSONEncoder().encode(self)
-        let object = try JSONSerialization.jsonObject(with: jsonData)
-        guard let dictionary = object as? [String: Any] else {
-            MXLog.error("[RegistrationParameters] dictionary: Unexpected type decoded \(type(of: object)). Expected a Dictionary.")
-            throw AuthenticationError.dictionaryError
-        }
-        
-        return dictionary
-    }
 }
 
-/// The data passed to the `auth` parameter in registration requests.
-struct AuthenticationParameters: Codable {
+/// The data passed to the `auth` parameter in authentication requests.
+struct AuthenticationParameters: Encodable {
     /// The type of authentication taking place. The identifier from `MXLoginFlowType`.
     let type: String
     

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
@@ -35,7 +35,7 @@ class RegistrationWizard {
         var sendAttempt: UInt = 0
     }
     
-    let client: MXRestClient
+    let client: AuthenticationRestClient
     let sessionCreator: SessionCreator
     
     private(set) var state: State
@@ -59,7 +59,7 @@ class RegistrationWizard {
         state.isRegistrationStarted
     }
     
-    init(client: MXRestClient, sessionCreator: SessionCreator = SessionCreator()) {
+    init(client: AuthenticationRestClient, sessionCreator: SessionCreator = SessionCreator()) {
         self.client = client
         self.sessionCreator = sessionCreator
         

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/SessionCreator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/SessionCreator.swift
@@ -19,7 +19,7 @@ import Foundation
 /// A WIP class that has common functionality to create a new session.
 class SessionCreator {
     /// Creates an `MXSession` using the supplied credentials and REST client.
-    func createSession(credentials: MXCredentials, client: MXRestClient) -> MXSession {
+    func createSession(credentials: MXCredentials, client: AuthenticationRestClient) -> MXSession {
         // Report the new account in account manager
         if credentials.identityServer == nil {
             #warning("Check that the client is actually updated with this info?")

--- a/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
@@ -180,8 +180,6 @@ final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
             switch authenticationError {
             case .invalidHomeserver:
                 authenticationRegistrationViewModel.displayError(.invalidHomeserver)
-            case .dictionaryError:
-                authenticationRegistrationViewModel.displayError(.unknown)
             case .loginFlowNotCalled:
                 #warning("Reset the flow")
             case .missingMXRestClient:

--- a/RiotTests/Modules/Authentication/LoginTests.swift
+++ b/RiotTests/Modules/Authentication/LoginTests.swift
@@ -1,0 +1,72 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+@testable import Riot
+
+class LoginTests: XCTestCase {
+    func testUserParameterIdentifier() {
+        // Given a user identifier.
+        let id = LoginPasswordParameters.Identifier.user("test")
+        
+        // When converting it to a dictionary.
+        let dictionary = id.dictionary
+        
+        // Then the dictionary should have the expected format.
+        XCTAssertEqual(dictionary["type"], "m.id.user")
+        XCTAssertEqual(dictionary["user"], "test")
+    }
+    
+    func testPhoneParameterIdentifier() {
+        // Given a phone number identifier.
+        let id = LoginPasswordParameters.Identifier.phone(country: "44", phone: "7777")
+        
+        // When converting it to a dictionary.
+        let dictionary = id.dictionary
+        
+        // Then the dictionary should have the expected format.
+        XCTAssertEqual(dictionary["type"], "m.id.phone")
+        XCTAssertEqual(dictionary["country"], "44")
+        XCTAssertEqual(dictionary["phone"], "7777")
+    }
+    
+    func testEmailParameterIdentifier() {
+        // Given an email identifier.
+        let id = LoginPasswordParameters.Identifier.thirdParty(medium: .email, address: "test@example.com")
+        
+        // When converting it to a dictionary.
+        let dictionary = id.dictionary
+        
+        // Then the dictionary should have the expected format.
+        XCTAssertEqual(dictionary["type"], "m.id.thirdparty")
+        XCTAssertEqual(dictionary["medium"], "email")
+        XCTAssertEqual(dictionary["address"], "test@example.com")
+    }
+    
+    func testMSISDNParameterIdentifier() {
+        // Given an msisdn phone number identifier.
+        let id = LoginPasswordParameters.Identifier.thirdParty(medium: .msisdn, address: "123456789")
+        
+        // When converting it to a dictionary.
+        let dictionary = id.dictionary
+        
+        // Then the dictionary should have the expected format.
+        XCTAssertEqual(dictionary["type"], "m.id.thirdparty")
+        XCTAssertEqual(dictionary["medium"], "msisdn")
+        XCTAssertEqual(dictionary["address"], "123456789")
+    }
+}

--- a/changelog.d/5896.wip
+++ b/changelog.d/5896.wip
@@ -1,0 +1,1 @@
+Authentication: Implement the LoginWizard to match Element Android.


### PR DESCRIPTION
This is the second part of #5896 that implements the `LoginWizard` similarly to the Android implementation. Additionally
- Adds an `AuthenticationRestClient` protocol so that the client can be mocked for testing the service layer.
- Adds a `DictionaryEncodable` protocol with a default implementation as I needed to get a dictionary from multiple `Encodable` types.

There are some remaining commented out parts of the from the Android service, but in essence this closes #5896 and those can be added/removed with the remaining tasks.