### PR TITLE
Add spacing between the Jitsi and Threads toolbar buttons.

### DIFF
--- a/Riot/Categories/UIView.swift
+++ b/Riot/Categories/UIView.swift
@@ -42,6 +42,16 @@ extension UIView {
         subView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor).isActive = true
     }
     
+    /// Add a subview matching parent view with additional insets using autolayout
+    @objc func vc_addSubViewMatchingParent(_ subView: UIView, withInsets insets: UIEdgeInsets) {
+        self.addSubview(subView)
+        subView.translatesAutoresizingMaskIntoConstraints = false
+        subView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: insets.left).isActive = true
+        subView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: insets.top).isActive = true
+        subView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: insets.right).isActive = true
+        subView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: insets.bottom).isActive = true
+    }
+    
     @objc func vc_removeAllSubviews() {
         for subView in self.subviews {
             subView.removeFromSuperview()

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1547,6 +1547,38 @@ static CGSize kThreadListBarButtonItemImageSize;
     return item;
 }
 
+- (UIBarButtonItem *)joinJitsiBarButtonItem
+{
+    CallTileActionButton *button = [CallTileActionButton new];
+    [button setImage:AssetImages.callVideoIcon.image
+            forState:UIControlStateNormal];
+    [button setTitle:[VectorL10n roomJoinGroupCall]
+            forState:UIControlStateNormal];
+    [button addTarget:self
+               action:@selector(onVideoCallPressed:)
+     forControlEvents:UIControlEventTouchUpInside];
+    button.contentEdgeInsets = UIEdgeInsetsMake(4, 12, 4, 12);
+    
+    UIBarButtonItem *item;
+    
+    if (RiotSettings.shared.enableThreads)
+    {
+        // Add some spacing when there is a threads button
+        UIView *buttonContainer = [[UIView alloc] initWithFrame:CGRectZero];
+        [buttonContainer vc_addSubViewMatchingParent:button withInsets:UIEdgeInsetsMake(0, 0, 0, -12)];
+        
+        item = [[UIBarButtonItem alloc] initWithCustomView:buttonContainer];
+    }
+    else
+    {
+        item = [[UIBarButtonItem alloc] initWithCustomView:button];
+    }
+    
+    item.accessibilityLabel = [VectorL10n roomAccessibilityVideoCall];
+    
+    return item;
+}
+
 - (UIBarButtonItem *)threadMoreBarButtonItem
 {
     UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:AssetImages.roomContextMenuMore.image
@@ -1751,18 +1783,7 @@ static CGSize kThreadListBarButtonItemImageSize;
                         }
                         else
                         {
-                            //  show Join button
-                            CallTileActionButton *button = [CallTileActionButton new];
-                            [button setImage:AssetImages.callVideoIcon.image
-                                    forState:UIControlStateNormal];
-                            [button setTitle:[VectorL10n roomJoinGroupCall]
-                                    forState:UIControlStateNormal];
-                            [button addTarget:self
-                                       action:@selector(onVideoCallPressed:)
-                             forControlEvents:UIControlEventTouchUpInside];
-                            button.contentEdgeInsets = UIEdgeInsetsMake(4, 12, 4, 12);
-                            UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithCustomView:button];
-                            item.accessibilityLabel = [VectorL10n roomAccessibilityVideoCall];
+                            UIBarButtonItem *item = [self joinJitsiBarButtonItem];
                             [rightBarButtonItems addObject:item];
                             
                             hasCustomJoinButton = YES;

--- a/changelog.d/6033.bugfix
+++ b/changelog.d/6033.bugfix
@@ -1,0 +1,1 @@
+Room: Add some additional spacing between the Jitsi and Threads buttons.


### PR DESCRIPTION
Fixes #6033

| Before | After | After with threads disabled |
| - | - | - |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-06-21 at 09 42 37](https://user-images.githubusercontent.com/6060466/174760337-17f5dfa6-2cf5-4312-a49f-b84a1a862a65.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-06-21 at 09 40 52](https://user-images.githubusercontent.com/6060466/174760356-528a356d-0198-4e80-ac31-aff9b263982c.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-06-21 at 09 41 48](https://user-images.githubusercontent.com/6060466/174760369-91bf333a-0d88-4f43-8e8a-6006646cbba6.png) |

