### PR TITLE
Support SSO login in the new flow.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: macos-11
+    runs-on: macos-12
     
     # Concurrency group not needed as this workflow only runs on develop which we always want to test.
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   tests:
     name: Tests
-    runs-on: macos-11
+    runs-on: macos-12
     
     concurrency:
       # When running on develop, use the sha to allow all runs of this workflow to run concurrently.

--- a/.github/workflows/ci-ui-tests.yml
+++ b/.github/workflows/ci-ui-tests.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   tests:
     name: UI Tests
-    runs-on: macos-11
+    runs-on: macos-12
     
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   check-secret:
-    runs-on: macos-11
+    runs-on: macos-12
     outputs:
       out-key: ${{ steps.out-key.outputs.defined }}
     steps:
@@ -29,7 +29,7 @@ jobs:
     needs: [check-secret]
     if: needs.check-secret.outputs.out-key == 'true'
     name: Release
-    runs-on: macos-11
+    runs-on: macos-12
     
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.

--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -189,8 +189,8 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
         let canOpenLink: Bool
         
         switch deepLinkOption {
-        case .connect(let loginToken, let transactionId):
-            canOpenLink = self.legacyAppDelegate.continueSSOLogin(withToken: loginToken, txnId: transactionId)
+        case .connect(let loginToken, let transactionID):
+            canOpenLink = AuthenticationService.shared.continueSSOLogin(with: loginToken, and: transactionID)
         }
         
         return canOpenLink

--- a/Riot/Modules/Application/LegacyAppDelegate.h
+++ b/Riot/Modules/Application/LegacyAppDelegate.h
@@ -282,14 +282,6 @@ UINavigationControllerDelegate
 */
 - (void)checkAppVersion;
 
-#pragma mark - Authentication
-
-/// When SSO login succeeded, when SFSafariViewController is used, continue login with success parameters.
-/// @param loginToken The login token provided when SSO succeeded.
-/// @param txnId transaction id generated during SSO page presentation.
-/// returns YES if the SSO login can be continued.
-- (BOOL)continueSSOLoginWithToken:(NSString*)loginToken txnId:(NSString*)txnId;
-
 @end
 
 @protocol LegacyAppDelegateDelegate <NSObject>

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -4696,21 +4696,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     [self presentViewController:viewController animated:YES completion:completion];
 }
 
-#pragma mark - Authentication
-
-- (BOOL)continueSSOLoginWithToken:(NSString*)loginToken txnId:(NSString*)txnId
-{
-    OnboardingCoordinatorBridgePresenter *bridgePresenter = self.masterTabBarController.onboardingCoordinatorBridgePresenter;
-    
-    if (!bridgePresenter)
-    {
-        MXLogDebug(@"[AppDelegate] Fail to continue SSO login");
-        return NO;
-    }
-    
-    return [bridgePresenter continueSSOLoginWithToken:loginToken transactionID:txnId];
-}
-
 #pragma mark - Private
 
 - (void)clearCache

