### PR TITLE
Make quoting context menu action work again

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -3687,9 +3687,10 @@ static CGSize kThreadListBarButtonItemImageSize;
                 MXStrongifyAndReturnIfNil(self);
                 
                 [self cancelEventSelection];
-                
+
                 // Quote the message a la Markdown into the input toolbar composer
-                self.inputToolbarView.textMessage = [NSString stringWithFormat:@"%@\n>%@\n\n", self.inputToolbarView.textMessage, selectedComponent.textMessage];
+                NSString *prefix = [self.inputToolbarView.textMessage length] ? [NSString stringWithFormat:@"%@\n", self.inputToolbarView.textMessage] : @"";
+                self.inputToolbarView.textMessage = [NSString stringWithFormat:@"%@>%@\n\n", prefix, selectedComponent.textMessage];
                 
                 // And display the keyboard
                 [self.inputToolbarView becomeFirstResponder];

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -159,10 +159,7 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
 
 - (void)setTextMessage:(NSString *)textMessage
 {
-    if (!textMessage)
-    {
-        [self setAttributedTextMessage:nil];
-    }
+    [self setAttributedTextMessage:textMessage ? [[NSAttributedString alloc] initWithString:textMessage] : nil];
 }
 
 - (void)setAttributedTextMessage:(NSAttributedString *)attributedTextMessage

--- a/changelog.d/pr-6328.bugfix
+++ b/changelog.d/pr-6328.bugfix
@@ -1,0 +1,1 @@
+Make quoting context menu action work again


### PR DESCRIPTION
This fixes the quoting action from the "more" section of the message context menu. The action previously didn't appear to do anything because the setter of `textMessage` only handled `nil` arguments.

I also made a small fix to prevent prepending an empty line when quoting with an empty composer.

| Context menu | Quoted text |
| - | - |
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-21 at 15 46 43](https://user-images.githubusercontent.com/1137962/174815148-92722c9f-5ca6-43d6-9b6d-7e4981ea688a.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-21 at 15 46 46](https://user-images.githubusercontent.com/1137962/174815175-adbfd814-1615-4e56-8374-17906479db25.png) |

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
