### PR TITLE
Invites are collapsed incorrectly

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -57,8 +57,8 @@
             senderId = event.sender;
             if ([event.type isEqualToString:kMXEventTypeStringRoomMember])
             {
-                NSString *membership = event.wireContent[@"membership"];
-                if (![membership isEqualToString:@"join"])
+                MXRoomMemberEventContent *content = [MXRoomMemberEventContent modelFromJSON:event.content];
+                if (![content.membership isEqualToString:kMXMembershipStringJoin])
                 {
                     targetId = event.stateKey;
                 }

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -55,7 +55,22 @@
             [bubbleComponents addObject:firstComponent];
             
             senderId = event.sender;
-            targetId = [event.type isEqualToString:kMXEventTypeStringRoomMember] ? event.stateKey : nil;
+            if ([event.type isEqualToString:kMXEventTypeStringRoomMember])
+            {
+                NSString *membership = event.wireContent[@"membership"];
+                if (![membership isEqualToString:@"join"])
+                {
+                    targetId = event.stateKey;
+                }
+                else
+                {
+                    targetId = event.sender;
+                }
+            }
+            else
+            {
+                targetId = nil;
+            }
             roomId = roomDataSource.roomId;
 
             // If `roomScreenUseOnlyLatestUserAvatarAndName`is enabled, the avatar and name are

--- a/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipCollapsedBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipCollapsedBubbleCell.m
@@ -70,18 +70,18 @@
         // Handle user's picture by considering it is stored unencrypted on Matrix media repository
         
         // Use the Riot style placeholder
-        if (!nextBubbleData.targetAvatarPlaceholder)
+        if (!nextBubbleData.senderAvatarPlaceholder)
         {
-            nextBubbleData.targetAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.targetId withDisplayName:nextBubbleData.targetDisplayName];
+            nextBubbleData.senderAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.senderId withDisplayName:nextBubbleData.senderDisplayName];
         }
         
         avatarView.enableInMemoryCache = YES;
-        [avatarView setImageURI:nextBubbleData.targetAvatarUrl
+        [avatarView setImageURI:nextBubbleData.senderAvatarUrl
                        withType:nil
             andImageOrientation:UIImageOrientationUp
                   toFitViewSize:avatarView.frame.size
                      withMethod:MXThumbnailingMethodCrop
-                   previewImage:nextBubbleData.targetAvatarPlaceholder
+                   previewImage:nextBubbleData.senderAvatarPlaceholder
                    mediaManager:nextBubbleData.mxSession.mediaManager];
 
         // Clear the default background color of a MXKImageView instance

--- a/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipCollapsedBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipCollapsedBubbleCell.m
@@ -68,20 +68,45 @@
         MXKImageView *avatarView = [[MXKImageView alloc] initWithFrame:CGRectMake(12 * self.avatarsView.subviews.count, 0, 16, 16)];
 
         // Handle user's picture by considering it is stored unencrypted on Matrix media repository
-        
-        // Use the Riot style placeholder
-        if (!nextBubbleData.senderAvatarPlaceholder)
-        {
-            nextBubbleData.senderAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.senderId withDisplayName:nextBubbleData.senderDisplayName];
-        }
-        
         avatarView.enableInMemoryCache = YES;
-        [avatarView setImageURI:nextBubbleData.senderAvatarUrl
+        
+        UIImage *avatarPlaceholder;
+        NSString *avatarUrl;
+
+        MXEvent *firstEvent = nextBubbleData.events.firstObject;
+        MXRoomMemberEventContent *content = [MXRoomMemberEventContent modelFromJSON:firstEvent.content];
+        
+        // We want to display the avatar of the invitee.
+        // In case of a join event, the invitee is the sender. Otherwise, the invitee is the target.
+        if (![content.membership isEqualToString:kMXMembershipStringJoin])
+        {
+            // Use the Riot style placeholder
+            if (!nextBubbleData.targetAvatarPlaceholder)
+            {
+                nextBubbleData.targetAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.targetId withDisplayName:nextBubbleData.targetDisplayName];
+            }
+            
+            avatarPlaceholder = nextBubbleData.targetAvatarPlaceholder;
+            avatarUrl = nextBubbleData.targetAvatarUrl;
+        }
+        else
+        {
+            // Use the Riot style placeholder
+            if (!nextBubbleData.senderAvatarPlaceholder)
+            {
+                nextBubbleData.senderAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:nextBubbleData.senderId withDisplayName:nextBubbleData.senderDisplayName];
+            }
+            
+            avatarPlaceholder = nextBubbleData.senderAvatarPlaceholder;
+            avatarUrl = nextBubbleData.senderAvatarUrl;
+        }
+
+        [avatarView setImageURI:avatarUrl
                        withType:nil
             andImageOrientation:UIImageOrientationUp
                   toFitViewSize:avatarView.frame.size
                      withMethod:MXThumbnailingMethodCrop
-                   previewImage:nextBubbleData.senderAvatarPlaceholder
+                   previewImage:avatarPlaceholder
                    mediaManager:nextBubbleData.mxSession.mediaManager];
 
         // Clear the default background color of a MXKImageView instance

--- a/changelog.d/4102.bugfix
+++ b/changelog.d/4102.bugfix
@@ -1,0 +1,1 @@
+Fix Invites are collapsed incorrectly


### PR DESCRIPTION
resolves https://github.com/vector-im/element-ios/issues/4102

Now use sender avatar instead of the target avatar for collapsed membership cell

![Simulator Screen Shot - iPhone 12 Pro - 2022-06-15 at 13 06 05](https://user-images.githubusercontent.com/15386762/173816309-7c514017-0a51-48d2-81b5-dac3f3495f15.png)

![Simulator Screen Shot - iPhone 12 Pro - 2022-06-15 at 15 57 48](https://user-images.githubusercontent.com/15386762/173845633-cc18531e-4df9-4190-8130-c352b75e8072.png)

