### PR TITLE
Update labels and confetti presentation in new flow.

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/ForgotPassword/View/AuthenticationForgotPasswordScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/ForgotPassword/View/AuthenticationForgotPasswordScreen.swift
@@ -93,7 +93,7 @@ struct AuthenticationForgotPasswordScreen: View {
     var waitingFooter: some View {
         VStack(spacing: 12) {
             Button(action: done) {
-                Text(VectorL10n.done)
+                Text(VectorL10n.next)
             }
             .buttonStyle(PrimaryActionButtonStyle())
             .accessibilityIdentifier("doneButton")

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
@@ -60,7 +60,7 @@ struct OnboardingCelebrationScreen: View {
             }
             .frame(maxHeight: .infinity)
         }
-        .background(theme.colors.background.ignoresSafeArea())
+        .background(OnboardingBreakerScreenBackground().ignoresSafeArea())
         .accentColor(theme.colors.accent)
         .navigationBarHidden(true)
     }

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/View/OnboardingCelebrationScreen.swift
@@ -60,7 +60,6 @@ struct OnboardingCelebrationScreen: View {
             }
             .frame(maxHeight: .infinity)
         }
-        .overlay(effects.ignoresSafeArea())
         .background(theme.colors.background.ignoresSafeArea())
         .accentColor(theme.colors.accent)
         .navigationBarHidden(true)
@@ -93,11 +92,6 @@ struct OnboardingCelebrationScreen: View {
             }
             .buttonStyle(PrimaryActionButtonStyle())
         }
-    }
-    
-    var effects: some View {
-        EffectsView(effect: .confetti)
-            .allowsHitTesting(false)
     }
 }
 

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/UI/OnboardingCongratulationsUITests.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Test/UI/OnboardingCongratulationsUITests.swift
@@ -43,9 +43,6 @@ class OnboardingCongratulationsUITests: MockScreenTest {
         
         let homeButton = app.buttons["homeButton"]
         XCTAssertTrue(homeButton.exists, "The home button should always be shown.")
-        
-        let confetti = app.otherElements["confetti"]
-        XCTAssertFalse(confetti.exists, "There should not be any confetti.")
     }
     
     func verifyButtonsWhenPersonalizationIsDisabled() {
@@ -54,8 +51,5 @@ class OnboardingCongratulationsUITests: MockScreenTest {
         
         let homeButton = app.buttons["homeButton"]
         XCTAssertTrue(homeButton.exists, "The home button should always be shown.")
-        
-        let confetti = app.otherElements["confetti"]
-        XCTAssertTrue(confetti.exists, "There should be a confetti overlay.")
     }
 }

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/View/OnboardingCongratulationsScreen.swift
@@ -128,13 +128,9 @@ struct OnboardingCongratulationsScreen: View {
         .accessibilityIdentifier("homeButton")
     }
     
-    @ViewBuilder
     var effects: some View {
-        if viewModel.viewState.personalizationDisabled {
-            EffectsView(effect: .confetti)
-                .allowsHitTesting(false)
-                .accessibilityIdentifier("confetti")
-        }
+        EffectsView(effect: .confetti)
+            .allowsHitTesting(false)
     }
 }
 

--- a/changelog.d/5151.wip
+++ b/changelog.d/5151.wip
@@ -1,0 +1,1 @@
+Authentication: Update labels and confetti in new flow.


### PR DESCRIPTION
- A button title has been changed in the forgot password flow
- The confetti is now always shown on the congratulations screen and never on the celebration screen.
- The celebration screen now uses the gradient background.

https://user-images.githubusercontent.com/6060466/172883445-1e5eaaf5-c729-48b1-a8c8-3f4e162ed879.mp4


