### PR TITLE
Expose live location sharing labs flag and enable background location access (PSF-1127)

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -426,8 +426,7 @@ final class BuildSettings: NSObject {
         guard self.locationSharingEnabled else {
             return false
         }
-        
-        // Do not enable live location sharing atm
-        return false
+
+        return true
     }
 }

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -153,7 +153,7 @@ final class RiotSettings: NSObject {
     var enableUISIAutoReporting
     
     /// Indicates if live location sharing is enabled
-    @UserDefault(key: UserDefaultsKeys.enableLiveLocationSharing, defaultValue: BuildSettings.liveLocationSharingEnabled, storage: defaults)
+    @UserDefault(key: UserDefaultsKeys.enableLiveLocationSharing, defaultValue: false, storage: defaults)
     var enableLiveLocationSharing
     
     // MARK: Calls

--- a/Riot/Modules/LocationSharing/UserLocationService.swift
+++ b/Riot/Modules/LocationSharing/UserLocationService.swift
@@ -52,7 +52,7 @@ class UserLocationService: UserLocationServiceProtocol {
     // MARK: - Setup
         
     init(session: MXSession) {
-        self.locationManager = LocationManager(accuracy: .full, allowsBackgroundLocationUpdates: false)
+        self.locationManager = LocationManager(accuracy: .full, allowsBackgroundLocationUpdates: true)
         self.session = session
     }
     

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -597,7 +597,6 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         [sectionLabs addRowWithTag:LABS_ENABLE_AUTO_REPORT_DECRYPTION_ERRORS];
         if (BuildSettings.liveLocationSharingEnabled)
         {
-            // Hide live location lab setting until it's ready to be release
             [sectionLabs addRowWithTag:LABS_ENABLE_LIVE_LOCATION_SHARING];
         }
         sectionLabs.headerTitle = [VectorL10n settingsLabs];

--- a/Riot/SupportingFiles/Info.plist
+++ b/Riot/SupportingFiles/Info.plist
@@ -89,6 +89,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>location</string>
 		<string>remote-notification</string>
 		<string>voip</string>
 	</array>

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
@@ -78,7 +78,7 @@ struct LocationSharingViewState: BindableState {
     /// True to indicate to show and follow current user location
     var showsUserLocation: Bool = false
     
-    /// Used to hide live location sharing features until is finished
+    /// Used to hide live location sharing features
     var isLiveLocationSharingEnabled: Bool = false
     
     var shareButtonEnabled: Bool {


### PR DESCRIPTION
This makes the labs flag for live location sharing available in the app settings (default value still `false`) and reverts #6299 which itself reverted background location access. In other words, background location access is _enabled_ now.

I also tweaked some of the comments because we'll keep the build setting even after live location sharing is finished so that forks can easily disable location-related features.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
