### PR TITLE
Fixes vector-im/element-ios/issues/6241 - Prevent random crashes when…

### DIFF
--- a/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
+++ b/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
@@ -1077,6 +1077,12 @@ static BOOL _disableLongPressGestureOnEvent;
     
     NSArray *bubbleComponents = bubbleData.bubbleComponents;
     
+    if (bubbleComponents.count == 1) {
+        return bubbleComponents.firstObject;
+    }
+    
+    // The position check below fails for bubble data with a single component when message
+    // bubbles are enabled, thus the early bailout above
     for (MXKRoomBubbleComponent *component in bubbleComponents)
     {
         // Ignore components without display (For example redacted event or state events)

--- a/changelog.d/6241.bugfix
+++ b/changelog.d/6241.bugfix
@@ -1,0 +1,1 @@
+Prevent random crashes when tapping links. Avoid displaying the confirmation alert for plain text ones.


### PR DESCRIPTION
… tapping links. Avoid displaying the confirmation alert for plain text ones.