### PR TITLE
Handle long press on back buttons

### DIFF
--- a/Riot/Assets/en.lproj/Untranslated.strings
+++ b/Riot/Assets/en.lproj/Untranslated.strings
@@ -88,3 +88,6 @@
 "password_validation_error_contain_uppercase_letter" = "Contain an upper-case letter.";
 "password_validation_error_contain_number" = "Contain a number.";
 "password_validation_error_contain_symbol" = "Contain a symbol.";
+
+// MARK: Room Info
+"room_info_back_button_title" = "Room Info";

--- a/Riot/Categories/UIViewController.swift
+++ b/Riot/Categories/UIViewController.swift
@@ -27,10 +27,9 @@ extension UIViewController {
     /// Remove back bar button title when pushing a view controller.
     /// This method should be called on the previous controller in UINavigationController stack.
     @objc func vc_removeBackTitle() {
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationItem.backButtonDisplayMode = .minimal
     }
-    
-    
+
     /// Add a child view controller matching current view controller view.
     ///
     /// - Parameter viewController: The child view controller to add.

--- a/Riot/Generated/UntranslatedStrings.swift
+++ b/Riot/Generated/UntranslatedStrings.swift
@@ -234,6 +234,10 @@ public extension VectorL10n {
   static var passwordValidationInfoHeader: String { 
     return VectorL10n.tr("Untranslated", "password_validation_info_header") 
   }
+  /// Room Info
+  static var roomInfoBackButtonTitle: String { 
+    return VectorL10n.tr("Untranslated", "room_info_back_button_title") 
+  }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Riot/Modules/Communities/Home/GroupHomeViewController.m
+++ b/Riot/Modules/Communities/Home/GroupHomeViewController.m
@@ -317,15 +317,15 @@
     if (self.parentViewController.navigationController)
     {
         // Hide back button title
-        self.parentViewController.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self.parentViewController vc_removeBackTitle];
+
         [self.parentViewController.navigationController pushViewController:viewController animated:YES];
     }
     else
     {
         // Hide back button title
-        self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self vc_removeBackTitle];
+
         [self.navigationController pushViewController:viewController animated:YES];
     }
 }

--- a/Riot/Modules/Communities/Members/GroupParticipantsViewController.m
+++ b/Riot/Modules/Communities/Members/GroupParticipantsViewController.m
@@ -680,15 +680,15 @@
     if (self.parentViewController.navigationController)
     {
         // Hide back button title
-        self.parentViewController.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self.parentViewController vc_removeBackTitle];
+
         [self.parentViewController.navigationController pushViewController:viewController animated:YES];
     }
     else
     {
         // Hide back button title
-        self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self vc_removeBackTitle];
+
         [self.navigationController pushViewController:viewController animated:YES];
     }
 }

--- a/Riot/Modules/Communities/Rooms/GroupRoomsViewController.m
+++ b/Riot/Modules/Communities/Rooms/GroupRoomsViewController.m
@@ -363,15 +363,15 @@
     if (self.parentViewController.navigationController)
     {
         // Hide back button title
-        self.parentViewController.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self.parentViewController vc_removeBackTitle];
+
         [self.parentViewController.navigationController pushViewController:viewController animated:YES];
     }
     else
     {
         // Hide back button title
-        self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self vc_removeBackTitle];
+
         [self.navigationController pushViewController:viewController animated:YES];
     }
 }

--- a/Riot/Modules/GlobalSearch/UnifiedSearchViewController.m
+++ b/Riot/Modules/GlobalSearch/UnifiedSearchViewController.m
@@ -361,7 +361,7 @@
     }
 
     // Hide back button title
-    self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
+    [self vc_removeBackTitle];
 }
 
 #pragma mark - Search

--- a/Riot/Modules/Integrations/WidgetPicker/WidgetPickerViewController.m
+++ b/Riot/Modules/Integrations/WidgetPicker/WidgetPickerViewController.m
@@ -69,11 +69,11 @@
                                                    style:UIAlertActionStyleDefault
                                                  handler:^(UIAlertAction * _Nonnull action)
                            {
-                               // Hide back button title
-                               mxkViewController.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-                               
-                               [self fetchWidgetURLAndDisplayUsingWidget:widget canPresentServiceTerms:YES];
-                           }];
+                // Hide back button title
+                [mxkViewController vc_removeBackTitle];
+
+                [self fetchWidgetURLAndDisplayUsingWidget:widget canPresentServiceTerms:YES];
+            }];
             [self.alertController addAction:alertAction];
         }
 

