### PR TITLE
Enable reporting of live location shares (PSF-1066)

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1618,6 +1618,11 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
             displayText = [MXEventContentPollStart modelFromJSON:event.content].question;
             break;
         }
+        case MXEventTypeBeaconInfo:
+        {
+            displayText = [MXBeaconInfo modelFromJSON:event.content].desc;
+            break;
+        }
         default:
             *error = MXKEventFormatterErrorUnknownEventType;
             break;

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -3662,22 +3662,6 @@ static CGSize kThreadListBarButtonItemImageSize;
             }]];
         }
 
-        if (selectedEvent.sentState == MXEventSentStateSent &&
-            selectedEvent.eventType != MXEventTypePollStart &&
-            !selectedEvent.location)
-        {
-            [self.eventMenuBuilder addItemWithType:EventMenuItemTypeForward
-                                            action:[UIAlertAction actionWithTitle:[VectorL10n roomEventActionForward]
-                                                                            style:UIAlertActionStyleDefault
-                                                                          handler:^(UIAlertAction * action) {
-                MXStrongifyAndReturnIfNil(self);
-
-                [self cancelEventSelection];
-
-                [self presentEventForwardingDialogForSelectedEvent:selectedEvent];
-            }]];
-        }
-
         if (!isJitsiCallEvent && selectedEvent.eventType != MXEventTypePollStart)
         {
             [self.eventMenuBuilder addItemWithType:EventMenuItemTypeQuote
@@ -3696,7 +3680,10 @@ static CGSize kThreadListBarButtonItemImageSize;
             }]];
         }
         
-        if (selectedEvent.sentState == MXEventSentStateSent && selectedEvent.eventType != MXEventTypePollStart)
+        if (selectedEvent.sentState == MXEventSentStateSent &&
+            selectedEvent.eventType != MXEventTypePollStart &&
+            // Forwarding of live-location shares still to be implemented
+            selectedEvent.eventType != MXEventTypeBeaconInfo)
         {
             [self.eventMenuBuilder addItemWithType:EventMenuItemTypeForward
                                             action:[UIAlertAction actionWithTitle:[VectorL10n roomEventActionForward]

--- a/changelog.d/pr-6326.change
+++ b/changelog.d/pr-6326.change
@@ -1,0 +1,1 @@
+Enable reporting of live location shares


### PR DESCRIPTION
This sets the display text of `beacon_info` events which enables the context menu on live location shares which in turn allows users to report the events. Other events in the menus will be implemented separately.

| Timeline | Location cell selected | More menu |
|-|-|-|
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-21 at 15 05 37](https://user-images.githubusercontent.com/1137962/174808860-b43f8210-b434-45c2-b3e3-8e7a61e22fad.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-21 at 15 05 40](https://user-images.githubusercontent.com/1137962/174808875-d527d922-d486-4952-a6a0-9d9f6a79ce9c.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-21 at 15 05 43](https://user-images.githubusercontent.com/1137962/174808882-806cca77-b267-4d26-ace1-6d0cb322cd35.png) |


### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
