### PR TITLE
Fix in reply to links appearing outside of mx-quote

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -29,7 +29,7 @@
 
 #import "MXKRoomNameStringLocalizer.h"
 
-static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
+static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>([^<]*)</a>";
 
 @interface MXKEventFormatter ()
 {
@@ -1843,6 +1843,14 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
  */
 - (NSString*)renderReplyTo:(NSString*)htmlString withRoomState:(MXRoomState*)roomState
 {
+    NSInteger mxReplyEndLocation = [htmlString rangeOfString:@"</mx-reply>"].location;
+
+    if (mxReplyEndLocation == NSNotFound)
+    {
+        MXLogWarning(@"[MXKEventFormatter] Missing mx-reply block in html string");
+        return htmlString;
+    }
+
     NSString *html = htmlString;
     
     static NSRegularExpression *htmlATagRegex;
@@ -1860,7 +1868,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=\"(.*?)\">([^<]*)</a>";
     
     [htmlATagRegex enumerateMatchesInString:html
                                     options:0
-                                      range:NSMakeRange(0, html.length)
+                                      range:NSMakeRange(0, mxReplyEndLocation)
                                  usingBlock:^(NSTextCheckingResult *match, NSMatchingFlags flags, BOOL *stop) {
                                      
                                      if (hrefCount > 1)

--- a/changelog.d/4586.bugfix
+++ b/changelog.d/4586.bugfix
@@ -1,0 +1,1 @@
+Fix in reply to links appearing outside of mx-quote


### PR DESCRIPTION
Fixes #4586 

This fix reduces the range for the regex inspecting a reply to the mx-reply body only.
It also allows the usage of both single quote and double quotes for href inside an mx-reply ```a``` tag.
It will also opt-out of the reply treatment if no mx-reply block is found (screenshot).

It should cover most frequent cases of pesky ```in reply to``` blocks, apart for some very badly built mx-replies.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/80891108/171877341-185a6c2c-77f8-4a4e-8faa-7ffab9e1fa7b.png) | ![image](https://user-images.githubusercontent.com/80891108/171876628-dad955c4-715e-4c2a-85a8-06163f81e263.png) |

