### PR TITLE
Attempt at fixing [CALayer animationForKey] crashes.

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -538,7 +538,7 @@
         // Select the right text view for measurement
         UITextView *selectedTextView = (removeVerticalInset ? measurementTextViewWithoutInset : measurementTextView);
         
-        selectedTextView.frame = CGRectMake(0, 0, _maxTextViewWidth, MAXFLOAT);
+        selectedTextView.frame = CGRectMake(0, 0, _maxTextViewWidth, 0);
         selectedTextView.attributedText = attributedText;
             
         CGSize size = [selectedTextView sizeThatFits:selectedTextView.frame.size];

--- a/changelog.d/pr-6188.bugfix
+++ b/changelog.d/pr-6188.bugfix
@@ -1,0 +1,1 @@
+Added attempt at fixing random crashes while calculating timeline cell heights.


### PR DESCRIPTION
This is just an educated guess, don't know much more than that

Crashlogs available here: xcode://organizer/crashes/downloadPoint?adamId=1083446067&platformId=iOS&installPlatformId=iOS&analyticsPointId=DAnw6bxyqudU75gNw0fsNY&bundleId=im.vector.app