### PR TITLE
Fix locheck-script that fails the build when there is space character on PROJECT_DIR path

### DIFF
--- a/Riot/target.yml
+++ b/Riot/target.yml
@@ -58,7 +58,7 @@ targets:
       script: |
         # homebrew uses a non-standard directory on M1
         if [[ $(arch) = arm64 ]]; then export PATH="$PATH:/opt/homebrew/bin"; fi
-        xcrun --sdk macosx mint run Asana/locheck@0.9.6 discoverlproj --treat-warnings-as-errors --ignore-missing --ignore lproj_file_missing_from_translation $PROJECT_DIR/Riot/Assets
+        xcrun --sdk macosx mint run Asana/locheck@0.9.6 discoverlproj --treat-warnings-as-errors --ignore-missing --ignore lproj_file_missing_from_translation "$PROJECT_DIR/Riot/Assets"
 
     sources:
     - path: ../RiotSwiftUI/Modules

--- a/changelog.d/6296.build
+++ b/changelog.d/6296.build
@@ -1,0 +1,1 @@
+locheck-script: fix build fails when there is space character on PROJECT_DIR's path. By Hudzaifah Lutfi.


### PR DESCRIPTION
[#6296](https://github.com/vector-im/element-ios/issues/6296)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
