### PR TITLE
Add an unrecognised certificate alert to the new authentication flow.

### DIFF
--- a/Riot/Modules/Authentication/LegacyAuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/LegacyAuthenticationCoordinator.swift
@@ -151,6 +151,10 @@ extension LegacyAuthenticationCoordinator: AuthenticationServiceDelegate {
             authenticationViewController.showCustomHomeserver(homeserver, andIdentityServer: identityServer)
         }
     }
+    
+    func authenticationService(_ service: AuthenticationService, needsPromptFor unrecognizedCertificate: Data?, completion: @escaping (Bool) -> Void) {
+        // Handled internally in AuthenticationViewController
+    }
 }
 
 // MARK: - AuthenticationViewControllerDelegate

--- a/Riot/Modules/Onboarding/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Onboarding/AuthenticationCoordinator.swift
@@ -167,6 +167,38 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
         toPresentable().present(alert, animated: true)
     }
     
+    /// Prompts the user to trust a certificate by displaying its fingerprint (SHA256).
+    @MainActor private func displayUnrecognizedCertificateAlert(for certificate: Data) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let title = VectorL10n.sslCouldNotVerify
+            let homeserverURLString = VectorL10n.sslHomeserverUrl(authenticationService.state.homeserver.displayableAddress)
+            let fingerprint = VectorL10n.sslFingerprintHash("SHA256")
+            let certificateFingerprint = (certificate as NSData).mx_SHA256AsHexString() ?? VectorL10n.error
+            
+            let message = [VectorL10n.sslCertNotTrust,
+                           VectorL10n.sslCertNewAccountExpl,
+                           homeserverURLString,
+                           fingerprint,
+                           certificateFingerprint,
+                           VectorL10n.sslOnlyAccept]
+                .joined(separator: "\n\n")
+            
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            
+            alert.addAction(UIAlertAction(title: VectorL10n.cancel, style: .cancel) { action in
+                continuation.resume(with: .success(false))
+            })
+            
+            alert.addAction(UIAlertAction(title: VectorL10n.sslTrust, style: .default) { action in
+                continuation.resume(with: .success(true))
+            })
+            
+            // The alert will be encountered on the current stack or when server selection is being presented.
+            let presentingViewController = toPresentable().presentedViewController ?? toPresentable()
+            presentingViewController.present(alert, animated: true, completion: nil)
+        }
+    }
+    
     /// Cancels the registration flow, handing control back to the onboarding coordinator.
     @MainActor private func cancelRegistration() {
         authenticationService.reset()
@@ -601,6 +633,19 @@ extension AuthenticationCoordinator: SSOAuthenticationPresenterDelegate {
 
 // MARK: - AuthenticationServiceDelegate
 extension AuthenticationCoordinator: AuthenticationServiceDelegate {
+    
+    func authenticationService(_ service: AuthenticationService, needsPromptFor unrecognizedCertificate: Data?, completion: @escaping (Bool) -> Void) {
+        guard let certificate = unrecognizedCertificate else {
+            completion(false)
+            return
+        }
+        
+        Task {
+            let trusted = await self.displayUnrecognizedCertificateAlert(for: certificate)
+            completion(trusted)
+        }
+    }
+    
     func authenticationService(_ service: AuthenticationService, didReceive ssoLoginToken: String, with transactionID: String) -> Bool {
         guard let presenter = ssoAuthenticationPresenter, transactionID == ssoTransactionID else {
             Task { await displayError(message: VectorL10n.errorCommonMessage) }

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
@@ -17,6 +17,13 @@
 import Foundation
 
 protocol AuthenticationServiceDelegate: AnyObject {
+    /// The authentication service encountered an unrecognized certificate and needs to
+    /// prompt the user to find out whether or not it should be trusted.
+    /// - Parameters:
+    ///   - service: The authentication service.
+    ///   - unrecognizedCertificate: The certificate data to be trusted.
+    ///   - completion: A completion handler called one the user accepts/rejects the certificate.
+    func authenticationService(_ service: AuthenticationService, needsPromptFor unrecognizedCertificate: Data?, completion: @escaping (Bool) -> Void)
     /// The authentication service received an SSO login token via a deep link.
     /// This only occurs when SSOAuthenticationPresenter uses an SFSafariViewController.
     /// - Parameters:
@@ -244,8 +251,21 @@ class AuthenticationService: NSObject {
             }
         }
         
-        #warning("Add an unrecognized certificate handler.")
-        let client = clientType.init(homeServer: homeserverURL, unrecognizedCertificateHandler: nil)
+        let client = clientType.init(homeServer: homeserverURL, unrecognizedCertificateHandler: { [weak self] certificate in
+            guard let self = self else { return false }
+            
+            var isTrusted = false
+            let semaphore = DispatchSemaphore(value: 0)
+            
+            self.delegate?.authenticationService(self, needsPromptFor: certificate) { didTrust in
+                isTrusted = didTrust
+                semaphore.signal()
+            }
+            
+            semaphore.wait()
+            return isTrusted
+        })
+        
         if let identityServerURL = identityServerURL {
             client.identityServer = identityServerURL.absoluteString
         }

--- a/changelog.d/6174.wip
+++ b/changelog.d/6174.wip
@@ -1,0 +1,1 @@
+Add an unrecognised certificate alert to the new authentication flow.


### PR DESCRIPTION
Adds the same unrecognised certificate alert to the new authentication flow as the current flow [shows](https://github.com/vector-im/element-ios/blob/fbbbbc0b79c3f70b5c18f198b81f756b2fa71cc7/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m#L1638-L1698).

Fixes #6174.

https://user-images.githubusercontent.com/6060466/172644925-d59a01a9-9520-4d03-bb26-88e5b958141e.mp4

