### PR TITLE
Make avatar view tappable in bubble layout

### DIFF
--- a/Riot/Modules/Room/TimelineCells/BaseRoomCell/RoomCellContentView.xib
+++ b/Riot/Modules/Room/TimelineCells/BaseRoomCell/RoomCellContentView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,7 +21,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="595" height="97"/>
                     <subviews>
                         <view hidden="YES" contentMode="scaleToFill" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="u1e-Q2-PhY">
-                            <rect key="frame" x="0.0" y="0.0" width="595" height="44"/>
+                            <rect key="frame" x="0.0" y="-44" width="595" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ro1-vP-6Ha" userLabel="Pagination Title View">
                                     <rect key="frame" x="56" y="10" width="529" height="24"/>
@@ -60,25 +60,6 @@
                                 <constraint firstAttribute="trailing" secondItem="Ro1-vP-6Ha" secondAttribute="trailing" constant="10" id="8P7-ZL-7pg"/>
                                 <constraint firstItem="Ro1-vP-6Ha" firstAttribute="leading" secondItem="u1e-Q2-PhY" secondAttribute="leading" constant="56" id="A4v-WV-EGn"/>
                                 <constraint firstAttribute="bottom" secondItem="Ro1-vP-6Ha" secondAttribute="bottom" constant="10" id="UcW-P4-rQv"/>
-                            </constraints>
-                        </view>
-                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1cK-e6-Mg5">
-                            <rect key="frame" x="0.0" y="0.0" width="595" height="0.0"/>
-                            <subviews>
-                                <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="yXz-Za-4yR" customClass="MXKImageView">
-                                    <rect key="frame" x="13" y="10" width="30" height="30"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <accessibility key="accessibilityConfiguration" identifier="PictureView"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="30" id="FbD-UB-dqc"/>
-                                        <constraint firstAttribute="width" constant="30" id="y7F-jl-kEF"/>
-                                    </constraints>
-                                </view>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstItem="yXz-Za-4yR" firstAttribute="leading" secondItem="1cK-e6-Mg5" secondAttribute="leading" constant="13" id="UjU-eY-ARJ"/>
-                                <constraint firstItem="yXz-Za-4yR" firstAttribute="top" secondItem="1cK-e6-Mg5" secondAttribute="top" constant="10" id="jlf-dg-fp0"/>
                             </constraints>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w0C-6a-f5M">
@@ -262,7 +243,6 @@
                     </subviews>
                     <constraints>
                         <constraint firstItem="Dj1-m6-1Jw" firstAttribute="width" secondItem="5GX-gn-bK1" secondAttribute="width" id="0Px-jL-CMJ"/>
-                        <constraint firstItem="1cK-e6-Mg5" firstAttribute="width" secondItem="5GX-gn-bK1" secondAttribute="width" id="2De-xT-k5e"/>
                         <constraint firstItem="meG-P8-61b" firstAttribute="trailing" secondItem="oeI-eO-mFK" secondAttribute="trailing" id="2Dy-o0-r33"/>
                         <constraint firstItem="snf-Ea-To0" firstAttribute="leading" secondItem="oeI-eO-mFK" secondAttribute="leading" id="2lm-T3-dEu"/>
                         <constraint firstItem="w0C-6a-f5M" firstAttribute="width" secondItem="5GX-gn-bK1" secondAttribute="width" id="5nl-Le-VDi"/>
@@ -274,12 +254,36 @@
                         <constraint firstItem="SNw-aM-ILI" firstAttribute="leading" secondItem="oeI-eO-mFK" secondAttribute="leading" id="x1n-oT-dez"/>
                     </constraints>
                 </stackView>
