### PR TITLE
Remove render edit flag and fix a nil room state crash

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
@@ -223,7 +223,7 @@ typedef enum : NSUInteger {
 
  @param htmlString the HTLM string to render.
  @param event the event associated to the string.
- @param roomState the room state right before the event.
+ @param roomState the room state right before the event. If nil, replies will not get constructed or formatted.
  @return an attributed string.
  */
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState;

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
@@ -229,18 +229,6 @@ typedef enum : NSUInteger {
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState;
 
 /**
- Render a random html string into an attributed string with the font and the text color
- that correspond to the passed event.
-
- @param htmlString the HTLM string to render.
- @param event the event associated to the string.
- @param roomState the room state right before the event.
- @param isEditMode wether string will be used for edition in the composer
- @return an attributed string.
- */
-- (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState isEditMode:(BOOL)isEditMode;
-
-/**
  Defines the replacement attributed string for a redacted message.
 
  @return attributed string describing redacted message.

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1755,7 +1755,6 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
     MXEvent *repliedEvent;
 
     // Special treatment for "In reply to" message
-    // Note: `isEditMode` fixes an issue where editing a reply would display an "In reply to" span instead of a mention.
     if (roomState && (event.isReplyEvent || (!RiotSettings.shared.enableThreads && event.isInThread)))
     {
         repliedEvent = [self->mxSession.store eventWithEventId:event.relatesTo.inReplyTo.eventId inRoom:roomState.roomId];

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1751,17 +1751,12 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
 
 - (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState
 {
-    return [self renderHTMLString:htmlString forEvent:event withRoomState:roomState isEditMode:NO];
-}
-
-- (NSAttributedString*)renderHTMLString:(NSString*)htmlString forEvent:(MXEvent*)event withRoomState:(MXRoomState*)roomState isEditMode:(BOOL)isEditMode
-{
     NSString *html = htmlString;
     MXEvent *repliedEvent;
 
     // Special treatment for "In reply to" message
     // Note: `isEditMode` fixes an issue where editing a reply would display an "In reply to" span instead of a mention.
-    if (!isEditMode && (event.isReplyEvent || (!RiotSettings.shared.enableThreads && event.isInThread)))
+    if (roomState && (event.isReplyEvent || (!RiotSettings.shared.enableThreads && event.isInThread)))
     {
         repliedEvent = [self->mxSession.store eventWithEventId:event.relatesTo.inReplyTo.eventId inRoom:roomState.roomId];
         if (repliedEvent)

--- a/Riot/Modules/Room/DataSources/RoomDataSource.swift
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.swift
@@ -156,7 +156,7 @@ extension RoomDataSource {
 
         if event.isReply() {
             let body: String
-            if let newContent = event.content[kMXMessageContentKeyNewContent] as? [String:Any] {
+            if let newContent = event.content[kMXMessageContentKeyNewContent] as? [String: Any] {
                 // Use new content if available.
                 body = newContent["formatted_body"] as? String ?? newContent[kMXMessageBodyKey] as? String ?? ""
             } else {
@@ -167,7 +167,7 @@ extension RoomDataSource {
                 body = replyEventParts?.formattedBodyParts?.replyText ?? replyEventParts?.bodyParts.replyText ?? ""
             }
 
-            let attributed = eventFormatter.renderHTMLString(body, for: event, with: self.roomState, isEditMode: true)
+            let attributed = eventFormatter.renderHTMLString(body, for: event, with: nil)
             if let attributed = attributed, #available(iOS 15.0, *) {
                 editableTextMessage = PillsFormatter.insertPills(in: attributed,
                                                                  withSession: self.mxSession,
@@ -180,7 +180,7 @@ extension RoomDataSource {
             }
         } else {
             let body: String = event.content["formatted_body"] as? String ?? event.content["body"] as? String ?? ""
-            let attributed = eventFormatter.renderHTMLString(body, for: event, with: self.roomState, isEditMode: true)
+            let attributed = eventFormatter.renderHTMLString(body, for: event, with: nil)
             if let attributed = attributed, #available(iOS 15.0, *) {
                 editableTextMessage = PillsFormatter.insertPills(in: attributed,
                                                                  withSession: self.mxSession,

--- a/changelog.d/pr-6251.bugfix
+++ b/changelog.d/pr-6251.bugfix
@@ -1,0 +1,1 @@
+Remove render edit flag and fix a nil room state crash


### PR DESCRIPTION
This removes the flag for edit mode and uses an empty room state instead for editable text HTML render.
Also, it fixes a crash when room state is empty while trying to render a reply.