### PR TITLE
Ignore data detector URLs on file attachment names

### DIFF
--- a/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
+++ b/Riot/Modules/Room/TimelineCells/Common/MXKRoomBubbleTableViewCell.m
@@ -1562,38 +1562,20 @@ static NSMutableDictionary *childClasses;
             associatedEvent = bubbleComponent.event;
         }
         
+        // Tapping a file attachment who's name triggers a data detector will try to open that URL.
+        // Detect this and instead map the interaction into a tap on the cell.
+        if (associatedEvent.isMediaAttachment)
+        {
+            [delegate cell:self didRecognizeAction:kMXKRoomBubbleCellTapOnAttachmentView userInfo:nil];
+            return NO;
+        }
+        
         // Ask the delegate if iOS can open the link
         shouldInteractWithURL = [self shouldInteractWithURL:URL urlItemInteraction:interaction associatedEvent:associatedEvent];
     }
     
     return shouldInteractWithURL;
 }
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-// Delegate method only called on iOS 9. iOS 10+ use method above.
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange
-{
-    BOOL shouldInteractWithURL = YES;
-    
-    if (delegate && URL)
-    {
-        MXEvent *associatedEvent;
-        
-        if ([textView isMemberOfClass:[MXKMessageTextView class]])
-        {
-            MXKMessageTextView *mxkMessageTextView = (MXKMessageTextView *)textView;
-            MXKRoomBubbleComponent *bubbleComponent = [self closestBubbleComponentAtPosition:mxkMessageTextView.lastHitTestLocation];
-            associatedEvent = bubbleComponent.event;
-        }
-        
-        // Ask the delegate if iOS can open the link
-        shouldInteractWithURL = [self shouldInteractWithURL:URL urlItemInteractionValue:@(0) associatedEvent:associatedEvent];
-    }
-    
-    return shouldInteractWithURL;
-}
-#pragma clang diagnostic pop
 
 #pragma mark - WKNavigationDelegate
 

--- a/changelog.d/6031.bugfix
+++ b/changelog.d/6031.bugfix
@@ -1,0 +1,1 @@
+Timeline: When an attachment is named like an email address, open the file instead of Mail.app when tapped.


### PR DESCRIPTION
With bubbles disabled, file attachment names are parsed with data detectors meaning that tapping on a file named `foo@bar.baz` was opening the email app instead of the file.

This PR first checks if the associated event for the URL is a media attachment, and if so will stop the URL handling and instead indicate that the attachment was tapped.

Fixes #6031