--- a/Riot/Modules/Integrations/Widgets/StickerPicker/StickerPickerViewController.m
+++ b/Riot/Modules/Integrations/Widgets/StickerPicker/StickerPickerViewController.m
@@ -33,7 +33,7 @@
     self.navigationItem.title = [VectorL10n roomActionSendSticker];
 
     // Hide back button title
-    self.parentViewController.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
+    [self.parentViewController vc_removeBackTitle];
 
     UIBarButtonItem *editButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemEdit target:self action:@selector(onEditButtonPressed)];
     [self.navigationItem setRightBarButtonItem: editButton animated:YES];

--- a/Riot/Modules/MediaPicker/MediaPickerViewController.m
+++ b/Riot/Modules/MediaPicker/MediaPickerViewController.m
@@ -134,6 +134,8 @@
     }];
     
     self.navigationItem.rightBarButtonItem = closeBarButtonItem;
+    // Hide back button title
+    [self vc_removeBackTitle];
     
     // Register collection view cell class
     [self.recentCapturesCollectionView registerNib:MXKMediaCollectionViewCell.nib forCellWithReuseIdentifier:[MXKMediaCollectionViewCell defaultReuseIdentifier]];
@@ -1029,9 +1031,6 @@
             albumContentViewController.allowsMultipleSelection = self.allowsMultipleSelection;
         }
 
-        // Hide back button title
-        self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
         [self.navigationController pushViewController:albumContentViewController animated:YES];
     }
 }

--- a/Riot/Modules/Room/Members/RoomParticipantsViewController.m
+++ b/Riot/Modules/Room/Members/RoomParticipantsViewController.m
@@ -825,15 +825,15 @@
     if (self.parentViewController.navigationController)
     {
         // Hide back button title
-        self.parentViewController.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self.parentViewController vc_removeBackTitle];
+
         [self.parentViewController.navigationController pushViewController:viewController animated:YES];
     }
     else
     {
         // Hide back button title
-        self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+        [self vc_removeBackTitle];
+
         [self.navigationController pushViewController:viewController animated:YES];
     }
 }

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
@@ -248,7 +248,9 @@ final class RoomInfoListViewController: UIViewController {
         }
         
         self.title = ""
-        
+        self.vc_removeBackTitle()
+        self.navigationItem.backButtonTitle = VectorL10n.back
+
         mainTableView.register(headerFooterViewType: TextViewTableViewHeaderFooterView.self)
         mainTableView.sectionHeaderHeight = UITableView.automaticDimension
         mainTableView.estimatedSectionHeaderHeight = 50

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewController.swift
@@ -249,7 +249,8 @@ final class RoomInfoListViewController: UIViewController {
         
         self.title = ""
         self.vc_removeBackTitle()
-        self.navigationItem.backButtonTitle = VectorL10n.back
+        // TODO: Check string with product (+ DM specific alt ?) and move this out of Untranslated.
+        self.navigationItem.backButtonTitle = VectorL10n.roomInfoBackButtonTitle
 
         mainTableView.register(headerFooterViewType: TextViewTableViewHeaderFooterView.self)
         mainTableView.sectionHeaderHeight = UITableView.automaticDimension

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4559,9 +4559,6 @@ static CGSize kThreadListBarButtonItemImageSize;
             unknownDevices = nil;
         }
     }
-    
-    // Hide back button title
-    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
 }
 
 #pragma mark - VoIP

--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -95,10 +95,8 @@ enum {
     // Do any additional setup after loading the view, typically from a nib.
     
     self.navigationItem.title = [VectorL10n manageSessionTitle];
+    [self vc_removeBackTitle];
     
-    // Remove back bar button title when pushing a view controller
-    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-
     [self.tableView registerClass:MXKTableViewCellWithLabelAndTextField.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndTextField defaultReuseIdentifier]];
     [self.tableView registerClass:MXKTableViewCellWithLabelAndSwitch.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndSwitch defaultReuseIdentifier]];
     [self.tableView registerNib:MXKTableViewCellWithTextView.nib forCellReuseIdentifier:[MXKTableViewCellWithTextView defaultReuseIdentifier]];
