### PR TITLE
Strip the trailing slash from homeserver addresses.

### DIFF
--- a/Riot/Modules/MatrixKit/Categories/NSBundle+MatrixKit.m
+++ b/Riot/Modules/MatrixKit/Categories/NSBundle+MatrixKit.m
@@ -16,14 +16,14 @@
 
 #import "NSBundle+MatrixKit.h"
 #import "NSBundle+MXKLanguage.h"
-#import "MXKViewController.h"
+#import "MXKAppSettings.h"
 
 @implementation NSBundle (MatrixKit)
 
 + (NSBundle*)mxk_assetsBundle
 {
     // Get the bundle within MatrixKit
-    NSBundle *bundle = [NSBundle mxk_bundleForClass:[MXKViewController class]];
+    NSBundle *bundle = [NSBundle mxk_bundleForClass:[MXKAppSettings class]];
     NSURL *assetsBundleURL = [bundle URLForResource:@"MatrixKitAssets" withExtension:@"bundle"];
 
     return [NSBundle bundleWithURL:assetsBundleURL];

--- a/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -30,6 +30,8 @@
 
 #import "MXKSwiftHeader.h"
 
+#import "GeneratedInterface-Swift.h"
+
 @interface MXKAuthenticationViewController ()
 {
     /**
@@ -1626,7 +1628,7 @@
 
 - (void)updateRESTClient
 {
-    NSString *homeserverURL = _homeServerTextField.text;
+    NSString *homeserverURL = [HomeserverAddress sanitized:_homeServerTextField.text];
     
     if (homeserverURL.length)
     {

--- a/RiotNSE/target.yml
+++ b/RiotNSE/target.yml
@@ -63,8 +63,10 @@ targets:
     - path: ../Riot/PropertyWrappers/UserDefaultsBackedPropertyWrapper.swift
     - path: ../Riot/Modules/MatrixKit
       excludes:
-        - "**/MXKAuthenticationRecaptchaWebView.*"
-        - "**/MXKAuthenticationViewController.*"
+        - "Controllers/**"
+        - "Models/*List/**"
+        - "Views/**"
+        
     - path: ../Riot/Modules/Analytics
     - path: ../Riot/Managers/UserSessions
     - path: ../Riot/Managers/AppInfo/

--- a/RiotNSE/target.yml
+++ b/RiotNSE/target.yml
@@ -64,6 +64,7 @@ targets:
     - path: ../Riot/Modules/MatrixKit
       excludes:
         - "**/MXKAuthenticationRecaptchaWebView.*"
+        - "**/MXKAuthenticationViewController.*"
     - path: ../Riot/Modules/Analytics
     - path: ../Riot/Managers/UserSessions
     - path: ../Riot/Managers/AppInfo/

--- a/RiotShareExtension/target.yml
+++ b/RiotShareExtension/target.yml
@@ -72,6 +72,7 @@ targets:
     - path: ../Riot/Modules/MatrixKit
       excludes:
         - "**/MXKAuthenticationRecaptchaWebView.*"
+        - "**/MXKAuthenticationViewController.*"
     - path: ../Riot/Modules/Analytics
     - path: ../Riot/Managers/UserSessions
       excludes:

--- a/RiotShareExtension/target.yml
+++ b/RiotShareExtension/target.yml
@@ -71,8 +71,8 @@ targets:
       buildPhase: resources
     - path: ../Riot/Modules/MatrixKit
       excludes:
-        - "**/MXKAuthenticationRecaptchaWebView.*"
         - "**/MXKAuthenticationViewController.*"
+        - "Views/Authentication/**"
     - path: ../Riot/Modules/Analytics
     - path: ../Riot/Managers/UserSessions
       excludes:

--- a/RiotSwiftUI/Modules/Authentication/Common/AuthenticationModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/AuthenticationModels.swift
@@ -78,10 +78,23 @@ enum LoginError: String, Error {
     case resetPasswordNotStarted
 }
 
-struct HomeserverAddress {
-    /// Ensures the address contains a scheme, otherwise makes it `https`.
+@objcMembers 
+class HomeserverAddress: NSObject {
+    /// Sanitizes a user entered homeserver address with the following rules
+    /// - Trim any whitespace.
+    /// - Lowercase the address.
+    /// - Ensure the address contains a scheme, otherwise make it `https`.
+    /// - Remove any trailing slashes.
     static func sanitized(_ address: String) -> String {
-        !address.contains("://") ? "https://\(address.lowercased())" : address.lowercased()
+        var address = address.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        
+        if !address.contains("://") {
+            address = "https://\(address)"
+        }
+        
+        address = address.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        
+        return address
     }
 }
 

--- a/RiotTests/Modules/Authentication/AuthenticationServiceTests.swift
+++ b/RiotTests/Modules/Authentication/AuthenticationServiceTests.swift
@@ -349,4 +349,27 @@ import XCTest
         XCTAssertFalse(forgotPasswordString.contains(password), "The password must not be included in any strings.")
         XCTAssertFalse(changePasswordString.contains(password), "The password must not be included in any strings.")
     }
+    
+    func testHomeserverAddressSanitization() {
+        let basicAddress = "matrix.org"
+        let httpAddress = "http://localhost"
+        let trailingSlashAddress = "https://matrix.example.com/"
+        let whitespaceAddress = " https://matrix.example.com/  "
+        let validAddress = "https://matrix.example.com"
+        let validAddressWithPort = "https://matrix.example.com:8484"
+        
+        let sanitizedBasicAddress = HomeserverAddress.sanitized(basicAddress)
+        let sanitizedHTTPAddress = HomeserverAddress.sanitized(httpAddress)
+        let sanitizedTrailingSlashAddress = HomeserverAddress.sanitized(trailingSlashAddress)
+        let sanitizedWhitespaceAddress = HomeserverAddress.sanitized(whitespaceAddress)
+        let sanitizedValidAddress = HomeserverAddress.sanitized(validAddress)
+        let sanitizedValidAddressWithPort = HomeserverAddress.sanitized(validAddressWithPort)
+        
+        XCTAssertEqual(sanitizedBasicAddress, "https://matrix.org")
+        XCTAssertEqual(sanitizedHTTPAddress, "http://localhost")
+        XCTAssertEqual(sanitizedTrailingSlashAddress, "https://matrix.example.com")
+        XCTAssertEqual(sanitizedWhitespaceAddress, "https://matrix.example.com")
+        XCTAssertEqual(sanitizedValidAddress, validAddress)
+        XCTAssertEqual(sanitizedValidAddressWithPort, validAddressWithPort)
+    }
 }

--- a/SiriIntents/target.yml
+++ b/SiriIntents/target.yml
@@ -52,8 +52,9 @@ targets:
     - path: ../Riot/Managers/Locale/LocaleProvider.swift
     - path: ../Riot/Modules/MatrixKit
       excludes:
-        - "**/MXKAuthenticationRecaptchaWebView.*"
-        - "**/MXKAuthenticationViewController.*"
+        - "Controllers/**"
+        - "Models/*List/**"
+        - "Views/**"
     - path: ../Riot/Modules/Analytics
     - path: ../Riot/Managers/UserSessions
     - path: ../Riot/Managers/AppInfo/

--- a/SiriIntents/target.yml
+++ b/SiriIntents/target.yml
@@ -53,6 +53,7 @@ targets:
     - path: ../Riot/Modules/MatrixKit
       excludes:
         - "**/MXKAuthenticationRecaptchaWebView.*"
+        - "**/MXKAuthenticationViewController.*"
     - path: ../Riot/Modules/Analytics
     - path: ../Riot/Managers/UserSessions
     - path: ../Riot/Managers/AppInfo/

--- a/changelog.d/995.bugfix
+++ b/changelog.d/995.bugfix
@@ -1,0 +1,1 @@
+Authentication: Trim whitespace and trailing slashes from the entered homeserver address.


### PR DESCRIPTION
This PR expands the checks made with `HomeserverAddress.sanitized(_:)` and adds it to `MXKAuthenticationViewController` as it was only being used on the new flow.

Additionally I've excluded all MatrixKit Views and ViewControllers from the NSE and SiriIntents targets as they'll never be needed for those.

Fixes #995 for new sign-ins.