### PR TITLE
Fix ITMS Warning on CFBundleDocumentTypes

### DIFF
--- a/Riot/SupportingFiles/Info.plist
+++ b/Riot/SupportingFiles/Info.plist
@@ -144,5 +144,7 @@
 			<string>im.vector.app.pills</string>
 		</dict>
 	</array>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 </dict>
 </plist>

--- a/changelog.d/6159.bugfix
+++ b/changelog.d/6159.bugfix
@@ -1,0 +1,1 @@
+Fix ITMS Warning on CFBundleDocumentTypes


### PR DESCRIPTION
Fixes #6159 