--- a/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinatorProtocol.swift
@@ -50,9 +50,6 @@ protocol AuthenticationCoordinatorProtocol: Coordinator, Presentable {
     /// Set up the authentication screen with the specified homeserver and/or identity server.
     func updateHomeserver(_ homeserver: String?, andIdentityServer identityServer: String?)
     
-    /// When SSO login succeeded, when SFSafariViewController is used, continue login with success parameters.
-    func continueSSOLogin(withToken loginToken: String, transactionID: String) -> Bool
-    
     /// Indicates to the coordinator to display any pending screens if it was created with
     /// the `canPresentAdditionalScreens` parameter set to `false`
     func presentPendingScreensIfNecessary()

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -554,6 +554,12 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 
 - (BOOL)continueSSOLoginWithToken:(NSString*)loginToken txnId:(NSString*)txnId
 {
+    // The presenter isn't dismissed automatically when finishing via a deep link
+    if (self.ssoAuthenticationPresenter)
+    {
+        [self dismissSSOAuthenticationPresenter];
+    }
+    
     // Check if transaction id is the same as expected
     if (loginToken &&
         txnId && self.ssoCallbackTxnId

--- a/Riot/Modules/Authentication/LegacyAuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/LegacyAuthenticationCoordinator.swift
@@ -73,8 +73,10 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
     // MARK: - Public
     
     func start() {
-        // Listen to the end of the authentication flow
+        // Listen to the end of the authentication flow.
         authenticationViewController.authVCDelegate = self
+        // Listen for changes from deep links.
+        AuthenticationService.shared.delegate = self
     }
     
     func toPresentable() -> UIViewController {
@@ -95,10 +97,6 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
     
     func updateHomeserver(_ homeserver: String?, andIdentityServer identityServer: String?) {
         authenticationViewController.showCustomHomeserver(homeserver, andIdentityServer: identityServer)
-    }
-    
-    func continueSSOLogin(withToken loginToken: String, transactionID: String) -> Bool {
-        authenticationViewController.continueSSOLogin(withToken: loginToken, txnId: transactionID)
     }
     
     func presentPendingScreensIfNecessary() {
@@ -144,6 +142,13 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
     
     private func authenticationDidComplete() {
         callback?(.didComplete)
+    }
+}
+
+// MARK: - AuthenticationServiceDelegate
+extension LegacyAuthenticationCoordinator: AuthenticationServiceDelegate {
+    func authenticationService(_ service: AuthenticationService, didReceive ssoLoginToken: String, with transactionID: String) -> Bool {
+        authenticationViewController.continueSSOLogin(withToken: ssoLoginToken, txnId: transactionID)
     }
 }
 

--- a/Riot/Modules/Authentication/SSO/SSOAuthenticationPresenter.swift
+++ b/Riot/Modules/Authentication/SSO/SSOAuthenticationPresenter.swift
@@ -72,17 +72,12 @@ final class SSOAuthenticationPresenter: NSObject {
         self.identityProvider = identityProvider
         self.presentingViewController = presentingViewController
         
-        // NOTE: By using SFAuthenticationSession the consent alert show product name instead of display name. Fallback to SFSafariViewController instead in order to not disturb users with "Riot" wording at the moment.
-        // (https://stackoverflow.com/questions/49860338/why-does-sfauthenticationsession-consent-alert-show-xcode-project-name-instead-o)
-        if #available(iOS 13.0, *) {
+        if #unavailable(iOS 15.0), UIAccessibility.isGuidedAccessEnabled {
             // SFAuthenticationSession and ASWebAuthenticationSession doesn't work with guided access (rdar://48376122)
-            if UIAccessibility.isGuidedAccessEnabled {
-                self.presentSafariViewController(with: authenticationURL, animated: animated)
-            } else {
-                self.startAuthenticationSession(with: authenticationURL)
-            }
+            // Confirmed to be fixed on iOS 15, haven't been able to test on iOS 14.
+            presentSafariViewController(with: authenticationURL, animated: animated)
         } else {
-            self.presentSafariViewController(with: authenticationURL, animated: animated)
+            startAuthenticationSession(with: authenticationURL)
         }
     }
     

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -128,12 +128,6 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         legacyAuthenticationCoordinator.updateHomeserver(homeserver, andIdentityServer: identityServer)
     }
     
-    /// When SSO login succeeded, when SFSafariViewController is used, continue login with success parameters.
-    func continueSSOLogin(withToken loginToken: String, transactionID: String) -> Bool {
-        guard isShowingLegacyAuthentication else { return false }
-        return legacyAuthenticationCoordinator.continueSSOLogin(withToken: loginToken, transactionID: transactionID)
-    }
-    
     // MARK: - Pre-Authentication
     
     /// Show the onboarding splash screen as the root module in the flow.

--- a/Riot/Modules/Onboarding/OnboardingCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinatorBridgePresenter.swift
@@ -97,12 +97,6 @@ final class OnboardingCoordinatorBridgePresenter: NSObject {
         coordinator?.updateHomeserver(homeserver, andIdentityServer: identityServer)
     }
     
-    /// When SSO login succeeded, when SFSafariViewController is used, continue login with success parameters.
-    func continueSSOLogin(withToken loginToken: String, transactionID: String) -> Bool {
-        guard let coordinator = coordinator else { return false }
-        return coordinator.continueSSOLogin(withToken: loginToken, transactionID: transactionID)
-    }
-    
     func dismiss(animated: Bool, completion: (() -> Void)?) {
         guard let coordinator = self.coordinator else {
             return

--- a/Riot/Modules/Onboarding/OnboardingCoordinatorProtocol.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinatorProtocol.swift
@@ -27,7 +27,4 @@ protocol OnboardingCoordinatorProtocol: Coordinator, Presentable {
     
     /// Set up the authentication screen with the specified homeserver and/or identity server.
     func updateHomeserver(_ homeserver: String?, andIdentityServer identityServer: String?)
-    
-    /// When SSO login succeeded, when SFSafariViewController is used, continue login with success parameters.
-    func continueSSOLogin(withToken loginToken: String, transactionID: String) -> Bool
 }

--- a/RiotSwiftUI/Modules/Authentication/Common/AuthenticationSSOButton.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/AuthenticationSSOButton.swift
@@ -16,7 +16,7 @@
 
 import SwiftUI
 
-/// An button that displays the icon and name of an SSO provider.
+/// A button that displays the icon and name of an SSO provider.
 struct AuthenticationSSOButton: View {
     
     // MARK: - Constants
@@ -28,6 +28,11 @@ struct AuthenticationSSOButton: View {
     // MARK: - Private
     
     @Environment(\.theme) private var theme
+    @ScaledMetric private var iconSize = 24
+    
+    private var renderingMode: Image.TemplateRenderingMode? {
+        provider.brand == Brand.apple.rawValue || provider.brand == Brand.github.rawValue ? .template : nil
+    }
     
     // MARK: - Public
     
@@ -52,32 +57,63 @@ struct AuthenticationSSOButton: View {
                     .opacity(0)
             }
             .frame(maxWidth: .infinity)
+            .fixedSize(horizontal: false, vertical: true)
             .contentShape(RoundedRectangle(cornerRadius: 8))
         }
         .buttonStyle(SecondaryActionButtonStyle(customColor: theme.colors.quinaryContent))
     }
     
-    @ViewBuilder
+    /// The icon with appropriate rendering mode and size for dynamic type.
     var icon: some View {
+        iconImage.map { image in
+            image
+                .renderingMode(renderingMode)
+                .resizable()
+                .scaledToFit()
+                .frame(width: iconSize, height: iconSize)
+                .foregroundColor(renderingMode == .template ? theme.colors.primaryContent : nil)
+        }
+    }
+    
+    /// The image to be shown in the icon.
+    var iconImage: Image? {
         switch provider.brand {
         case Brand.apple.rawValue:
-            Image(Asset.Images.authenticationSsoIconApple.name)
-                .renderingMode(.template)
-                .foregroundColor(theme.colors.primaryContent)
+            return Image(Asset.Images.authenticationSsoIconApple.name)
         case Brand.facebook.rawValue:
-            Image(Asset.Images.authenticationSsoIconFacebook.name)
+            return Image(Asset.Images.authenticationSsoIconFacebook.name)
         case Brand.github.rawValue:
-            Image(Asset.Images.authenticationSsoIconGithub.name)
-                .renderingMode(.template)
-                .foregroundColor(theme.colors.primaryContent)
+            return Image(Asset.Images.authenticationSsoIconGithub.name)
         case Brand.gitlab.rawValue:
-            Image(Asset.Images.authenticationSsoIconGitlab.name)
+            return Image(Asset.Images.authenticationSsoIconGitlab.name)
         case Brand.google.rawValue:
-            Image(Asset.Images.authenticationSsoIconGoogle.name)
+            return Image(Asset.Images.authenticationSsoIconGoogle.name)
         case Brand.twitter.rawValue:
-            Image(Asset.Images.authenticationSsoIconTwitter.name)
+            return Image(Asset.Images.authenticationSsoIconTwitter.name)
         default:
-            EmptyView()
+            return nil
         }
+    }
+}
+
+struct AuthenticationSSOButton_Previews: PreviewProvider {
+    static var matrixDotOrg = AuthenticationHomeserverViewData.mockMatrixDotOrg
+    
+    static var buttons: some View {
+        VStack {
+            ForEach(matrixDotOrg.ssoIdentityProviders) { provider in
+                AuthenticationSSOButton(provider: provider) { }
+            }
+            AuthenticationSSOButton(provider: SSOIdentityProvider(id: "", name: "SAML", brand: nil, iconURL: nil)) { }
+        }
+        .padding()
+    }
+    
+    static var previews: some View {
+        buttons
+            .theme(.light).preferredColorScheme(.light)
+            .environment(\.sizeCategory, .accessibilityLarge)
+        buttons
+            .theme(.dark).preferredColorScheme(.dark)
     }
 }

--- a/RiotSwiftUI/Modules/Authentication/Login/AuthenticationLoginModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/AuthenticationLoginModels.swift
@@ -27,6 +27,8 @@ enum AuthenticationLoginViewModelResult {
     case forgotPassword
     /// Login using the supplied credentials.
     case login(username: String, password: String)
+    /// Continue using the supplied SSO provider.
+    case continueWithSSO(SSOIdentityProvider)
 }
 
 // MARK: View
@@ -68,8 +70,8 @@ enum AuthenticationLoginViewAction {
     case forgotPassword
     /// Continue using the input username and password.
     case next
-    /// Login using the supplied SSO provider ID.
-    case continueWithSSO(id: String)
+    /// Continue using the supplied SSO provider.
+    case continueWithSSO(SSOIdentityProvider)
 }
 
 enum AuthenticationLoginErrorType: Hashable {

--- a/RiotSwiftUI/Modules/Authentication/Login/AuthenticationLoginViewModel.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/AuthenticationLoginViewModel.swift
@@ -49,8 +49,8 @@ class AuthenticationLoginViewModel: AuthenticationLoginViewModelType, Authentica
             Task { await callback?(.forgotPassword) }
         case .next:
             Task { await callback?(.login(username: state.bindings.username, password: state.bindings.password)) }
-        case .continueWithSSO(let id):
-            break
+        case .continueWithSSO(let provider):
+            Task { await callback?(.continueWithSSO(provider))}
         }
     }
     

--- a/RiotSwiftUI/Modules/Authentication/Login/Coordinator/AuthenticationLoginCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/Coordinator/AuthenticationLoginCoordinator.swift
@@ -26,6 +26,8 @@ struct AuthenticationLoginCoordinatorParameters {
 }
 
 enum AuthenticationLoginCoordinatorResult {
+    /// Continue using the supplied SSO provider.
+    case continueWithSSO(SSOIdentityProvider)
     /// Login was successful with the associated session created.
     case success(MXSession)
 }
@@ -95,6 +97,7 @@ final class AuthenticationLoginCoordinator: Coordinator, Presentable {
         authenticationLoginViewModel.callback = { [weak self] result in
             guard let self = self else { return }
             MXLog.debug("[AuthenticationLoginCoordinator] AuthenticationLoginViewModel did callback with result: \(result).")
+            
             switch result {
             case .selectServer:
                 self.presentServerSelectionScreen()
@@ -104,6 +107,8 @@ final class AuthenticationLoginCoordinator: Coordinator, Presentable {
                 #warning("Show the forgot password flow.")
             case .login(let username, let password):
                 self.login(username: username, password: password)
+            case .continueWithSSO(let identityProvider):
+                self.callback?(.continueWithSSO(identityProvider))
             }
         }
     }

--- a/RiotSwiftUI/Modules/Authentication/Login/Coordinator/AuthenticationLoginCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/Coordinator/AuthenticationLoginCoordinator.swift
@@ -29,7 +29,7 @@ enum AuthenticationLoginCoordinatorResult {
     /// Continue using the supplied SSO provider.
     case continueWithSSO(SSOIdentityProvider)
     /// Login was successful with the associated session created.
-    case success(MXSession)
+    case success(session: MXSession, password: String)
 }
 
 final class AuthenticationLoginCoordinator: Coordinator, Presentable {
@@ -144,7 +144,7 @@ final class AuthenticationLoginCoordinator: Coordinator, Presentable {
                                                           initialDeviceName: UIDevice.current.initialDisplayName)
                 
                 guard !Task.isCancelled else { return }
-                callback?(.success(session))
+                callback?(.success(session: session, password: password))
                 
                 self?.stopLoading()
             } catch {

--- a/RiotSwiftUI/Modules/Authentication/Login/View/AuthenticationLoginScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/View/AuthenticationLoginScreen.swift
@@ -97,7 +97,8 @@ struct AuthenticationLoginScreen: View {
                                    configuration: UIKitTextInputConfiguration(returnKeyType: .next,
                                                                               autocapitalizationType: .none,
                                                                               autocorrectionType: .no),
-                                   onEditingChanged: usernameEditingChanged)
+                                   onEditingChanged: usernameEditingChanged,
+                                   onCommit: { isPasswordFocused = true })
             .accessibilityIdentifier("usernameTextField")
             
             Spacer().frame(height: 20)
@@ -107,7 +108,8 @@ struct AuthenticationLoginScreen: View {
                                    isFirstResponder: isPasswordFocused,
                                    configuration: UIKitTextInputConfiguration(returnKeyType: .done,
                                                                               isSecureTextEntry: true),
-                                   onEditingChanged: passwordEditingChanged)
+                                   onEditingChanged: passwordEditingChanged,
+                                   onCommit: submit)
             .accessibilityIdentifier("passwordTextField")
             
             Button { viewModel.send(viewAction: .forgotPassword) } label: {
@@ -138,19 +140,17 @@ struct AuthenticationLoginScreen: View {
         }
     }
     
-    /// Give focus to the password text field.
+    /// Parses the username for a homeserver.
     func usernameEditingChanged(isEditing: Bool) {
         guard !isEditing, !viewModel.username.isEmpty else { return }
         
         viewModel.send(viewAction: .parseUsername)
-        isPasswordFocused = true
     }
     
-    /// Submits the form if valid credentials have been input.
+    /// Resets the password field focus.
     func passwordEditingChanged(isEditing: Bool) {
         guard !isEditing else { return }
         isPasswordFocused = false
-        submit()
     }
     
     /// Sends the `next` view action so long as valid credentials have been input.

--- a/RiotSwiftUI/Modules/Authentication/Login/View/AuthenticationLoginScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/View/AuthenticationLoginScreen.swift
@@ -131,7 +131,7 @@ struct AuthenticationLoginScreen: View {
         VStack(spacing: 16) {
             ForEach(viewModel.viewState.homeserver.ssoIdentityProviders) { provider in
                 AuthenticationSSOButton(provider: provider) {
-                    viewModel.send(viewAction: .continueWithSSO(id: provider.id))
+                    viewModel.send(viewAction: .continueWithSSO(provider))
                 }
                 .accessibilityIdentifier("ssoButton")
             }

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationModels.swift
@@ -25,6 +25,8 @@ enum AuthenticationRegistrationViewModelResult {
     case validateUsername(String)
     /// Create an account using the supplied credentials.
     case createAccount(username: String, password: String)
+    /// Continue using the supplied SSO provider.
+    case continueWithSSO(SSOIdentityProvider)
 }
 
 // MARK: View
@@ -92,8 +94,8 @@ enum AuthenticationRegistrationViewAction {
     case clearUsernameError
     /// Continue using the input username and password.
     case next
-    /// Login using the supplied SSO provider ID.
-    case continueWithSSO(id: String)
+    /// Continue using the supplied SSO provider.
+    case continueWithSSO(SSOIdentityProvider)
 }
 
 enum AuthenticationRegistrationErrorType: Hashable {

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModel.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationViewModel.swift
@@ -52,8 +52,8 @@ class AuthenticationRegistrationViewModel: AuthenticationRegistrationViewModelTy
             Task { await clearUsernameError() }
         case .next:
             Task { await callback?(.createAccount(username: state.bindings.username, password: state.bindings.password)) }
-        case .continueWithSSO(let id):
-            break
+        case .continueWithSSO(let provider):
+            Task { await callback?(.continueWithSSO(provider)) }
         }
     }
     

--- a/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
@@ -31,7 +31,7 @@ enum AuthenticationRegistrationCoordinatorResult {
     /// Continue using the supplied SSO provider.
     case continueWithSSO(SSOIdentityProvider)
     /// The screen completed with the associated registration result.
-    case completed(RegistrationResult)
+    case completed(result: RegistrationResult, password: String)
 }
 
 final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
@@ -160,7 +160,7 @@ final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
                                                                         initialDeviceDisplayName: UIDevice.current.initialDisplayName)
                 
                 guard !Task.isCancelled else { return }
-                callback?(.completed(result))
+                callback?(.completed(result: result, password: password))
                 
                 self?.stopLoading()
             } catch {

--- a/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
@@ -28,6 +28,8 @@ struct AuthenticationRegistrationCoordinatorParameters {
 }
 
 enum AuthenticationRegistrationCoordinatorResult {
+    /// Continue using the supplied SSO provider.
+    case continueWithSSO(SSOIdentityProvider)
     /// The screen completed with the associated registration result.
     case completed(RegistrationResult)
 }
@@ -97,6 +99,7 @@ final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
         authenticationRegistrationViewModel.callback = { [weak self] result in
             guard let self = self else { return }
             MXLog.debug("[AuthenticationRegistrationCoordinator] AuthenticationRegistrationViewModel did complete with result: \(result).")
+            
             switch result {
             case .selectServer:
                 self.presentServerSelectionScreen()
@@ -104,6 +107,8 @@ final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
                 self.validateUsername(username)
             case .createAccount(let username, let password):
                 self.createAccount(username: username, password: password)
+            case .continueWithSSO(let provider):
+                self.callback?(.continueWithSSO(provider))
             }
         }
     }

--- a/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
@@ -108,7 +108,8 @@ struct AuthenticationRegistrationScreen: View {
                                    configuration: UIKitTextInputConfiguration(returnKeyType: .next,
                                                                               autocapitalizationType: .none,
                                                                               autocorrectionType: .no),
-                                   onEditingChanged: usernameEditingChanged)
+                                   onEditingChanged: usernameEditingChanged,
+                                   onCommit: { isPasswordFocused = true })
             .onChange(of: viewModel.username) { _ in viewModel.send(viewAction: .clearUsernameError) }
             .accessibilityIdentifier("usernameTextField")
             