@@ -185,10 +183,6 @@ enum {
 {
     // Keep ref on pushed view controller
     pushedViewController = viewController;
-
-    // Hide back button title
-    self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-
     [self.navigationController pushViewController:viewController animated:YES];
 }
 

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -154,9 +154,7 @@ TableViewSectionsDelegate>
     // Do any additional setup after loading the view, typically from a nib.
     
     self.navigationItem.title = [VectorL10n securitySettingsTitle];
-    
-    // Remove back bar button title when pushing a view controller
-    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
+    [self vc_removeBackTitle];
 
     [self.tableView registerClass:MXKTableViewCellWithLabelAndSwitch.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndSwitch defaultReuseIdentifier]];
     [self.tableView registerNib:MXKTableViewCellWithTextView.nib forCellReuseIdentifier:[MXKTableViewCellWithTextView defaultReuseIdentifier]];
@@ -423,10 +421,6 @@ TableViewSectionsDelegate>
 {
     // Keep ref on pushed view controller
     pushedViewController = viewController;
-
-    // Hide back button title
-    self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-
     [self.navigationController pushViewController:viewController animated:YES];
 }
 

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -638,10 +638,8 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     // Do any additional setup after loading the view, typically from a nib.
     
     self.navigationItem.title = [VectorL10n settingsTitle];
-    
-    // Remove back bar button title when pushing a view controller
-    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-    
+    [self vc_removeBackTitle];
+
     [self.tableView registerClass:MXKTableViewCellWithLabelAndTextField.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndTextField defaultReuseIdentifier]];
     [self.tableView registerClass:MXKTableViewCellWithLabelAndSwitch.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndSwitch defaultReuseIdentifier]];
     [self.tableView registerClass:MXKTableViewCellWithLabelAndMXKImageView.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndMXKImageView defaultReuseIdentifier]];
@@ -896,10 +894,6 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
 {
     // Keep ref on pushed view controller
     pushedViewController = viewController;
-    
-    // Hide back button title
-    self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-    
     [self.navigationController pushViewController:viewController animated:YES];
 }
 

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -112,7 +112,7 @@
     [self vc_removeBackTitle];
     
     [self setupTitleView];
-    titleView.titleLabel.text = [VectorL10n titleHome];
+    self.titleLabelText = [VectorL10n titleHome];
     
     childViewControllers = [NSMutableArray array];
     
@@ -278,8 +278,8 @@
         }
     }
     
-    titleView.titleLabel.text = [self getTitleForItemViewController:self.selectedViewController];
-    
+    self.titleLabelText = [self getTitleForItemViewController:self.selectedViewController];
+
     // Need to be called in case of the controllers have been replaced
     [self.selectedViewController viewDidAppear:NO];
 }
@@ -299,7 +299,7 @@
     NSInteger index = [self indexOfTabItemWithTag:tabBarIndex];
     self.selectedIndex = index;
     
-    titleView.titleLabel.text = [self getTitleForItemViewController:self.selectedViewController];
+    self.titleLabelText = [self getTitleForItemViewController:self.selectedViewController];
 }
 
 #pragma mark -
@@ -697,6 +697,12 @@
     self.navigationItem.titleView = titleView;
 }
 
+-(void)setTitleLabelText:(NSString *)text
+{
+    titleView.titleLabel.text = text;
+    self.navigationItem.backButtonTitle = text;
+}
+
 - (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion
 {
     // Keep ref on presented view controller
@@ -1032,7 +1038,7 @@
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController
 {
-    titleView.titleLabel.text = [self getTitleForItemViewController:viewController];
+    self.titleLabelText = [self getTitleForItemViewController:viewController];
 }
 
 @end

--- a/changelog.d/5971.change
+++ b/changelog.d/5971.change
@@ -1,0 +1,1 @@
+Handle longpress on back buttons


### PR DESCRIPTION
Resolves #5971 

This takes advantage of the iOS 14 introduced `backButtonDisplayMode` to allow displaying VC titles (or back button titles, if defined) inside back button longpress menu.

As it is hard to exhaustively test every screen within the app, some displayed titles could be odd (but obviously still better than an empty cell).

https://user-images.githubusercontent.com/80891108/174811856-32b3c3be-2121-42d2-ac8c-f4bb5cf4240d.mp4


