### PR TITLE
Avoid launch animation for `backgroundSyncInProgress` state

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2282,12 +2282,10 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     if (mainSession)
     {
-        
         switch (mainSession.state)
         {
             case MXSessionStateClosed:
             case MXSessionStateInitialised:
-            case MXSessionStateBackgroundSyncInProgress:
                 self.roomListDataReady = NO;
                 [self listenForRoomListDataReady];
             default:
@@ -2315,7 +2313,6 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
             {
                 case MXSessionStateClosed:
                 case MXSessionStateInitialised:
-                case MXSessionStateBackgroundSyncInProgress:
                     isLaunching = YES;
                     break;
                 case MXSessionStateStoreDataReady:

--- a/changelog.d/6288.bugfix
+++ b/changelog.d/6288.bugfix
@@ -1,0 +1,1 @@
+AppDelegate: Do not show launch animation for `backgroundSyncInProgress` state.


### PR DESCRIPTION
Fixes #6288 