### PR TITLE
Add missing ) in workflow.

### DIFF
--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -12,7 +12,7 @@ jobs:
        !contains(github.event.issue.labels.*.name, 'A-E2EE-Cross-Signing') &&
        !contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') &&
        !contains(github.event.issue.labels.*.name, 'A-E2EE-Key-Backup') &&
-       !contains(github.event.issue.labels.*.name, 'A-E2EE-SAS-Verification') &&
+       !contains(github.event.issue.labels.*.name, 'A-E2EE-SAS-Verification')) &&
       (contains(github.event.issue.labels.*.name, 'T-Defect') &&
        contains(github.event.issue.labels.*.name, 'S-Critical') &&
        (contains(github.event.issue.labels.*.name, 'O-Frequent') ||

--- a/changelog.d/pr-6321.misc
+++ b/changelog.d/pr-6321.misc
@@ -1,0 +1,1 @@
+Fix workflow syntax of the P1 action.


### PR DESCRIPTION
It looks like 1 too many brackets were removed in #6230. This PR adds the missing one back and should make [CI](https://github.com/vector-im/element-ios/actions/workflows/triage-priority-bugs.yml) happy once more.