### PR TITLE
Fix unresponsive soft-logout in the legacy flow.

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationViewController.h
+++ b/Riot/Modules/Authentication/AuthenticationViewController.h
@@ -73,4 +73,9 @@
                          andPassword:(NSString * _Nullable)password
                orSSOIdentityProvider:(SSOIdentityProvider * _Nullable)identityProvider;
 
+/**
+ Notifies the delegate that the user would like to clear all data following a soft logout.
+ @param authenticationViewController The view controller that the user was shown.
+ */
+- (void)authenticationViewControllerDidRequestClearAllData:(AuthenticationViewController * _Nonnull)authenticationViewController;
 @end;

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -698,48 +698,6 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
     }
 }
 
-- (void)showClearDataAfterSoftLogoutConfirmation
-{
-    // Request confirmation
-    if (alert)
-    {
-        [alert dismissViewControllerAnimated:NO completion:nil];
-    }
-
-    alert = [UIAlertController alertControllerWithTitle:[VectorL10n authSoftlogoutClearDataSignOutTitle]
-                                                message:[VectorL10n authSoftlogoutClearDataSignOutMsg]
-                                         preferredStyle:UIAlertControllerStyleAlert];
-
-
-    [alert addAction:[UIAlertAction actionWithTitle:[VectorL10n authSoftlogoutClearDataSignOut]
-                                              style:UIAlertActionStyleDestructive
-                                            handler:^(UIAlertAction * action)
-                      {
-                          [self clearDataAfterSoftLogout];
-                      }]];
-
-    MXWeakify(self);
-    [alert addAction:[UIAlertAction actionWithTitle:[VectorL10n cancel]
-                                              style:UIAlertActionStyleDefault
-                                            handler:^(UIAlertAction * action)
-                      {
-                          MXStrongifyAndReturnIfNil(self);
-                          self->alert = nil;
-                      }]];
-
-    [self presentViewController:alert animated:YES completion:nil];
-}
-
-- (void)clearDataAfterSoftLogout
-{
-    MXLogDebug(@"[AuthenticationVC] clearDataAfterSoftLogout %@", self.softLogoutCredentials.userId);
-
-    // Use AppDelegate so that we reset app settings and this auth screen
-    [[AppDelegate theDelegate] logoutSendingRequestServer:YES completion:^(BOOL isLoggedOut) {
-        MXLogDebug(@"[AuthenticationVC] Complete. isLoggedOut: %@", @(isLoggedOut));
-    }];
-}
-
 /**
  Filter and prioritise flows supported by the app.
 
@@ -1010,7 +968,7 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
     }
     else if (sender == self.softLogoutClearDataButton)
     {
-        [self showClearDataAfterSoftLogoutConfirmation];
+        [self.authVCDelegate authenticationViewControllerDidRequestClearAllData:self];
     }
     else
     {

--- a/Riot/Modules/Authentication/LegacyAuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/LegacyAuthenticationCoordinator.swift
@@ -62,7 +62,6 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
         self.canPresentAdditionalScreens = parameters.canPresentAdditionalScreens
         
         let authenticationViewController = AuthenticationViewController()
-        authenticationViewController.softLogoutCredentials = authenticationService.softLogoutCredentials
         self.authenticationViewController = authenticationViewController
         
         // Preload the view as this can a second and lock up the UI at presentation.
@@ -77,6 +76,8 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
     func start() {
         // Listen to the end of the authentication flow.
         authenticationViewController.authVCDelegate = self
+        // Set (or clear) any soft-logout credentials.
+        authenticationViewController.softLogoutCredentials = authenticationService.softLogoutCredentials
         // Listen for changes from deep links.
         AuthenticationService.shared.delegate = self
     }
@@ -206,6 +207,10 @@ extension LegacyAuthenticationCoordinator: AuthenticationViewControllerDelegate 
         callback?(.didLogin(session: session,
                             authenticationFlow: authenticationViewController.authType.flow,
                             authenticationType: authenticationType))
+    }
+    
+    func authenticationViewControllerDidRequestClearAllData(_ authenticationViewController: AuthenticationViewController) {
+        callback?(.clearAllData)
     }
 }
 

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -264,7 +264,15 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
                 self.authenticationCoordinator(coordinator, didLoginWith: session, and: authenticationFlow, using: authenticationType)
             case .didComplete:
                 self.authenticationCoordinatorDidComplete(coordinator)
-            case .didStart, .clearAllData, .cancel:
+            case .clearAllData:
+                self.showClearAllDataConfirmation {
+                    MXLog.debug("[OnboardingCoordinator] showLegacyAuthenticationScreen: Clear all data after soft logout")
+                    self.authenticationService.reset()
+                    self.authenticationFinished = false
+                    self.cancelAuthentication(flow: .login)
+                    AppDelegate.theDelegate().logoutSendingRequestServer(true, completion: nil)
+                }
+            case .didStart, .cancel:
                 // These results are only sent by the new flow.
                 break
             }
@@ -606,9 +614,9 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
                                                 message: VectorL10n.authSoftlogoutClearDataSignOutMsg,
                                                 preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: VectorL10n.cancel, style: .cancel, handler: nil))
-        alertController.addAction(UIAlertAction(title: VectorL10n.authSoftlogoutClearDataSignOut, style: .default, handler: { action in
+        alertController.addAction(UIAlertAction(title: VectorL10n.authSoftlogoutClearDataSignOut, style: .destructive) { action in
             confirmed?()
-        }))
+        })
         navigationRouter.present(alertController, animated: true)
     }
 }

--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -233,13 +233,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
             case .didComplete:
                 self.authenticationCoordinatorDidComplete(coordinator)
             case .clearAllData:
-                self.showClearAllDataConfirmation {
-                    MXLog.debug("[OnboardingCoordinator] beginAuthentication: clear all data after soft logout")
-                    self.authenticationService.reset()
-                    self.authenticationFinished = false
-                    self.cancelAuthentication(flow: .login)
-                    AppDelegate.theDelegate().logoutSendingRequestServer(true, completion: nil)
-                }
+                self.showClearAllDataConfirmation()
             case .cancel(let flow):
                 self.cancelAuthentication(flow: flow)
             }
@@ -265,13 +259,7 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
             case .didComplete:
                 self.authenticationCoordinatorDidComplete(coordinator)
             case .clearAllData:
-                self.showClearAllDataConfirmation {
-                    MXLog.debug("[OnboardingCoordinator] showLegacyAuthenticationScreen: Clear all data after soft logout")
-                    self.authenticationService.reset()
-                    self.authenticationFinished = false
-                    self.cancelAuthentication(flow: .login)
-                    AppDelegate.theDelegate().logoutSendingRequestServer(true, completion: nil)
-                }
+                self.showClearAllDataConfirmation()
             case .didStart, .cancel:
                 // These results are only sent by the new flow.
                 break
@@ -607,16 +595,21 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         loadingIndicator = nil
     }
 
-    /// Show confirmation to clear all data
-    /// - Parameter confirmed: Callback to be called when confirmed.
-    private func showClearAllDataConfirmation(_ confirmed: (() -> Void)?) {
+    /// Shows a confirmation to clear all data, and proceeds to do so if the user confirms.
+    private func showClearAllDataConfirmation() {
         let alertController = UIAlertController(title: VectorL10n.authSoftlogoutClearDataSignOutTitle,
                                                 message: VectorL10n.authSoftlogoutClearDataSignOutMsg,
                                                 preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: VectorL10n.cancel, style: .cancel, handler: nil))
-        alertController.addAction(UIAlertAction(title: VectorL10n.authSoftlogoutClearDataSignOut, style: .destructive) { action in
-            confirmed?()
+        alertController.addAction(UIAlertAction(title: VectorL10n.authSoftlogoutClearDataSignOut, style: .destructive) { [weak self] action in
+            guard let self = self else { return }
+            MXLog.debug("[OnboardingCoordinator] showClearAllDataConfirmation: clear all data after soft logout")
+            self.authenticationService.reset()
+            self.authenticationFinished = false
+            self.cancelAuthentication(flow: .login)
+            AppDelegate.theDelegate().logoutSendingRequestServer(true, completion: nil)
         })
+        
         navigationRouter.present(alertController, animated: true)
     }
 }

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -487,9 +487,15 @@
 {
     MXLogDebug(@"[MasterTabBarController] showAuthenticationScreenAfterSoftLogout");
     
-    AuthenticationService.shared.softLogoutCredentials = credentials;
-    
-    [self showOnboardingFlowAndResetSessionFlags:NO];
+    // This method can be called after the user chooses to clear their data as the MXSession
+    // is opened to call logout from. So we only set the credentials when authentication isn't
+    // in progress to prevent a second soft logout screen being shown.
+    if (!self.onboardingCoordinatorBridgePresenter && !self.isOnboardingCoordinatorPreparing)
+    {
+        AuthenticationService.shared.softLogoutCredentials = credentials;
+        
+        [self showOnboardingFlowAndResetSessionFlags:NO];
+    }
 }
 
 - (void)showOnboardingFlowAndResetSessionFlags:(BOOL)resetSessionFlags

--- a/changelog.d/5881.bugfix
+++ b/changelog.d/5881.bugfix
@@ -1,0 +1,1 @@
+Soft logout: Fix a bug where clearing all data from soft logout didn't present the login screen.


### PR DESCRIPTION
Closes #5881 (the crash was already fixed as part of #6257) by making sure that splash screen/use case screen is presented after choosing to delete all data when using the old auth flow. This is done by

- Delegating logic to the `OnboardingCoordinator` like the new flow does.
- Reseting the credentials on every presentation of authVC.
- Making sure not to set the credentials again after deleting the data (the new soft logout screen was being shown twice).