### PR TITLE
Fixes vector-im/element-ios/issues/6095 - Random square home screen room avatars

### DIFF
--- a/Riot/Modules/Home/Views/RoomCollectionViewCell.m
+++ b/Riot/Modules/Home/Views/RoomCollectionViewCell.m
@@ -34,10 +34,6 @@
 {
     [super awakeFromNib];
     
-    // Round room image view
-    [_roomAvatar.layer setCornerRadius:_roomAvatar.frame.size.width / 2];
-    _roomAvatar.clipsToBounds = YES;
-    
     // Disable the user interaction on the room avatar.
     self.roomAvatar.userInteractionEnabled = NO;
     
@@ -73,6 +69,9 @@
 - (void)layoutSubviews
 {
     [super layoutSubviews];
+    
+    [self.roomAvatar.layer setCornerRadius:self.roomAvatar.frame.size.width / 2.0];
+    [self.roomAvatar setClipsToBounds: YES];
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/changelog.d/6095.bugfix
+++ b/changelog.d/6095.bugfix
@@ -1,0 +1,1 @@
+Fixed home screen room avatars being sometimes square.


### PR DESCRIPTION
This is basically just a guess but I think sometimes the avatar image views don't have a good frame setup when awaken from nib and the layer corner radius calculation fails. After this PR they should get updated after every frame change.