@@ -120,7 +121,8 @@ struct AuthenticationRegistrationScreen: View {
                                    isFirstResponder: isPasswordFocused,
                                    configuration: UIKitTextInputConfiguration(returnKeyType: .done,
                                                                               isSecureTextEntry: true),
-                                   onEditingChanged: passwordEditingChanged)
+                                   onEditingChanged: passwordEditingChanged,
+                                   onCommit: submit)
             .accessibilityIdentifier("passwordTextField")
             
             Button(action: submit) {
@@ -144,19 +146,17 @@ struct AuthenticationRegistrationScreen: View {
         }
     }
     
-    /// Validates the username when the text field ends editing, and selects the password text field.
+    /// Validates the username when the text field ends editing.
     func usernameEditingChanged(isEditing: Bool) {
         guard !isEditing, !viewModel.username.isEmpty else { return }
-        
         viewModel.send(viewAction: .validateUsername)
-        isPasswordFocused = true
     }
     
-    /// Enables password validation the first time the user taps return, and sends the username and submits the form if possible.
+    /// Enables password validation the first time the user finishes editing.
+    /// Additionally resets the password field focus.
     func passwordEditingChanged(isEditing: Bool) {
         guard !isEditing else { return }
         isPasswordFocused = false
-        submit()
         
         guard !viewModel.viewState.hasEditedPassword else { return }
         viewModel.send(viewAction: .enablePasswordValidation)

--- a/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/View/AuthenticationRegistrationScreen.swift
@@ -137,7 +137,7 @@ struct AuthenticationRegistrationScreen: View {
         VStack(spacing: 16) {
             ForEach(viewModel.viewState.homeserver.ssoIdentityProviders) { provider in
                 AuthenticationSSOButton(provider: provider) {
-                    viewModel.send(viewAction: .continueWithSSO(id: provider.id))
+                    viewModel.send(viewAction: .continueWithSSO(provider))
                 }
                 .accessibilityIdentifier("ssoButton")
             }

--- a/RiotSwiftUI/Modules/Common/Util/ClearViewModifier.swift
+++ b/RiotSwiftUI/Modules/Common/Util/ClearViewModifier.swift
@@ -18,15 +18,25 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 extension ThemableTextField {
-    func showClearButton(text: Binding<String>, alignement: VerticalAlignment = .center) -> some View {
-        return modifier(ClearViewModifier(alignment: alignement, text: text))
+    /// Adds a clear button to the text field
+    /// - Parameters:
+    ///   - show: A boolean that can be used to dynamically show/hide the button. Defaults to `true`.
+    ///   - text: The text for the clear button to clear.
+    ///   - alignment: The vertical alignment of the button in the text field. Default to `center`
+    @ViewBuilder
+    func showClearButton(_ show: Bool = true, text: Binding<String>, alignment: VerticalAlignment = .center) -> some View {
+        if show {
+            modifier(ClearViewModifier(alignment: alignment, text: text))
+        } else {
+            self
+        }
     }
 }
 
 @available(iOS 14.0, *)
 extension ThemableTextEditor {
-    func showClearButton(text: Binding<String>, alignement: VerticalAlignment = .top) -> some View {
-        return modifier(ClearViewModifier(alignment: alignement, text: text))
+    func showClearButton(text: Binding<String>, alignment: VerticalAlignment = .top) -> some View {
+        return modifier(ClearViewModifier(alignment: alignment, text: text))
     }
 }
 

--- a/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextField.swift
+++ b/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextField.swift
@@ -33,6 +33,7 @@ struct RoundedBorderTextField: View {
     
     var onTextChanged: ((String) -> Void)? = nil
     var onEditingChanged: ((Bool) -> Void)? = nil
+    var onCommit: (() -> Void)? = nil
 
     // MARK: Private
     
@@ -52,6 +53,7 @@ struct RoundedBorderTextField: View {
                     .multilineTextAlignment(.leading)
                     .padding(EdgeInsets(top: 0, leading: 0, bottom: 8, trailing: 0))
             }
+            
             ZStack(alignment: .leading) {
                 if text.isEmpty {
                     Text(placeHolder)
@@ -60,32 +62,22 @@ struct RoundedBorderTextField: View {
                         .lineLimit(1)
                         .accessibilityHidden(true)
                 }
-                if isEnabled {
-                    ThemableTextField(placeholder: "", text: $text, configuration: configuration, onEditingChanged: { edit in
-                        self.editing = edit
-                        onEditingChanged?(edit)
-                    })
-                    .makeFirstResponder(isFirstResponder)
-                    .showClearButton(text: $text)
-                    .onChange(of: text) { newText in
-                        onTextChanged?(newText)
-                    }
-                    .frame(height: 30)
-                    .accessibilityLabel(text.isEmpty ? placeHolder : "")
-                } else {
-                    ThemableTextField(placeholder: "", text: $text, configuration: configuration, onEditingChanged: { edit in
-                        self.editing = edit
-                        onEditingChanged?(edit)
-                    })
-                    .makeFirstResponder(isFirstResponder)
-                    .onChange(of: text) { newText in
-                        onTextChanged?(newText)
-                    }
-                    .frame(height: 30)
-                    .allowsHitTesting(false)
-                    .opacity(0.5)
-                    .accessibilityLabel(text.isEmpty ? placeHolder : "")
+                
+                ThemableTextField(placeholder: "", text: $text, configuration: configuration, onEditingChanged: { edit in
+                    self.editing = edit
+                    onEditingChanged?(edit)
+                }, onCommit: {
+                    onCommit?()
+                })
+                .makeFirstResponder(isFirstResponder)
+                .showClearButton(isEnabled, text: $text)
+                .onChange(of: text) { newText in
+                    onTextChanged?(newText)
                 }
+                .frame(height: 30)
+                .allowsHitTesting(isEnabled)
+                .opacity(isEnabled ? 1 : 0.5)
+                .accessibilityLabel(text.isEmpty ? placeHolder : "")
             }
             .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: text.isEmpty ? 8 : 0))
             .background(RoundedRectangle(cornerRadius: 8).fill(theme.colors.background))

--- a/RiotSwiftUI/Modules/Common/Util/SecondaryActionButtonStyle.swift
+++ b/RiotSwiftUI/Modules/Common/Util/SecondaryActionButtonStyle.swift
@@ -27,25 +27,24 @@ struct SecondaryActionButtonStyle: ButtonStyle {
         configuration.label
             .padding(12.0)
             .frame(maxWidth: .infinity)
-            .foregroundColor(strokeColor(configuration.isPressed))
+            .foregroundColor(customColor ?? theme.colors.accent)
             .font(theme.fonts.body)
             .background(RoundedRectangle(cornerRadius: 8)
                             .strokeBorder()
-                            .foregroundColor(strokeColor(configuration.isPressed)))
-            .opacity(isEnabled ? 1.0 : 0.6)
+                            .foregroundColor(customColor ?? theme.colors.accent))
+            .opacity(opacity(when: configuration.isPressed))
     }
     
-    func strokeColor(_ isPressed: Bool) -> Color {
-        if let customColor = customColor {
-            return customColor
-        }
-        
-        return isPressed ? theme.colors.accent.opacity(0.6) : theme.colors.accent
+    private func opacity(when isPressed: Bool) -> CGFloat {
+        guard isEnabled else { return 0.6 }
+        return isPressed ? 0.6 : 1.0
     }
 }
 
 @available(iOS 14.0, *)
 struct SecondaryActionButtonStyle_Previews: PreviewProvider {
+    static var theme: ThemeSwiftUI = DefaultThemeSwiftUI()
+    
     static var previews: some View {
         Group {
             buttonGroup
@@ -64,14 +63,14 @@ struct SecondaryActionButtonStyle_Previews: PreviewProvider {
                 .buttonStyle(SecondaryActionButtonStyle())
                 .disabled(true)
             
-            Button { } label: {
-                Text("Clear BG")
-                    .foregroundColor(.red)
-            }
-            .buttonStyle(SecondaryActionButtonStyle(customColor: .clear))
-            
             Button("Red BG") { }
             .buttonStyle(SecondaryActionButtonStyle(customColor: .red))
+            
+            Button { } label: {
+                Text("Custom")
+                    .foregroundColor(theme.colors.secondaryContent)
+            }
+            .buttonStyle(SecondaryActionButtonStyle(customColor: theme.colors.quarterlyContent))
         }
         .padding()
     }

--- a/changelog.d/5654.wip
+++ b/changelog.d/5654.wip
@@ -1,1 +1,1 @@
-Authentication: Add the login screen to the new flow.
+Authentication: Add the login screen to the new flow and support SSO on both login and registration flows.

--- a/changelog.d/pr-6204.build
+++ b/changelog.d/pr-6204.build
@@ -1,0 +1,1 @@
+CI: Use macOS 12 and Xcode 13.4

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :ios do
 
   before_all do
     # Ensure used Xcode version
-    xcversion(version: "~> 13.2")
+    xcversion(version: "~> 13.4")
   end
 
   #### Public ####


### PR DESCRIPTION
This PR adds the use of `SSOAuthenticationPresenter` to the new flow. Additionally
- Updates the deep link signalling to go via the `AuthenticationService` instead of through the `LegacyAppDelegate`.
- Fixes a bug in old flow contained a bug when `SFSafariViewController` was used where the vc was never dismissed.
- Updates the CI to use macOS 12 and Xcode 13.4 so that `#unavailable` can be used.
- Allows SSO button icons to scale with dynamic type.
- Adds `onCommit` actions to the text fields on the login/registration screens.

| Light Mode | Dark Mode | iPad |
| - | - | - |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-25 at 18 18 54](https://user-images.githubusercontent.com/6060466/170324483-53f7dc2b-f0ac-49b4-a531-abca95134b4f.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-25 at 18 18 25](https://user-images.githubusercontent.com/6060466/170324503-9b4dffe4-19d9-4227-af8a-fa0f8fbdc099.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-25 at 18 19 11](https://user-images.githubusercontent.com/6060466/170324528-1faea6d2-9e10-496f-8976-e262770e33af.png) |