+                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1cK-e6-Mg5">
+                    <rect key="frame" x="0.0" y="0.0" width="56" height="50"/>
+                    <subviews>
+                        <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="yXz-Za-4yR" customClass="MXKImageView">
+                            <rect key="frame" x="13" y="10" width="30" height="30"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="PictureView"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="30" id="FbD-UB-dqc"/>
+                                <constraint firstAttribute="width" constant="30" id="y7F-jl-kEF"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="yXz-Za-4yR" secondAttribute="trailing" constant="13" id="HG0-UN-Gyn"/>
+                        <constraint firstItem="yXz-Za-4yR" firstAttribute="leading" secondItem="1cK-e6-Mg5" secondAttribute="leading" constant="13" id="UjU-eY-ARJ"/>
+                        <constraint firstItem="yXz-Za-4yR" firstAttribute="top" secondItem="1cK-e6-Mg5" secondAttribute="top" constant="10" id="jlf-dg-fp0"/>
+                        <constraint firstAttribute="bottom" secondItem="yXz-Za-4yR" secondAttribute="bottom" constant="10" id="x4o-Nf-FRD"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" red="0.95294117649999999" green="0.97254901959999995" blue="0.99215686270000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="5GX-gn-bK1" firstAttribute="leading" secondItem="zG5-YA-Ijy" secondAttribute="leading" id="36u-ut-l3G"/>
+                <constraint firstItem="1cK-e6-Mg5" firstAttribute="top" secondItem="u1e-Q2-PhY" secondAttribute="bottom" id="AIL-hS-Rft"/>
                 <constraint firstItem="5GX-gn-bK1" firstAttribute="top" secondItem="zG5-YA-Ijy" secondAttribute="top" id="As1-dI-9ba"/>
                 <constraint firstItem="XQw-Mj-NZY" firstAttribute="top" secondItem="zG5-YA-Ijy" secondAttribute="top" id="BuL-ri-8kT"/>
+                <constraint firstItem="1cK-e6-Mg5" firstAttribute="leading" secondItem="5GX-gn-bK1" secondAttribute="leading" id="J1c-Cc-JKy"/>
+                <constraint firstItem="1cK-e6-Mg5" firstAttribute="top" secondItem="5GX-gn-bK1" secondAttribute="top" priority="999" id="bI2-rS-fzm"/>
                 <constraint firstAttribute="bottom" secondItem="5GX-gn-bK1" secondAttribute="bottom" id="cNV-Or-YPg"/>
                 <constraint firstAttribute="trailing" secondItem="5GX-gn-bK1" secondAttribute="trailing" id="deR-Cu-Brh"/>
                 <constraint firstAttribute="trailing" secondItem="XQw-Mj-NZY" secondAttribute="trailing" id="eJl-Fg-neU"/>

--- a/changelog.d/5572.bugfix
+++ b/changelog.d/5572.bugfix
@@ -1,0 +1,1 @@
+Make avatar view tappable in bubble layout


### PR DESCRIPTION
Previously the avatar wasn't tappable in the bubble layout because its container view was collapsed to a height of 1 point. Increasing the container height is tricky though because it breaks the surrounding vertical stack view. As a workaround this change moves the avatar container out of the stack view so that it can safely be assigned a non-vanishing height that allows for receiving touches.

The vertical layout is fixed with a priority-999 alignment to the stack view and a priority-1000 alignment to the pagination label container (the only view above the avatar container). When the pagination container is hidden, the priority-1000 constraint takes no effect. When it is shown, the priority-1000 constraint trumps the priority-999 constraint.

Otherwise, moving the avatar container out of the stack view seems safe because at a height of 1 point, it wasn't contributing to the layout anyway.

If you pixel-compare the screenshots below, you'll notice a 1-point vertical shift of the stack view content that is caused by moving the (previously 1-point-tall) avatar container out of the stack view. I deemed this a negligible change but please let me know if there's any concern.

| Before without pagination | Before with pagination | After without pagination | After with pagination |
| - | - | - | - |
| ![without-pagination-before](https://user-images.githubusercontent.com/1137962/174667433-fe73fca5-7501-4be7-8be5-ba79c1474844.png) | ![with-pagination-before](https://user-images.githubusercontent.com/1137962/174667465-cfbf953d-69c8-49f3-b8da-4dc71160baee.png) | ![without-pagination-after](https://user-images.githubusercontent.com/1137962/174667484-8c3f7483-2c15-42ca-ac4c-c5feaba0ac50.png) | ![with-pagination-after](https://user-images.githubusercontent.com/1137962/174667494-9844cc1a-4439-48e0-b05d-75626d0c1f9e.png) |

Fixes: #5572

The layout 

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
