### PR TITLE
Display mandatory backup only if session is running

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2358,6 +2358,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         }
 
         if (mainSession.vc_homeserverConfiguration.encryption.isSecureBackupRequired
+            && mainSession.state == MXSessionStateRunning
             && mainSession.vc_canSetupSecureBackup)
         {
             // This only happens at the first login

--- a/changelog.d/pr-6331.bugfix
+++ b/changelog.d/pr-6331.bugfix
@@ -1,0 +1,1 @@
+Display mandatory backup only if session is running


### PR DESCRIPTION
This fixes an issue where failed syncs after user migration could trigger an unwanted display of the mandatory secure backup setup. 