### PR TITLE
Fix reply to usernames containing HTML escape characters

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1995,7 +1995,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
         
         if (senderDisplayName)
         {
-            html = [html stringByReplacingCharactersInRange:userIdRange withString:senderDisplayName];
+            html = [html stringByReplacingCharactersInRange:userIdRange withString:senderDisplayName.stringByAddingHTMLEntities];
         }
     }
     

--- a/changelog.d/5526.bugfix
+++ b/changelog.d/5526.bugfix
@@ -1,0 +1,1 @@
+Fix reply to usernames containing HTML escape characters


### PR DESCRIPTION
Fixes #5526 