### PR TITLE
Display redacted messages in the timeline

### DIFF
--- a/Riot/Assets/Riot-Defaults.plist
+++ b/Riot/Assets/Riot-Defaults.plist
@@ -11,7 +11,7 @@
 	<key>showAllEventsInRoomHistory</key>
 	<false/>
 	<key>showRedactionsInRoomHistory</key>
-	<false/>
+	<true/>
 	<key>showUnsupportedEventsInRoomHistory</key>
 	<false/>
 	<key>sortRoomMembersUsingLastSeenTime</key>

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -655,6 +655,7 @@ Tap the + to start adding people.";
 "settings_ui_theme_picker_title" = "Select a theme";
 "settings_ui_theme_picker_message_invert_colours" = "\"Auto\" uses your device's \"Invert Colours\" settings";
 "settings_ui_theme_picker_message_match_system_theme" = "\"Auto\" matches your device's system theme";
+"settings_ui_show_redactions_in_room_history" = "Show a placeholder for removed messages";
 
 "settings_show_url_previews" = "Show website preview";
 "settings_show_url_previews_description" = "Previews will only be shown in unencrypted rooms.";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -7123,6 +7123,10 @@ public class VectorL10n: NSObject {
   public static var settingsUiLanguage: String { 
     return VectorL10n.tr("Vector", "settings_ui_language") 
   }
+  /// Show a placeholder for removed messages
+  public static var settingsUiShowRedactionsInRoomHistory: String { 
+    return VectorL10n.tr("Vector", "settings_ui_show_redactions_in_room_history") 
+  }
   /// Theme
   public static var settingsUiTheme: String { 
     return VectorL10n.tr("Vector", "settings_ui_theme") 

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -130,7 +130,8 @@ typedef NS_ENUM(NSUInteger, USER_INTERFACE)
 {
     USER_INTERFACE_LANGUAGE_INDEX = 0,
     USER_INTERFACE_THEME_INDEX,
-    USER_INTERFACE_TIMELINE_STYLE_INDEX
+    USER_INTERFACE_TIMELINE_STYLE_INDEX,
+    USER_INTERFACE_SHOW_REDACTIONS_IN_ROOM_HISTORY
 };
 
 typedef NS_ENUM(NSUInteger, IDENTITY_SERVER)
@@ -518,6 +519,8 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         
 //        [sectionUserInterface addRowWithTag:USER_INTERFACE_TIMELINE_STYLE_INDEX];
     }
+
+    [sectionUserInterface addRowWithTag:USER_INTERFACE_SHOW_REDACTIONS_IN_ROOM_HISTORY];
         
     [tmpSections addObject: sectionUserInterface];
     
@@ -2264,6 +2267,19 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         {
             cell = [self buildMessageBubblesCellForTableView:tableView atIndexPath:indexPath];
         }
+        else if (row == USER_INTERFACE_SHOW_REDACTIONS_IN_ROOM_HISTORY)
+        {
+            MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
+
+            labelAndSwitchCell.mxkLabel.text = VectorL10n.settingsUiShowRedactionsInRoomHistory;
+
+            labelAndSwitchCell.mxkSwitch.on = [MXKAppSettings standardAppSettings].showRedactionsInRoomHistory;
+            labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
+            labelAndSwitchCell.mxkSwitch.enabled = YES;
+            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleShowRedacted:) forControlEvents:UIControlEventTouchUpInside];
+
+            cell = labelAndSwitchCell;
+        }
     }
     else if (section == SECTION_TAG_IGNORED_USERS)
     {
@@ -3972,6 +3988,11 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     deactivateAccountViewController.delegate = self;
     
     self.deactivateAccountViewController = deactivateAccountViewController;
+}
+
+- (void)toggleShowRedacted:(UISwitch *)sender
+{
+    [MXKAppSettings standardAppSettings].showRedactionsInRoomHistory = sender.isOn;
 }
 
 - (void)togglePresenceOfflineMode:(UISwitch *)sender

--- a/changelog.d/2180.change
+++ b/changelog.d/2180.change
@@ -1,0 +1,1 @@
+Display redacted messages in the timeline


### PR DESCRIPTION
Might be a fix for #2180 (which is labelled as requiring design input). This simply reuses the same design that's currently seen when the root message of a thread is redacted. 