### PR TITLE
Clean up iOS 14 availability checks

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -398,13 +398,7 @@ final class BuildSettings: NSObject {
     
     // MARK: - Polls
     
-    static var pollsEnabled: Bool {
-        guard #available(iOS 14, *) else {
-            return false
-        }
-        
-        return true
-    }
+    static let pollsEnabled = true
     
     // MARK: - Location Sharing
     

--- a/DesignKit/Source/ColorsSwiftUI.swift
+++ b/DesignKit/Source/ColorsSwiftUI.swift
@@ -20,7 +20,6 @@ import SwiftUI
 /**
  Struct for holding colors for use in SwiftUI.
  */
-@available(iOS 14.0, *)
 public struct ColorSwiftUI: Colors {
 
     public let accent: Color

--- a/DesignKit/Source/FontsSwiftUI.swift
+++ b/DesignKit/Source/FontsSwiftUI.swift
@@ -20,7 +20,6 @@ import SwiftUI
 /**
  Struct for holding fonts for use in SwiftUI.
  */
-@available(iOS 14.0, *)
 public struct FontSwiftUI: Fonts {
     
     public let uiFonts: FontsUIKit

--- a/DesignKit/Source/ThemeV2.swift
+++ b/DesignKit/Source/ThemeV2.swift
@@ -30,7 +30,6 @@ import UIKit
 }
 
 /// Theme v2 for SwiftUI.
-@available(iOS 14.0, *)
 public protocol ThemeSwiftUIType {
     
     /// Colors object

--- a/DesignKit/Variants/Colors/Dark/DarkColors.swift
+++ b/DesignKit/Variants/Colors/Dark/DarkColors.swift
@@ -47,6 +47,5 @@ public class DarkColors {
     )
     
     public static var uiKit = ColorsUIKit(values: values)
-    @available(iOS 14.0, *)
     public static var swiftUI = ColorSwiftUI(values: values)
 }

--- a/DesignKit/Variants/Colors/Light/LightColors.swift
+++ b/DesignKit/Variants/Colors/Light/LightColors.swift
@@ -48,7 +48,6 @@ public class LightColors {
     )
     
     public static var uiKit = ColorsUIKit(values: values)
-    @available(iOS 14.0, *)
     public static var swiftUI = ColorSwiftUI(values: values)
 }
 

--- a/Riot/Categories/Publisher+Riot.swift
+++ b/Riot/Categories/Publisher+Riot.swift
@@ -16,7 +16,6 @@
 
 import Combine
 
-@available(iOS 14.0, *)
 extension Publisher {
     
     ///

--- a/Riot/Managers/UISIAutoReporter/UISIAutoReporter.swift
+++ b/Riot/Managers/UISIAutoReporter/UISIAutoReporter.swift
@@ -41,7 +41,6 @@ extension UISIAutoReportData: Codable {
 
 /// Listens for failed decryption events and silently sends reports RageShake server.
 /// Also requests that message senders send a matching report to have both sides of the interaction.
-@available(iOS 14.0, *)
 @objcMembers class UISIAutoReporter: NSObject, UISIDetectorDelegate {
     
     struct ReportInfo: Hashable {

--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -119,21 +119,20 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
     
     private func setupTheme() {
         ThemeService.shared().themeId = RiotSettings.shared.userInterfaceTheme
-        if #available(iOS 14.0, *) {
-            // Set theme id from current theme.identifier, themeId can be nil.
-            if let themeId = ThemeIdentifier(rawValue: ThemeService.shared().theme.identifier) {
-                ThemePublisher.configure(themeId: themeId)
-            } else {
-                MXLog.error("[AppCoordinator] No theme id found to update ThemePublisher")
-            }
-            
-            // Always republish theme change events, and again always getting the identifier from the theme.
-            let themeIdPublisher = NotificationCenter.default.publisher(for: Notification.Name.themeServiceDidChangeTheme)
-                .compactMap({ _ in ThemeIdentifier(rawValue: ThemeService.shared().theme.identifier) })
-                .eraseToAnyPublisher()
 
-            ThemePublisher.shared.republish(themeIdPublisher: themeIdPublisher)
+        // Set theme id from current theme.identifier, themeId can be nil.
+        if let themeId = ThemeIdentifier(rawValue: ThemeService.shared().theme.identifier) {
+            ThemePublisher.configure(themeId: themeId)
+        } else {
+            MXLog.error("[AppCoordinator] No theme id found to update ThemePublisher")
         }
+        
+        // Always republish theme change events, and again always getting the identifier from the theme.
+        let themeIdPublisher = NotificationCenter.default.publisher(for: Notification.Name.themeServiceDidChangeTheme)
+            .compactMap({ _ in ThemeIdentifier(rawValue: ThemeService.shared().theme.identifier) })
+            .eraseToAnyPublisher()
+
+        ThemePublisher.shared.republish(themeIdPublisher: themeIdPublisher)
     }
     
     private func excludeAllItemsFromBackup() {

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -476,11 +476,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     self.pushNotificationService.delegate = self;
         
     self.spaceFeatureUnavailablePresenter = [SpaceFeatureUnavailablePresenter new];
-    
-    if (@available(iOS 14.0, *)) {
-        self.uisiAutoReporter = [[UISIAutoReporter alloc] init];
-    }
-    
+
+    self.uisiAutoReporter = [[UISIAutoReporter alloc] init];
+
     // Add matrix observers, and initialize matrix sessions if the app is not launched in background.
     [self initMatrixSessions];
     
@@ -2022,11 +2020,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         // register the session to the uisi auto-reporter
         if (_uisiAutoReporter != nil)
         {
-            if (@available(iOS 14.0, *))
-            {
-                UISIAutoReporter* uisiAutoReporter = (UISIAutoReporter*)_uisiAutoReporter;
-                [uisiAutoReporter add:mxSession];
-            }
+            UISIAutoReporter* uisiAutoReporter = (UISIAutoReporter*)_uisiAutoReporter;
+            [uisiAutoReporter add:mxSession];
         }
         
         [mxSessionArray addObject:mxSession];
@@ -2048,11 +2043,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     // register the session to the uisi auto-reporter
     if (_uisiAutoReporter != nil)
     {
-        if (@available(iOS 14.0, *))
-        {
-            UISIAutoReporter* uisiAutoReporter = (UISIAutoReporter*)_uisiAutoReporter;
-            [uisiAutoReporter remove:mxSession];
-        }
+        UISIAutoReporter* uisiAutoReporter = (UISIAutoReporter*)_uisiAutoReporter;
+        [uisiAutoReporter remove:mxSession];
     }
 
     // Update the widgets manager

--- a/Riot/Modules/Common/SwiftUI/VectorHostingController.swift
+++ b/Riot/Modules/Common/SwiftUI/VectorHostingController.swift
@@ -21,7 +21,6 @@ import SwiftUI
  UIHostingController that applies some app-level specific configuration
  (E.g. `vectorContent` modifier and theming to the NavigationController container.
  */
-@available(iOS 14.0, *)
 class VectorHostingController: UIHostingController<AnyView> {
     
     // MARK: Private

--- a/Riot/Modules/ContextMenu/ActionProviders/RoomActionProvider.swift
+++ b/Riot/Modules/ContextMenu/ActionProviders/RoomActionProvider.swift
@@ -104,13 +104,7 @@ class RoomActionProvider: RoomActionProviderProtocol {
     }
     
     private var leaveAction: UIAction {
-        let image: UIImage?
-        if #available(iOS 14.0, *) {
-            image = UIImage(systemName: "rectangle.righthalf.inset.fill.arrow.right")
-        } else {
-            image = UIImage(systemName: "rectangle.xmark")
-        }
-
+        let image = UIImage(systemName: "rectangle.righthalf.inset.fill.arrow.right")
         let action = UIAction(title: VectorL10n.homeContextMenuLeave, image: image) { [weak self] action in
             guard let self = self else { return }
             self.service.leaveRoom(promptUser: true)

--- a/Riot/Modules/CreateRoom/CreateRoomCoordinator.swift
+++ b/Riot/Modules/CreateRoom/CreateRoomCoordinator.swift
@@ -114,7 +114,6 @@ final class CreateRoomCoordinator: CreateRoomCoordinatorType {
         return coordinator
     }
     
-    @available(iOS 14.0, *)
     private func createRoomSelectorCoordinator(parentSpace: MXSpace) -> MatrixItemChooserCoordinator {
         let paramaters = MatrixItemChooserCoordinatorParameters(session: self.parameters.session, viewProvider: AddRoomSelectorViewProvider(), itemsProcessor: AddRoomItemsProcessor(parentSpace: parentSpace))
         let coordinator = MatrixItemChooserCoordinator(parameters: paramaters)

--- a/Riot/Modules/CreateRoom/CreateRoomCoordinator.swift
+++ b/Riot/Modules/CreateRoom/CreateRoomCoordinator.swift
@@ -75,7 +75,7 @@ final class CreateRoomCoordinator: CreateRoomCoordinatorType {
 
         self.add(childCoordinator: createRoomCoordinator)
 
-        if let parentSpace = self.parentSpace, #available(iOS 14, *) {
+        if let parentSpace = self.parentSpace {
             let roomSelectionCoordinator = self.createRoomSelectorCoordinator(parentSpace: parentSpace)
             roomSelectionCoordinator.completion = { [weak self] result in
                 guard let self = self else {

--- a/Riot/Modules/MediaPickerV2/MediaPickerPresenter.swift
+++ b/Riot/Modules/MediaPickerV2/MediaPickerPresenter.swift
@@ -74,7 +74,6 @@ final class MediaPickerPresenter: NSObject {
 }
 
 // MARK: - PHPickerViewControllerDelegate
-@available(iOS 14, *)
 extension MediaPickerPresenter: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         // TODO: Handle videos and multi-selection

--- a/Riot/Modules/Room/RoomCoordinator.swift
+++ b/Riot/Modules/Room/RoomCoordinator.swift
@@ -88,9 +88,7 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
         
         self.roomViewController.parentSpaceId = parameters.parentSpaceId
 
-        if #available(iOS 14, *) {
-            TimelinePollProvider.shared.session = parameters.session
-        }
+        TimelinePollProvider.shared.session = parameters.session
         
         super.init()
     }
@@ -331,10 +329,6 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
     }
     
     private func showLocationCoordinatorWithEvent(_ event: MXEvent, bubbleData: MXKRoomBubbleCellDataStoring) {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-        
         guard let navigationRouter = self.navigationRouter,
               let mediaManager = mxSession?.mediaManager,
               let locationContent = event.location else {
@@ -377,10 +371,6 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
     }
 
     private func startLocationCoordinator() {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-        
         guard let navigationRouter = self.navigationRouter,
               let mediaManager = mxSession?.mediaManager,
               let user = mxSession?.myUser else {
@@ -414,10 +404,6 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
     }
     
     private func startEditPollCoordinator(startEvent: MXEvent? = nil) {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-        
         let parameters = PollEditFormCoordinatorParameters(room: roomViewController.roomDataSource.room, pollStartEvent: startEvent)
         let coordinator = PollEditFormCoordinator(parameters: parameters)
         
@@ -562,26 +548,14 @@ extension RoomCoordinator: RoomViewControllerDelegate {
     }
     
     func roomViewController(_ roomViewController: RoomViewController, canEndPollWithEventIdentifier eventIdentifier: String) -> Bool {
-        guard #available(iOS 14.0, *) else {
-            return false
-        }
-        
         return TimelinePollProvider.shared.timelinePollCoordinatorForEventIdentifier(eventIdentifier)?.canEndPoll() ?? false
     }
     
     func roomViewController(_ roomViewController: RoomViewController, endPollWithEventIdentifier eventIdentifier: String) {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-        
         TimelinePollProvider.shared.timelinePollCoordinatorForEventIdentifier(eventIdentifier)?.endPoll()
     }
     
     func roomViewController(_ roomViewController: RoomViewController, canEditPollWithEventIdentifier eventIdentifier: String) -> Bool {
-        guard #available(iOS 14.0, *) else {
-            return false
-        }
-        
         return TimelinePollProvider.shared.timelinePollCoordinatorForEventIdentifier(eventIdentifier)?.canEditPoll() ?? false
     }
     

--- a/Riot/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Riot/Modules/Room/Settings/RoomSettingsViewController.m
@@ -60,9 +60,6 @@ enum
 enum
 {
     ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ACCESS,
-    ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_INVITED_ONLY,
-    ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE_APART_FROM_GUEST,
-    ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE,
     ROOM_SETTINGS_ROOM_ACCESS_DIRECTORY_VISIBILITY,
     ROOM_SETTINGS_ROOM_ACCESS_MISSING_ADDRESS_WARNING
 };
@@ -147,9 +144,6 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     
     // Room Access items
     
-    TableViewCellWithCheckBoxAndLabel *accessInvitedOnlyTickCell;
-    TableViewCellWithCheckBoxAndLabel *accessAnyoneApartGuestTickCell;
-    TableViewCellWithCheckBoxAndLabel *accessAnyoneTickCell;
     UISwitch *directoryVisibilitySwitch;
     MXRoomDirectoryVisibility actualDirectoryVisibility;
     MXHTTPOperation* actualDirectoryVisibilityRequest;
@@ -546,44 +540,20 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     if (RiotSettings.shared.roomSettingsScreenAllowChangingAccessSettings)
     {
         Section *sectionAccess = [Section sectionWithTag:SECTION_TAG_ACCESS];
-        if (@available(iOS 14, *))
+        [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ACCESS];
+        
+        // Check whether a room address is required for the current join rule
+        NSString *joinRule = updatedItemsDict[kRoomSettingsJoinRuleKey];
+        if (!joinRule)
         {
-            [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ACCESS];
-            
-            // Check whether a room address is required for the current join rule
-            NSString *joinRule = updatedItemsDict[kRoomSettingsJoinRuleKey];
-            if (!joinRule)
-            {
-                // Use the actual values if no change is pending.
-                joinRule = mxRoomState.joinRule;
-            }
-            
-            if ([joinRule isEqualToString:kMXRoomJoinRulePublic] && !roomAddresses.count)
-            {
-                // Notify the user that a room address is required.
-                [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_MISSING_ADDRESS_WARNING];
-            }
+            // Use the actual values if no change is pending.
+            joinRule = mxRoomState.joinRule;
         }
-        else
+        
+        if ([joinRule isEqualToString:kMXRoomJoinRulePublic] && !roomAddresses.count)
         {
-            [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_INVITED_ONLY];
-            [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE_APART_FROM_GUEST];
-            [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE];
-            
-            // Check whether a room address is required for the current join rule
-            NSString *joinRule = updatedItemsDict[kRoomSettingsJoinRuleKey];
-            if (!joinRule)
-            {
-                // Use the actual values if no change is pending.
-                joinRule = mxRoomState.joinRule;
-            }
-            
-            if ([joinRule isEqualToString:kMXRoomJoinRulePublic] && !roomAddresses.count)
-            {
-                // Notify the user that a room address is required.
-                [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_MISSING_ADDRESS_WARNING];
-            }
-            [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_DIRECTORY_VISIBILITY];
+            // Notify the user that a room address is required.
+            [sectionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_MISSING_ADDRESS_WARNING];
         }
         
         if (mxRoom.isDirect)
@@ -596,15 +566,13 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
         }
         [tmpSections addObject:sectionAccess];
         
-        if (@available(iOS 14, *)) {
-            if (RiotSettings.shared.roomSettingsScreenAllowChangingAccessSettings)
-            {
-                Section *promotionAccess = [Section sectionWithTag:SECTION_TAG_PROMOTION];
-                promotionAccess.headerTitle = VectorL10n.roomDetailsPromoteRoomTitle;
-                [promotionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_DIRECTORY_VISIBILITY];
-                [promotionAccess addRowWithTag:ROOM_SETTINGS_ROOM_PROMOTE_SECTION_ROW_SUGGEST];
-                [tmpSections addObject:promotionAccess];
-            }
+        if (RiotSettings.shared.roomSettingsScreenAllowChangingAccessSettings)
+        {
+            Section *promotionAccess = [Section sectionWithTag:SECTION_TAG_PROMOTION];
+            promotionAccess.headerTitle = VectorL10n.roomDetailsPromoteRoomTitle;
+            [promotionAccess addRowWithTag:ROOM_SETTINGS_ROOM_ACCESS_DIRECTORY_VISIBILITY];
+            [promotionAccess addRowWithTag:ROOM_SETTINGS_ROOM_PROMOTE_SECTION_ROW_SUGGEST];
+            [tmpSections addObject:promotionAccess];
         }
     }
     
@@ -2610,46 +2578,7 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
             {
                 guestAccess = mxRoomState.guestAccess;
             }
-            
-            if (row == ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_INVITED_ONLY)
-            {
-                roomAccessCell.label.text = [VectorL10n roomDetailsAccessSectionInvitedOnly];
-                
-                roomAccessCell.enabled = ([joinRule isEqualToString:kMXRoomJoinRuleInvite]);
-                
-                accessInvitedOnlyTickCell = roomAccessCell;
-            }
-            else if (row == ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE_APART_FROM_GUEST)
-            {
-                if (mxRoom.isDirect)
-                {
-                    roomAccessCell.label.text = [VectorL10n roomDetailsAccessSectionAnyoneApartFromGuestForDm];
-                }
-                else
-                {
-                    roomAccessCell.label.text = [VectorL10n roomDetailsAccessSectionAnyoneApartFromGuest];
-                }
-                
-                roomAccessCell.enabled = ([joinRule isEqualToString:kMXRoomJoinRulePublic] && [guestAccess isEqualToString:kMXRoomGuestAccessForbidden]);
-                
-                accessAnyoneApartGuestTickCell = roomAccessCell;
-            }
-            else if (row == ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE)
-            {
-                if (mxRoom.isDirect)
-                {
-                    roomAccessCell.label.text = [VectorL10n roomDetailsAccessSectionAnyoneForDm];
-                }
-                else
-                {
-                    roomAccessCell.label.text = [VectorL10n roomDetailsAccessSectionAnyone];
-                }
-                
-                roomAccessCell.enabled = ([joinRule isEqualToString:kMXRoomJoinRulePublic] && [guestAccess isEqualToString:kMXRoomGuestAccessCanJoin]);
-                
-                accessAnyoneTickCell = roomAccessCell;
-            }
-            
+
             // Check whether the user can change this option
             roomAccessCell.userInteractionEnabled = (oneSelfPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomJoinRules]);
             roomAccessCell.checkBox.alpha = roomAccessCell.userInteractionEnabled ? 1.0f : 0.5f;
@@ -3150,129 +3079,8 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
         else if (section == SECTION_TAG_ACCESS)
         {
             BOOL isUpdated = NO;
-            
-            if (row == ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_INVITED_ONLY)
-            {
-                // Ignore the selection if the option is already enabled
-                if (! accessInvitedOnlyTickCell.isEnabled)
-                {
-                    // Enable this option
-                    accessInvitedOnlyTickCell.enabled = YES;
-                    // Disable other options
-                    accessAnyoneApartGuestTickCell.enabled = NO;
-                    accessAnyoneTickCell.enabled = NO;
-                    
-                    // Check the actual option
-                    if ([mxRoomState.joinRule isEqualToString:kMXRoomJoinRuleInvite])
-                    {
-                        // No change on room access
-                        [updatedItemsDict removeObjectForKey:kRoomSettingsJoinRuleKey];
-                        [updatedItemsDict removeObjectForKey:kRoomSettingsGuestAccessKey];
-                    }
-                    else
-                    {
-                        updatedItemsDict[kRoomSettingsJoinRuleKey] = kMXRoomJoinRuleInvite;
-                        
-                        // Update guest access to allow guest on invitation.
-                        // Note: if guest_access is "forbidden" here, guests cannot join this room even if explicitly invited.
-                        if ([mxRoomState.guestAccess isEqualToString:kMXRoomGuestAccessCanJoin])
-                        {
-                            [updatedItemsDict removeObjectForKey:kRoomSettingsGuestAccessKey];
-                        }
-                        else
-                        {
-                            updatedItemsDict[kRoomSettingsGuestAccessKey] = kMXRoomGuestAccessCanJoin;
-                        }
-                    }
-                    
-                    isUpdated = YES;
-                }
-            }
-            else if (row == ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE_APART_FROM_GUEST)
-            {
-                // Ignore the selection if the option is already enabled
-                if (! accessAnyoneApartGuestTickCell.isEnabled)
-                {
-                    // Enable this option
-                    accessAnyoneApartGuestTickCell.enabled = YES;
-                    // Disable other options
-                    accessInvitedOnlyTickCell.enabled = NO;
-                    accessAnyoneTickCell.enabled = NO;
-                    
-                    // Check the actual option
-                    if ([mxRoomState.joinRule isEqualToString:kMXRoomJoinRulePublic] && [mxRoomState.guestAccess isEqualToString:kMXRoomGuestAccessForbidden])
-                    {
-                        // No change on room access
-                        [updatedItemsDict removeObjectForKey:kRoomSettingsJoinRuleKey];
-                        [updatedItemsDict removeObjectForKey:kRoomSettingsGuestAccessKey];
-                    }
-                    else
-                    {
-                        if ([mxRoomState.joinRule isEqualToString:kMXRoomJoinRulePublic])
-                        {
-                            [updatedItemsDict removeObjectForKey:kRoomSettingsJoinRuleKey];
-                        }
-                        else
-                        {
-                            updatedItemsDict[kRoomSettingsJoinRuleKey] = kMXRoomJoinRulePublic;
-                        }
-                        
-                        if ([mxRoomState.guestAccess isEqualToString:kMXRoomGuestAccessForbidden])
-                        {
-                            [updatedItemsDict removeObjectForKey:kRoomSettingsGuestAccessKey];
-                        }
-                        else
-                        {
-                            updatedItemsDict[kRoomSettingsGuestAccessKey] = kMXRoomGuestAccessForbidden;
-                        }
-                    }
-                    
-                    isUpdated = YES;
-                }
-            }
-            else if (row == ROOM_SETTINGS_ROOM_ACCESS_SECTION_ROW_ANYONE)
-            {
-                // Ignore the selection if the option is already enabled
-                if (! accessAnyoneTickCell.isEnabled)
-                {
-                    // Enable this option
-                    accessAnyoneTickCell.enabled = YES;
-                    // Disable other options
-                    accessInvitedOnlyTickCell.enabled = NO;
-                    accessAnyoneApartGuestTickCell.enabled = NO;
-                    
-                    // Check the actual option
-                    if ([mxRoomState.joinRule isEqualToString:kMXRoomJoinRulePublic] && [mxRoomState.guestAccess isEqualToString:kMXRoomGuestAccessCanJoin])
-                    {
-                        // No change on room access
-                        [updatedItemsDict removeObjectForKey:kRoomSettingsJoinRuleKey];
-                        [updatedItemsDict removeObjectForKey:kRoomSettingsGuestAccessKey];
-                    }
-                    else
-                    {
-                        if ([mxRoomState.joinRule isEqualToString:kMXRoomJoinRulePublic])
-                        {
-                            [updatedItemsDict removeObjectForKey:kRoomSettingsJoinRuleKey];
-                        }
-                        else
-                        {
-                            updatedItemsDict[kRoomSettingsJoinRuleKey] = kMXRoomJoinRulePublic;
-                        }
-                        
-                        if ([mxRoomState.guestAccess isEqualToString:kMXRoomGuestAccessCanJoin])
-                        {
-                            [updatedItemsDict removeObjectForKey:kRoomSettingsGuestAccessKey];
-                        }
-                        else
-                        {
-                            updatedItemsDict[kRoomSettingsGuestAccessKey] = kMXRoomGuestAccessCanJoin;
-                        }
-                    }
-                    
-                    isUpdated = YES;
-                }
-            }
-            else if (row == ROOM_SETTINGS_ROOM_ACCESS_MISSING_ADDRESS_WARNING)
+
+            if (row == ROOM_SETTINGS_ROOM_ACCESS_MISSING_ADDRESS_WARNING)
             {
                 // Scroll to room addresses section
                 NSIndexPath *addressIndexPath = [_tableViewSections exactIndexPathForRowTag:0 sectionTag:SECTION_TAG_ADDRESSES];
@@ -3832,29 +3640,23 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
 
 - (void)showRoomAccessFlow
 {
-    if (@available(iOS 14.0, *))
-    {
-        MXRoom *room = [self.mainSession roomWithRoomId:self.roomId];
-        
-        if (room) {
-            roomAccessPresenter = [[RoomAccessCoordinatorBridgePresenter alloc] initWithRoom:room parentSpaceId:self.parentSpaceId];
-            roomAccessPresenter.delegate = self;
-            [roomAccessPresenter presentFrom:self animated:YES];
-        }
+    MXRoom *room = [self.mainSession roomWithRoomId:self.roomId];
+
+    if (room) {
+        roomAccessPresenter = [[RoomAccessCoordinatorBridgePresenter alloc] initWithRoom:room parentSpaceId:self.parentSpaceId];
+        roomAccessPresenter.delegate = self;
+        [roomAccessPresenter presentFrom:self animated:YES];
     }
 }
 
 - (void)showSuggestToSpaceMembers
 {
-    if (@available(iOS 14.0, *))
-    {
-        MXRoom *room = [self.mainSession roomWithRoomId:self.roomId];
-        
-        if (room) {
-            roomSuggestionPresenter = [[RoomSuggestionCoordinatorBridgePresenter alloc] initWithRoom:room];
-            roomSuggestionPresenter.delegate = self;
-            [roomSuggestionPresenter presentFrom:self animated:YES];
-        }
+    MXRoom *room = [self.mainSession roomWithRoomId:self.roomId];
+
+    if (room) {
+        roomSuggestionPresenter = [[RoomSuggestionCoordinatorBridgePresenter alloc] initWithRoom:room];
+        roomSuggestionPresenter.delegate = self;
+        [roomSuggestionPresenter presentFrom:self animated:YES];
     }
 }
 

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/Location/LocationPlainCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/Location/LocationPlainCell.swift
@@ -25,8 +25,7 @@ class LocationPlainCell: SizableBaseRoomCell, RoomCellReactionsDisplayable, Room
     override func render(_ cellData: MXKCellData!) {
         super.render(cellData)
         
-        guard #available(iOS 14.0, *),
-              let bubbleData = cellData as? RoomBubbleCellData,
+        guard let bubbleData = cellData as? RoomBubbleCellData,
               let event = bubbleData.events.last
         else {
             return
@@ -118,8 +117,7 @@ class LocationPlainCell: SizableBaseRoomCell, RoomCellReactionsDisplayable, Room
         roomCellContentView?.showSenderInfo = true
         roomCellContentView?.showPaginationTitle = false
         
-        guard #available(iOS 14.0, *),
-              let contentView = roomCellContentView?.innerContentView else {
+        guard let contentView = roomCellContentView?.innerContentView else {
                   return
               }
         

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/Poll/PollPlainCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/Poll/PollPlainCell.swift
@@ -24,8 +24,7 @@ class PollPlainCell: SizableBaseRoomCell, RoomCellReactionsDisplayable, RoomCell
     override func render(_ cellData: MXKCellData!) {
         super.render(cellData)
         
-        guard #available(iOS 14.0, *),
-              let contentView = roomCellContentView?.innerContentView,
+        guard let contentView = roomCellContentView?.innerContentView,
               let bubbleData = cellData as? RoomBubbleCellData,
               let event = bubbleData.events.last,
               event.eventType == __MXEventType.pollStart,

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -414,23 +414,13 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     {
         [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_SHOW_DECODED_CONTENT];
     }
-    
-    if (@available(iOS 14.0, *)) {
-        // Don't display Global settings footer for iOS 14+
-    } else {
-        sectionNotificationSettings.footerTitle = [VectorL10n settingsGlobalSettingsInfo:AppInfo.current.displayName];
-    }
 
     [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_PIN_MISSED_NOTIFICATIONS_INDEX];
     [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_PIN_UNREAD_INDEX];
     
-    if (@available(iOS 14.0, *)) {
-        [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_DEFAULT_SETTINGS_INDEX];
-        [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_MENTION_AND_KEYWORDS_SETTINGS_INDEX];
-        [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_OTHER_SETTINGS_INDEX];
-    } else {
-        // Don't add new sections on pre iOS 14
-    }
+    [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_DEFAULT_SETTINGS_INDEX];
+    [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_MENTION_AND_KEYWORDS_SETTINGS_INDEX];
+    [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_OTHER_SETTINGS_INDEX];
 
     sectionNotificationSettings.headerTitle = [VectorL10n settingsNotifications];
     [tmpSections addObject:sectionNotificationSettings];
@@ -2941,18 +2931,16 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         }
         else if (section == SECTION_TAG_NOTIFICATIONS)
         {
-            if (@available(iOS 14.0, *)) {
-                switch (row) {
-                    case NOTIFICATION_SETTINGS_DEFAULT_SETTINGS_INDEX:
-                        [self showNotificationSettings:NotificationSettingsScreenDefaultNotifications];
-                        break;
-                    case NOTIFICATION_SETTINGS_MENTION_AND_KEYWORDS_SETTINGS_INDEX:
-                        [self showNotificationSettings:NotificationSettingsScreenMentionsAndKeywords];
-                        break;
-                    case NOTIFICATION_SETTINGS_OTHER_SETTINGS_INDEX:
-                        [self showNotificationSettings:NotificationSettingsScreenOther];
-                        break;
-                }
+            switch (row) {
+                case NOTIFICATION_SETTINGS_DEFAULT_SETTINGS_INDEX:
+                    [self showNotificationSettings:NotificationSettingsScreenDefaultNotifications];
+                    break;
+                case NOTIFICATION_SETTINGS_MENTION_AND_KEYWORDS_SETTINGS_INDEX:
+                    [self showNotificationSettings:NotificationSettingsScreenMentionsAndKeywords];
+                    break;
+                case NOTIFICATION_SETTINGS_OTHER_SETTINGS_INDEX:
+                    [self showNotificationSettings:NotificationSettingsScreenOther];
+                    break;
             }
         }
         

--- a/Riot/Modules/SideMenu/SideMenuCoordinator.swift
+++ b/Riot/Modules/SideMenu/SideMenuCoordinator.swift
@@ -260,7 +260,6 @@ final class SideMenuCoordinator: NSObject, SideMenuCoordinatorType {
         self.spaceDetailPresenter.present(forSpaceWithId: spaceId, from: self.sideMenuViewController, sourceView: sourceView, session: session, animated: true)
     }
     
-    @available(iOS 14.0, *)
     private func showCreateSpace() {
         guard let session = self.parameters.userSessionsService.mainUserSession?.matrixSession else {
             return
@@ -301,7 +300,6 @@ final class SideMenuCoordinator: NSObject, SideMenuCoordinatorType {
         self.createRoomCoordinator = createRoomCoordinator
     }
     
-    @available(iOS 14.0, *)
     private func showSpaceSettings(spaceId: String, session: MXSession) {
         let coordinator = SpaceSettingsModalCoordinator(parameters: SpaceSettingsModalCoordinatorParameters(session: session, spaceId: spaceId, parentSpaceId: nil))
         coordinator.callback = { [weak self] result in

--- a/Riot/Modules/SideMenu/SideMenuCoordinator.swift
+++ b/Riot/Modules/SideMenu/SideMenuCoordinator.swift
@@ -430,9 +430,7 @@ extension SideMenuCoordinator: SpaceListCoordinatorDelegate {
     }
     
     func spaceListCoordinatorDidSelectCreateSpace(_ coordinator: SpaceListCoordinatorType) {
-        if #available(iOS 14.0, *) {
-            self.showCreateSpace()
-        }
+        self.showCreateSpace()
     }
 }
 
@@ -460,11 +458,7 @@ extension SideMenuCoordinator: SpaceMenuPresenterDelegate {
             case .addSpace:
                 AppDelegate.theDelegate().showAlert(withTitle: VectorL10n.spacesAddSpace, message: VectorL10n.spacesFeatureNotAvailable(AppInfo.current.displayName))
             case .settings:
-                if #available(iOS 14.0, *) {
-                    self.showSpaceSettings(spaceId: spaceId, session: session)
-                } else {
-                    AppDelegate.theDelegate().showAlert(withTitle: VectorL10n.settingsTitle, message: VectorL10n.spacesFeatureNotAvailable(AppInfo.current.displayName))
-                }
+                self.showSpaceSettings(spaceId: spaceId, session: session)
             case .invite:
                 self.showSpaceInvite(spaceId: spaceId, session: session)
             }

--- a/Riot/Modules/Spaces/SpaceList/SpaceListViewModel.swift
+++ b/Riot/Modules/Spaces/SpaceList/SpaceListViewModel.swift
@@ -167,10 +167,8 @@ final class SpaceListViewModel: SpaceListViewModelType {
             ]
 
         let spacesSectionIndex = sections.count - 1
-        if #available(iOS 14.0, *) {
-            let addSpaceViewData = self.createAddSpaceViewData(session: session)
-            sections.append(.addSpace(addSpaceViewData))
-        }
+        let addSpaceViewData = self.createAddSpaceViewData(session: session)
+        sections.append(.addSpace(addSpaceViewData))
         
         self.sections = sections
         let homeIndexPath = viewDataList.invites.isEmpty ? IndexPath(row: 0, section: 0) : IndexPath(row: 0, section: 1)

--- a/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
+++ b/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
@@ -100,7 +100,6 @@ class SpaceMenuPresenter: NSObject {
         }
     }
     
-    @available(iOS 14.0, *)
     private func showLeaveSpace() {
         let name = session.spaceService.getSpace(withId: spaceId)?.summary?.displayname ?? VectorL10n.spaceTag
         

--- a/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
+++ b/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
@@ -146,9 +146,7 @@ extension SpaceMenuPresenter: SpaceMenuModelViewModelCoordinatorDelegate {
         case .invite:
             self.delegate?.spaceMenuPresenter(self, didCompleteWith: .invite, forSpaceWithId: self.spaceId, with: self.session)
         case .leaveSpaceAndChooseRooms:
-            if #available(iOS 14.0, *) {
-                self.showLeaveSpace()
-            }
+            self.showLeaveSpace()
         default:
             MXLog.error("[SpaceMenuPresenter] spaceListViewModel didSelectItem: invalid action \(action)")
         }

--- a/Riot/Modules/Spaces/SpaceMenu/SpaceMenuViewModel.swift
+++ b/Riot/Modules/Spaces/SpaceMenu/SpaceMenuViewModel.swift
@@ -85,22 +85,6 @@ class SpaceMenuViewModel: SpaceMenuViewModelType {
     }
 
     private func leaveSpace() {
-        guard #available(iOS 14, *) else {
-            guard let room = self.session.room(withRoomId: self.spaceId), let displayName = room.summary?.displayname else {
-                return
-            }
-
-            var isAdmin = false
-            if let roomState = room.dangerousSyncState, let powerLevels = roomState.powerLevels {
-                let powerLevel = powerLevels.powerLevelOfUser(withUserID: self.session.myUserId)
-                let roomPowerLevel = RoomPowerLevelHelper.roomPowerLevel(from: powerLevel)
-                isAdmin = roomPowerLevel == .admin
-            }
-
-            self.viewDelegate?.spaceMenuViewModel(self, didUpdateViewState: .leaveOptions(displayName, isAdmin))
-            return
-        }
-        
         self.viewDelegate?.spaceMenuViewModel(self, didUpdateViewState: .deselect)
         self.coordinatorDelegate?.spaceMenuViewModel(self, didSelectItemWith: .leaveSpaceAndChooseRooms)
     }

--- a/Riot/Modules/Spaces/SpaceRoomList/ExploreRoomCoordinator.swift
+++ b/Riot/Modules/Spaces/SpaceRoomList/ExploreRoomCoordinator.swift
@@ -240,10 +240,6 @@ final class ExploreRoomCoordinator: NSObject, ExploreRoomCoordinatorType {
     }
 
     private func startEditPollCoordinator(room: MXRoom, startEvent: MXEvent? = nil) {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-        
         let parameters = PollEditFormCoordinatorParameters(room: room, pollStartEvent: startEvent)
         let coordinator = PollEditFormCoordinator(parameters: parameters)
         
@@ -283,9 +279,7 @@ extension ExploreRoomCoordinator: SpaceExploreRoomCoordinatorDelegate {
     
     func spaceExploreRoomCoordinator(_ coordinator: SpaceExploreRoomCoordinatorType, openSettingsOf item: SpaceExploreRoomListItemViewData) {
         if item.childInfo.roomType == .space {
-            if #available(iOS 14, *) {
-                self.showSpaceSettings(of: item.childInfo)
-            }
+            self.showSpaceSettings(of: item.childInfo)
         } else {
             if !presentSettings(ofRoomWithId: item.childInfo.childRoomId) {
                 self.navigateTo(roomWith: item.childInfo.childRoomId, showSettingsInitially: true, animated: true)
@@ -438,18 +432,10 @@ extension ExploreRoomCoordinator: RoomViewControllerDelegate {
     }
 
     func roomViewController(_ roomViewController: RoomViewController, canEditPollWithEventIdentifier eventIdentifier: String) -> Bool {
-        guard #available(iOS 14.0, *) else {
-            return false
-        }
-        
         return TimelinePollProvider.shared.timelinePollCoordinatorForEventIdentifier(eventIdentifier)?.canEditPoll() ?? false
     }
 
     func roomViewController(_ roomViewController: RoomViewController, endPollWithEventIdentifier eventIdentifier: String) {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-        
         TimelinePollProvider.shared.timelinePollCoordinatorForEventIdentifier(eventIdentifier)?.endPoll()
     }
     
@@ -458,10 +444,6 @@ extension ExploreRoomCoordinator: RoomViewControllerDelegate {
     }
     
     func roomViewController(_ roomViewController: RoomViewController, canEndPollWithEventIdentifier eventIdentifier: String) -> Bool {
-        guard #available(iOS 14.0, *) else {
-            return false
-        }
-        
         return TimelinePollProvider.shared.timelinePollCoordinatorForEventIdentifier(eventIdentifier)?.canEndPoll() ?? false
     }
     

--- a/Riot/Modules/Spaces/SpaceRoomList/ExploreRoomCoordinator.swift
+++ b/Riot/Modules/Spaces/SpaceRoomList/ExploreRoomCoordinator.swift
@@ -204,7 +204,6 @@ final class ExploreRoomCoordinator: NSObject, ExploreRoomCoordinatorType {
         self.navigationRouter.present(coordinator, animated: true)
     }
     
-    @available(iOS 14.0, *)
     private func showSpaceSettings(of childInfo: MXSpaceChildInfo) {
         let coordinator = SpaceSettingsModalCoordinator(parameters: SpaceSettingsModalCoordinatorParameters(session: session, spaceId: childInfo.childRoomId, parentSpaceId: spaceIdStack.last))
         coordinator.callback = { [weak self] result in

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/AnalyticsPromptViewModel.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/AnalyticsPromptViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias AnalyticsPromptViewModelType = StateStoreViewModel<AnalyticsPromptViewState,
                                                              Never,
                                                              AnalyticsPromptViewAction>
-@available(iOS 14, *)
 class AnalyticsPromptViewModel: AnalyticsPromptViewModelType {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
@@ -31,7 +31,6 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
     private let analyticsPromptHostingController: UIViewController
     private var _analyticsPromptViewModel: Any? = nil
     
-    @available(iOS 14.0, *)
     fileprivate var analyticsPromptViewModel: AnalyticsPromptViewModel {
         return _analyticsPromptViewModel as! AnalyticsPromptViewModel
     }
@@ -44,7 +43,6 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: AnalyticsPromptCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
@@ -65,11 +65,6 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
     // MARK: - Public
     
     func start() {
-        guard #available(iOS 14.0, *) else {
-            MXLog.debug("[AnalyticsPromptCoordinator] start: Invalid iOS version, returning.")
-            return
-        }
-        
         MXLog.debug("[AnalyticsPromptCoordinator] did start.")
         
         analyticsPromptViewModel.completion = { [weak self] result in

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptStrings.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptStrings.swift
@@ -17,7 +17,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 14.0, *)
 struct AnalyticsPromptStrings: AnalyticsPromptStringsProtocol {
     let point1 = HTMLFormatter.formatHTML(VectorL10n.analyticsPromptPoint1,
                                           withAllowedTags: ["b", "p"],

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/MockAnalyticsPromptScreenState.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/MockAnalyticsPromptScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAnalyticsPromptScreenState: MockScreenState, CaseIterable {
     /// The type of prompt to display.
     case promptType(AnalyticsPromptType)

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/Test/UI/AnalyticsPromptUITests.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/Test/UI/AnalyticsPromptUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class AnalyticsPromptUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPrompt.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPrompt.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A prompt that asks the user whether they would like to enable Analytics or not.
 struct AnalyticsPrompt: View {
 

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPromptCheckmarkItem.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/View/AnalyticsPromptCheckmarkItem.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct AnalyticsPromptCheckmarkItem: View {
     
     // MARK: - Properties
@@ -75,7 +74,6 @@ struct AnalyticsPromptCheckmarkItem: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct AnalyticsPromptCheckmarkItem_Previews: PreviewProvider {
     
     static let strings = MockAnalyticsPromptStrings()

--- a/RiotSwiftUI/Modules/Authentication/ChoosePassword/Coordinator/AuthenticationChoosePasswordCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/ChoosePassword/Coordinator/AuthenticationChoosePasswordCoordinator.swift
@@ -28,7 +28,6 @@ enum AuthenticationChoosePasswordCoordinatorResult {
     case cancel
 }
 
-@available(iOS 14.0, *)
 final class AuthenticationChoosePasswordCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/ChoosePassword/MockAuthenticationChoosePasswordScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/ChoosePassword/MockAuthenticationChoosePasswordScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationChoosePasswordScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Authentication/ForgotPassword/Coordinator/AuthenticationForgotPasswordCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/ForgotPassword/Coordinator/AuthenticationForgotPasswordCoordinator.swift
@@ -29,7 +29,6 @@ enum AuthenticationForgotPasswordCoordinatorResult {
     case cancel
 }
 
-@available(iOS 14.0, *)
 final class AuthenticationForgotPasswordCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/ForgotPassword/MockAuthenticationForgotPasswordScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/ForgotPassword/MockAuthenticationForgotPasswordScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationForgotPasswordScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Authentication/SoftLogout/Coordinator/AuthenticationSoftLogoutCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/SoftLogout/Coordinator/AuthenticationSoftLogoutCoordinator.swift
@@ -49,7 +49,6 @@ enum AuthenticationSoftLogoutCoordinatorResult: CustomStringConvertible {
     }
 }
 
-@available(iOS 14.0, *)
 final class AuthenticationSoftLogoutCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/SoftLogout/MockAuthenticationSoftLogoutScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/SoftLogout/MockAuthenticationSoftLogoutScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationSoftLogoutScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Authentication/VerifyEmail/Coordinator/AuthenticationVerifyEmailCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyEmail/Coordinator/AuthenticationVerifyEmailCoordinator.swift
@@ -21,7 +21,6 @@ struct AuthenticationVerifyEmailCoordinatorParameters {
     let registrationWizard: RegistrationWizard
 }
 
-@available(iOS 14.0, *)
 final class AuthenticationVerifyEmailCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Authentication/VerifyEmail/MockAuthenticationVerifyEmailScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyEmail/MockAuthenticationVerifyEmailScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationVerifyEmailScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Authentication/VerifyMsisdn/MockAuthenticationVerifyMsisdnScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyMsisdn/MockAuthenticationVerifyMsisdnScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockAuthenticationVerifyMsisdnScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Common/ActivityIndicator/ActivityIndicator.swift
+++ b/RiotSwiftUI/Modules/Common/ActivityIndicator/ActivityIndicator.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A visual cue to user that something is in progress.
 struct ActivityIndicator: View {
     
@@ -34,7 +33,6 @@ struct ActivityIndicator: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct ActivityIndicator_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/ActivityIndicator/ActivityIndicatorModifier.swift
+++ b/RiotSwiftUI/Modules/Common/ActivityIndicator/ActivityIndicatorModifier.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A modifier for showing the activity indicator centered over a view.
 struct ActivityIndicatorModifier: ViewModifier {
     var show: Bool
@@ -36,9 +35,7 @@ struct ActivityIndicatorModifier: ViewModifier {
     }
 }
 
-@available(iOS 14.0, *)
 extension View {
-    @available(iOS 14.0, *)
     func activityIndicator(show: Bool) -> some View {
         self.modifier(ActivityIndicatorModifier(show: show))
     }

--- a/RiotSwiftUI/Modules/Common/Avatar/Service/MatrixSDK/AvatarService.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/Service/MatrixSDK/AvatarService.swift
@@ -48,7 +48,6 @@ class AvatarService: AvatarServiceProtocol {
     ///   - mxContentUri: matrix uri of the avatar to fetch
     ///   - avatarSize: The size of avatar to retrieve as defined in the DesignKit spec.
     /// - Returns: A Future of UIImage that returns an error if it fails to fetch the image.
-    @available(iOS 14.0, *)
     func avatarImage(mxContentUri: String, avatarSize: AvatarSize) -> Future<UIImage, Error> {
         
         let cachePath = MXMediaManager.thumbnailCachePath(

--- a/RiotSwiftUI/Modules/Common/Avatar/Service/Mock/MockAvatarService.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/Service/Mock/MockAvatarService.swift
@@ -19,7 +19,6 @@ import Combine
 import DesignKit
 import UIKit
 
-@available(iOS 14.0, *)
 class MockAvatarService: AvatarServiceProtocol {
     static let example: AvatarServiceProtocol = MockAvatarService()
     func avatarImage(mxContentUri: String, avatarSize: AvatarSize) -> Future<UIImage, Error> {

--- a/RiotSwiftUI/Modules/Common/Avatar/View/AvatarImage.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/View/AvatarImage.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import DesignKit
 
-@available(iOS 14.0, *)
 struct AvatarImage: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -57,7 +56,6 @@ struct AvatarImage: View {
     }
 }
 
-@available(iOS 14.0, *)
 extension AvatarImage {
     init(avatarData: AvatarInputProtocol, size: AvatarSize) {
         self.init(
@@ -69,7 +67,6 @@ extension AvatarImage {
     }
 }
 
-@available(iOS 14.0, *)
 extension AvatarImage {
     func border(color: Color) -> some View {
         modifier(BorderModifier(color: color, borderWidth: 3, shape: Circle()))
@@ -82,7 +79,6 @@ extension AvatarImage {
     }
 }
 
-@available(iOS 14.0, *)
 struct AvatarImage_Previews: PreviewProvider {
     static let mxContentUri = "fakeUri"
     static let name = "Alice"

--- a/RiotSwiftUI/Modules/Common/Avatar/View/PlaceholderAvatarImage.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/View/PlaceholderAvatarImage.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A reusable view that will show a standard placeholder avatar with the
 /// supplied character and colour index for the `namesAndAvatars` color array.
 ///
@@ -50,7 +49,6 @@ struct PlaceholderAvatarImage: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct Previews_TemplateAvatarImage_Previews: PreviewProvider {
     static var previews: some View {
         PlaceholderAvatarImage(firstCharacter: "X", colorIndex: 1)

--- a/RiotSwiftUI/Modules/Common/Avatar/View/SpaceAvatarImage.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/View/SpaceAvatarImage.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import DesignKit
 
-@available(iOS 14.0, *)
 struct SpaceAvatarImage: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -73,7 +72,6 @@ struct SpaceAvatarImage: View {
     }
 }
 
-@available(iOS 14.0, *)
 extension SpaceAvatarImage {
     init(avatarData: AvatarInputProtocol, size: AvatarSize) {
         self.init(
@@ -85,7 +83,6 @@ extension SpaceAvatarImage {
     }
 }
 
-@available(iOS 14.0, *)
 struct LiveAvatarImage_Previews: PreviewProvider {
     static let mxContentUri = "fakeUri"
     static let name = "Alice"

--- a/RiotSwiftUI/Modules/Common/Avatar/ViewModel/AvatarServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/ViewModel/AvatarServiceProtocol.swift
@@ -22,6 +22,5 @@ import UIKit
 
 /// Provides a simple api to retrieve and cache avatar images
 protocol AvatarServiceProtocol {
-    @available(iOS 14.0, *)
     func avatarImage(mxContentUri: String, avatarSize: AvatarSize) -> Future<UIImage, Error>
 }

--- a/RiotSwiftUI/Modules/Common/Avatar/ViewModel/AvatarViewModel.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/ViewModel/AvatarViewModel.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import DesignKit
 
-@available(iOS 14.0, *)
 /// Simple ViewModel that supports loading an avatar image
 class AvatarViewModel: InjectableObject, ObservableObject {
     

--- a/RiotSwiftUI/Modules/Common/Bridging/VectorContentView.swift
+++ b/RiotSwiftUI/Modules/Common/Bridging/VectorContentView.swift
@@ -19,7 +19,6 @@ import SwiftUI
 /// A Modifier to be called from the top-most SwiftUI view before being added to a HostViewController.
 ///
 /// Provides any app level configuration the SwiftUI hierarchy might need (E.g. to monitor theme changes).
-@available(iOS 14.0, *)
 struct VectorContentModifier: ViewModifier {
     
     @ObservedObject private var themePublisher = ThemePublisher.shared
@@ -38,7 +37,6 @@ struct VectorContentModifier: ViewModifier {
     }
 }
 
-@available(iOS 14.0, *)
 extension View {
     func vectorContent() -> some View {
         self.modifier(VectorContentModifier())

--- a/RiotSwiftUI/Modules/Common/DependencyInjection/DependencyContainerKey.swift
+++ b/RiotSwiftUI/Modules/Common/DependencyInjection/DependencyContainerKey.swift
@@ -25,7 +25,6 @@ private struct DependencyContainerKey: EnvironmentKey {
     static let defaultValue = DependencyContainer()
 }
 
-@available(iOS 14.0, *)
 extension EnvironmentValues {
     var dependencies: DependencyContainer {
         get { self[DependencyContainerKey.self] }
@@ -33,7 +32,6 @@ extension EnvironmentValues {
     }
 }
 
-@available(iOS 14.0, *)
 extension View {
     
     /// A modifier for adding a dependency to the SwiftUI view hierarchy's dependency container.

--- a/RiotSwiftUI/Modules/Common/EffectsScene/EffectsScene.swift
+++ b/RiotSwiftUI/Modules/Common/EffectsScene/EffectsScene.swift
@@ -17,7 +17,6 @@
 import SceneKit
 import SwiftUI
 
-@available(iOS 14.0, *)
 class EffectsScene: SCNScene {
     
     // MARK: - Constants
@@ -61,7 +60,6 @@ class EffectsScene: SCNScene {
     }
 }
 
-@available(iOS 14.0, *)
 fileprivate extension Color {
     /// The color's components as an array of floats in the extended linear sRGB colorspace.
     ///

--- a/RiotSwiftUI/Modules/Common/EffectsScene/EffectsView.swift
+++ b/RiotSwiftUI/Modules/Common/EffectsScene/EffectsView.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import SceneKit
 
-@available(iOS 14.0, *)
 /// A SwiftUI wrapper around `SCNView`, that unlike `SceneView` allows the
 /// scene to have a transparent background and be rendered on top of other views.
 struct EffectsView: UIViewRepresentable {

--- a/RiotSwiftUI/Modules/Common/Extensions/Publisher.swift
+++ b/RiotSwiftUI/Modules/Common/Extensions/Publisher.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 extension Publisher where Failure == Never {
     /// Same as `assign(to:on:)` but maintains a weak reference to object
     ///

--- a/RiotSwiftUI/Modules/Common/Mock/MockAppScreens.swift
+++ b/RiotSwiftUI/Modules/Common/Mock/MockAppScreens.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 /// The static list of mocked screens in RiotSwiftUI
-@available(iOS 14.0, *)
 enum MockAppScreens {
     static let appScreens: [MockScreenState.Type] = [
         MockLiveLocationSharingViewerScreenState.self,

--- a/RiotSwiftUI/Modules/Common/Mock/MockScreenState.swift
+++ b/RiotSwiftUI/Modules/Common/Mock/MockScreenState.swift
@@ -17,14 +17,12 @@
 import SwiftUI
 
 /// Used for mocking top level screens and their various states.
-@available(iOS 14.0, *)
 protocol MockScreenState {
     static var screenStates: [MockScreenState] { get }
     var screenType: Any.Type { get }
     var screenView: ([Any], AnyView) { get }
 }
 
-@available(iOS 14.0, *)
 extension MockScreenState {
     
     /// Get a list of the screens for every screen state.
@@ -60,7 +58,6 @@ extension MockScreenState {
     }
 }
 
-@available(iOS 14.0, *)
 extension MockScreenState where Self: CaseIterable {
     static var screenStates: [MockScreenState] {
         return Array(self.allCases)

--- a/RiotSwiftUI/Modules/Common/Mock/ScreenList.swift
+++ b/RiotSwiftUI/Modules/Common/Mock/ScreenList.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct ScreenList: View {
     
     private var allStates: [ScreenStateInfo]
@@ -49,7 +48,6 @@ struct ScreenList: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct ScreenList_Previews: PreviewProvider {
     static var previews: some View {
         ScreenList(screens: [MockTemplateUserProfileScreenState.self])

--- a/RiotSwiftUI/Modules/Common/Mock/ScreenStateInfo.swift
+++ b/RiotSwiftUI/Modules/Common/Mock/ScreenStateInfo.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct ScreenStateInfo {
     var dependencies: [Any]
     var view: AnyView

--- a/RiotSwiftUI/Modules/Common/Mock/StateRenderer.swift
+++ b/RiotSwiftUI/Modules/Common/Mock/StateRenderer.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 class StateRenderer {
     var states: [ScreenStateInfo]
     init(states: [ScreenStateInfo]) {

--- a/RiotSwiftUI/Modules/Common/Test/UI/MockScreenTest.swift
+++ b/RiotSwiftUI/Modules/Common/Test/UI/MockScreenTest.swift
@@ -21,7 +21,6 @@ import RiotSwiftUI
 /// Creates a test case for each screen state, launches the app,
 /// goes to the correct screen and provides the state and key for each
 /// invocation of the test.
-@available(iOS 14.0, *)
 class MockScreenTest: XCTestCase {
     
     enum Constants {

--- a/RiotSwiftUI/Modules/Common/Test/XCTestPublisherExtensions.swift
+++ b/RiotSwiftUI/Modules/Common/Test/XCTestPublisherExtensions.swift
@@ -17,7 +17,6 @@
 import XCTest
 import Combine
 
-@available(iOS 14.0, *)
 extension XCTestCase {
     /// XCTest utility to wait for results from publishers, so that the output can be used for assertions.
     ///

--- a/RiotSwiftUI/Modules/Common/Theme/ThemeIdentifierExtensions.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/ThemeIdentifierExtensions.swift
@@ -17,7 +17,6 @@
 import Foundation
 import DesignKit
 
-@available(iOS 14.0, *)
 extension ThemeIdentifier {
     fileprivate static let defaultTheme = DefaultThemeSwiftUI()
     fileprivate static let darkTheme = DarkThemeSwiftUI()

--- a/RiotSwiftUI/Modules/Common/Theme/ThemeKey.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/ThemeKey.swift
@@ -18,12 +18,10 @@ import Foundation
 import SwiftUI
 import DesignKit
 
-@available(iOS 14.0, *)
 private struct ThemeKey: EnvironmentKey {
     static let defaultValue = ThemePublisher.shared.theme
 }
 
-@available(iOS 14.0, *)
 extension EnvironmentValues {
   var theme: ThemeSwiftUI {
     get { self[ThemeKey.self] }
@@ -31,7 +29,6 @@ extension EnvironmentValues {
   }
 }
 
-@available(iOS 14.0, *)
 extension View {
     /// A theme modifier for setting the theme for this view and all its descendants in the hierarchy.
     /// - Parameter theme: A theme to be set as the environment value.
@@ -41,7 +38,6 @@ extension View {
   }
 }
 
-@available(iOS 14.0, *)
 extension View {
     /// A theme modifier for setting the theme by id for this view and all its descendants in the hierarchy.
     /// - Parameter themeId: ThemeIdentifier of a theme to be set as the environment value.

--- a/RiotSwiftUI/Modules/Common/Theme/ThemePublisher.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/ThemePublisher.swift
@@ -21,7 +21,6 @@ import Combine
 ///
 /// Replaces the old ThemeObserver. Riot app can push updates to this class
 /// removing the dependency of this class on the `ThemeService`.
-@available(iOS 14.0, *)
 class ThemePublisher: ObservableObject {
     
     private static var _shared: ThemePublisher? = nil

--- a/RiotSwiftUI/Modules/Common/Theme/ThemeSwiftUI.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/ThemeSwiftUI.swift
@@ -17,7 +17,6 @@
 import Foundation
 import DesignKit
 
-@available(iOS 14.0, *)
 protocol ThemeSwiftUI: ThemeSwiftUIType {
     var identifier: ThemeIdentifier { get }
     var isDark: Bool { get }

--- a/RiotSwiftUI/Modules/Common/Theme/ThemeUsersColorsExtension.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/ThemeUsersColorsExtension.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 extension ThemeSwiftUI {
     
     /// Get the stable display user color based on userId.

--- a/RiotSwiftUI/Modules/Common/Theme/Themes/DarkThemeSwiftUI.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/Themes/DarkThemeSwiftUI.swift
@@ -17,7 +17,6 @@
 import Foundation
 import DesignKit
 
-@available(iOS 14.0, *)
 struct DarkThemeSwiftUI: ThemeSwiftUI {
     var identifier: ThemeIdentifier = .dark
     let isDark: Bool = true

--- a/RiotSwiftUI/Modules/Common/Theme/Themes/DefaultThemeSwiftUI.swift
+++ b/RiotSwiftUI/Modules/Common/Theme/Themes/DefaultThemeSwiftUI.swift
@@ -17,7 +17,6 @@
 import Foundation
 import DesignKit
 
-@available(iOS 14.0, *)
 struct DefaultThemeSwiftUI: ThemeSwiftUI {
     var identifier: ThemeIdentifier = .light
     let isDark: Bool = false

--- a/RiotSwiftUI/Modules/Common/Util/BorderModifier.swift
+++ b/RiotSwiftUI/Modules/Common/Util/BorderModifier.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct BorderModifier<Shape: InsettableShape>: ViewModifier {
     
     var color: Color
@@ -29,7 +28,6 @@ struct BorderModifier<Shape: InsettableShape>: ViewModifier {
     }
 }
 
-@available(iOS 14.0, *)
 extension View {
     func shapedBorder<Shape: InsettableShape>(color: Color, borderWidth: CGFloat, shape: Shape) -> some View {
         modifier(BorderModifier(color: color, borderWidth: borderWidth, shape: shape))

--- a/RiotSwiftUI/Modules/Common/Util/BorderedInputFieldStyle.swift
+++ b/RiotSwiftUI/Modules/Common/Util/BorderedInputFieldStyle.swift
@@ -18,7 +18,6 @@ import Foundation
 import SwiftUI
 import Introspect
 
-@available(iOS 14.0, *)
 /// A bordered style of text input
 ///
 /// As defined in:
@@ -90,7 +89,6 @@ struct BorderedInputFieldStyle: TextFieldStyle {
     }
 }
 
-@available(iOS 14.0, *)
 struct BorderedInputFieldStyle_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/Util/InlineTextButton.swift
+++ b/RiotSwiftUI/Modules/Common/Util/InlineTextButton.swift
@@ -78,7 +78,6 @@ struct InlineTextButton: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct Previews_InlineButtonText_Previews: PreviewProvider {
     static var previews: some View {
         InlineTextButton("Hello there this is a sentence. %@.",

--- a/RiotSwiftUI/Modules/Common/Util/MultilineTextField.swift
+++ b/RiotSwiftUI/Modules/Common/Util/MultilineTextField.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct MultilineTextField: View {
     
     @Environment(\.theme) private var theme: ThemeSwiftUI
@@ -92,7 +91,6 @@ struct MultilineTextField: View {
     }
 }
 
-@available(iOS 14.0, *)
 fileprivate struct UITextViewWrapper: UIViewRepresentable {
     typealias UIViewType = UITextView
 
@@ -172,7 +170,6 @@ fileprivate struct UITextViewWrapper: UIViewRepresentable {
     }
 }
 
-@available(iOS 14.0, *)
 struct MultilineTextField_Previews: PreviewProvider {
     
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Common/Util/OptionButton.swift
+++ b/RiotSwiftUI/Modules/Common/Util/OptionButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OptionButton: View {
     
     // MARK: - Style
@@ -70,7 +69,6 @@ struct OptionButton: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct OptionButton_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/Util/PrimaryActionButtonStyle.swift
+++ b/RiotSwiftUI/Modules/Common/Util/PrimaryActionButtonStyle.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct PrimaryActionButtonStyle: ButtonStyle {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
@@ -48,7 +47,6 @@ struct PrimaryActionButtonStyle: ButtonStyle {
     }
 }
 
-@available(iOS 14.0, *)
 struct PrimaryActionButtonStyle_Previews: PreviewProvider {
     static var buttons: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/Util/RadioButton.swift
+++ b/RiotSwiftUI/Modules/Common/Util/RadioButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RadioButton: View {
     
     // MARK: - Properties
@@ -51,7 +50,6 @@ struct RadioButton: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct RadioButton_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextEditor.swift
+++ b/RiotSwiftUI/Modules/Common/Util/RoundedBorderTextEditor.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoundedBorderTextEditor: View {
     
     // MARK: - Properties
@@ -100,7 +99,6 @@ struct RoundedBorderTextEditor: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct ThemableTextEditor_Previews: PreviewProvider {
     static var previews: some View {
 

--- a/RiotSwiftUI/Modules/Common/Util/RoundedCornerShape.swift
+++ b/RiotSwiftUI/Modules/Common/Util/RoundedCornerShape.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoundedCornerShape: Shape {
 
     let radius: CGFloat

--- a/RiotSwiftUI/Modules/Common/Util/SafeBindingCollectionEnumerator.swift
+++ b/RiotSwiftUI/Modules/Common/Util/SafeBindingCollectionEnumerator.swift
@@ -21,7 +21,6 @@ import SwiftUI
  https://stackoverflow.com/q/65375372
  Replace with Swift 5.5 bindings enumerator later.
  */
-@available(iOS 14.0, *)
 struct SafeBindingCollectionEnumerator<T: RandomAccessCollection & MutableCollection, C: View>: View {
     
     typealias BoundElement = Binding<T.Element>

--- a/RiotSwiftUI/Modules/Common/Util/ScreenTrackerViewModifier.swift
+++ b/RiotSwiftUI/Modules/Common/Util/ScreenTrackerViewModifier.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// `ScreenTrackerViewModifier` is a helper class used to track PostHog screen from SwiftUI screens.
 struct ScreenTrackerViewModifier: ViewModifier {
     let screen: AnalyticsScreen
@@ -32,7 +31,6 @@ struct ScreenTrackerViewModifier: ViewModifier {
     }
 }
 
-@available(iOS 14.0, *)
 extension View {
     func track(screen: AnalyticsScreen) -> some View {
         return self.modifier(ScreenTrackerViewModifier(screen: screen))

--- a/RiotSwiftUI/Modules/Common/Util/SearchBar.swift
+++ b/RiotSwiftUI/Modules/Common/Util/SearchBar.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SearchBar: View {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Common/Util/SecondaryActionButtonStyle.swift
+++ b/RiotSwiftUI/Modules/Common/Util/SecondaryActionButtonStyle.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SecondaryActionButtonStyle: ButtonStyle {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
@@ -41,7 +40,6 @@ struct SecondaryActionButtonStyle: ButtonStyle {
     }
 }
 
-@available(iOS 14.0, *)
 struct SecondaryActionButtonStyle_Previews: PreviewProvider {
     static var theme: ThemeSwiftUI = DefaultThemeSwiftUI()
     

--- a/RiotSwiftUI/Modules/Common/Util/StyledText.swift
+++ b/RiotSwiftUI/Modules/Common/Util/StyledText.swift
@@ -81,7 +81,6 @@ struct StyledText: View {
 }
 
 
-@available(iOS 14.0, *)
 struct StyledText_Previews: PreviewProvider {
     static func prettyText() -> NSAttributedString {
         let string = NSMutableAttributedString(string: "T", attributes: [

--- a/RiotSwiftUI/Modules/Common/Util/ThemableButton.swift
+++ b/RiotSwiftUI/Modules/Common/Util/ThemableButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct ThemableButton: View {
     
     // MARK: - Style
@@ -64,7 +63,6 @@ struct ThemableButton: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct ThemableButton_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/Util/ThemableNavigationBar.swift
+++ b/RiotSwiftUI/Modules/Common/Util/ThemableNavigationBar.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct ThemableNavigationBar: View {
     
     // MARK: - Style
@@ -65,7 +64,6 @@ struct ThemableNavigationBar: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct NavigationBar_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/Util/ThemableTextEditor.swift
+++ b/RiotSwiftUI/Modules/Common/Util/ThemableTextEditor.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 
-@available(iOS 14.0, *)
 struct ThemableTextEditor: UIViewRepresentable {
     
     // MARK: Properties
@@ -128,7 +127,6 @@ struct ThemableTextEditor: UIViewRepresentable {
 
 // MARK: - modifiers
 
-@available(iOS 14.0, *)
 extension ThemableTextEditor {
     func keyboardType(_ type: UIKeyboardType) -> ThemableTextEditor {
         textView.keyboardType = type

--- a/RiotSwiftUI/Modules/Common/Util/WaitOverlay.swift
+++ b/RiotSwiftUI/Modules/Common/Util/WaitOverlay.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 /// A modifier for showing the wait overlay view over a view.
 struct WaitOverlayModifier: ViewModifier {
     
@@ -34,16 +33,13 @@ struct WaitOverlayModifier: ViewModifier {
     }
 }
 
-@available(iOS 14.0, *)
 extension View {
-    @available(iOS 14.0, *)
     func waitOverlay(show: Bool, message: String? = nil, allowUserInteraction: Bool = true) -> some View {
         self.modifier(WaitOverlayModifier(allowUserInteraction: allowUserInteraction, show: show, message: message))
     }
 }
 
 /// `WaitOverlay` allows to easily add an overlay that covers the entire with an `ActivityIndicator` at the center
-@available(iOS 14.0, *)
 struct WaitOverlay: ViewModifier {
     // MARK: - Properties
     
@@ -103,7 +99,6 @@ struct WaitOverlay: ViewModifier {
     }
 }
 
-@available(iOS 14.0, *)
 struct WaitOverlay_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Common/ViewFrameReader/FramePreferenceKey.swift
+++ b/RiotSwiftUI/Modules/Common/ViewFrameReader/FramePreferenceKey.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 /// A SwiftUI `PreferenceKey` for `CGRect` values such as a view's frame.
-@available(iOS 14.0, *)
 struct FramePreferenceKey: PreferenceKey {
     static var defaultValue: CGRect = .zero
     

--- a/RiotSwiftUI/Modules/Common/ViewFrameReader/ViewFrameReader.swift
+++ b/RiotSwiftUI/Modules/Common/ViewFrameReader/ViewFrameReader.swift
@@ -26,7 +26,6 @@ import SwiftUI
 /// SomeView()
 ///    .background(ViewFrameReader(frame: $frame))
 /// ```
-@available(iOS 14.0, *)
 struct ViewFrameReader: View {
     @Binding var frame: CGRect
     

--- a/RiotSwiftUI/Modules/Common/ViewModel/StateStoreViewModel.swift
+++ b/RiotSwiftUI/Modules/Common/ViewModel/StateStoreViewModel.swift
@@ -33,7 +33,6 @@ import Combine
 /// A similar approach is taken in libraries like [CombineFeedback](https://github.com/sergdort/CombineFeedback).
 /// It provides a nice layer of consistency and also safety. As we are not passing the `ViewModel` to the view directly, shortcuts/hacks
 /// can't be made into the `ViewModel`.
-@available(iOS 14, *)
 @dynamicMemberLookup
 class ViewModelContext<ViewState:BindableState, ViewAction>: ObservableObject {
     // MARK: - Properties
@@ -75,7 +74,6 @@ class ViewModelContext<ViewState:BindableState, ViewAction>: ObservableObject {
 /// a specific portion of state that can be safely bound to.
 /// If we decide to add more features to our state management (like doing state processing off the main thread)
 /// we can do it in this centralised place.
-@available(iOS 14, *)
 class StateStoreViewModel<State: BindableState, StateAction, ViewAction> {
 
     typealias Context = ViewModelContext<State, ViewAction>

--- a/RiotSwiftUI/Modules/Onboarding/Common/OnboardingIcon.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Common/OnboardingIcon.swift
@@ -35,7 +35,6 @@ struct OnboardingIconImage: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct OnboardingIconImage_Previews: PreviewProvider {
     static var previews: some View {
         OnboardingIconImage(image: Asset.Images.authenticationEmailIcon)

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Coordinator/LiveLocationSharingViewerCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Coordinator/LiveLocationSharingViewerCoordinator.swift
@@ -44,7 +44,6 @@ final class LiveLocationSharingViewerCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: LiveLocationSharingViewerCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/LiveLocationSharingViewerModels.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/LiveLocationSharingViewerModels.swift
@@ -29,7 +29,6 @@ enum LiveLocationSharingViewerViewModelResult {
 
 // MARK: View
 
-@available(iOS 14, *)
 struct LiveLocationSharingViewerViewState: BindableState {
     
     /// Map style URL

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
@@ -18,11 +18,9 @@ import SwiftUI
 import Combine
 import Mapbox
 
-@available(iOS 14, *)
 typealias LiveLocationSharingViewerViewModelType = StateStoreViewModel<LiveLocationSharingViewerViewState,
                                                                  Never,
                                                                  LiveLocationSharingViewerViewAction>
-@available(iOS 14, *)
 class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType, LiveLocationSharingViewerViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/LiveLocationSharingViewerViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/LiveLocationSharingViewerViewModelProtocol.swift
@@ -19,6 +19,5 @@ import Foundation
 protocol LiveLocationSharingViewerViewModelProtocol {
     
     var completion: ((LiveLocationSharingViewerViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: LiveLocationSharingViewerViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/MockLiveLocationSharingViewerScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/MockLiveLocationSharingViewerScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockLiveLocationSharingViewerScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Service/LiveLocationSharingViewerServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Service/LiveLocationSharingViewerServiceProtocol.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import CoreLocation
 
-@available(iOS 14.0, *)
 protocol LiveLocationSharingViewerServiceProtocol {
     
     /// All shared users live location

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Service/MatrixSDK/LiveLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Service/MatrixSDK/LiveLocationSharingViewerService.swift
@@ -18,7 +18,6 @@ import Foundation
 import CoreLocation
 import MatrixSDK
 
-@available(iOS 14.0, *)
 class LiveLocationSharingViewerService: LiveLocationSharingViewerServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Service/Mock/MockLiveLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Service/Mock/MockLiveLocationSharingViewerService.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import CoreLocation
 
-@available(iOS 14.0, *)
 class MockLiveLocationSharingViewerService: LiveLocationSharingViewerServiceProtocol {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Test/UI/LiveLocationSharingViewerUITests.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Test/UI/LiveLocationSharingViewerUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class LiveLocationSharingViewerUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Test/Unit/LiveLocationSharingViewerViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/Test/Unit/LiveLocationSharingViewerViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class LiveLocationSharingViewerViewModelTests: XCTestCase {
     
     var service: MockLiveLocationSharingViewerService!

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/View/LiveLocationListItem.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/View/LiveLocationListItem.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct LiveLocationListItem: View {
     
     // MARK: - Properties
@@ -121,7 +120,6 @@ struct LiveLocationListItem: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct LiveLocationListPreview: View {
     
     let liveLocationSharingViewerService: LiveLocationSharingViewerServiceProtocol = MockLiveLocationSharingViewerService()
@@ -181,7 +179,6 @@ struct LiveLocationListPreview: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct LiveLocationListItem_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
+++ b/RiotSwiftUI/Modules/Room/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import DSBottomSheet
 
-@available(iOS 14.0, *)
 struct LiveLocationSharingViewer: View {
 
     // MARK: - Properties
@@ -90,7 +89,6 @@ struct LiveLocationSharingViewer: View {
 }
 
 // MARK: - Bottom sheet
-@available(iOS 14.0, *)
 extension LiveLocationSharingViewer {
 
     var sheetStyle: BottomSheetStyle {
@@ -119,7 +117,6 @@ extension LiveLocationSharingViewer {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct LiveLocationSharingViewer_Previews: PreviewProvider {
     static let stateRenderer = MockLiveLocationSharingViewerScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/LocationSharing/Coordinator/LocationSharingCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/Coordinator/LocationSharingCoordinator.swift
@@ -91,11 +91,6 @@ final class LocationSharingCoordinator: Coordinator, Presentable {
     
     // MARK: - Public
     func start() {
-        guard #available(iOS 14.0, *) else {
-            MXLog.error("[LocationSharingCoordinator] start: Invalid iOS version, returning.")
-            return
-        }
-        
         locationSharingViewModel.completion = { [weak self] result in
             guard let self = self else { return }
             

--- a/RiotSwiftUI/Modules/Room/LocationSharing/Coordinator/LocationSharingCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/Coordinator/LocationSharingCoordinator.swift
@@ -73,7 +73,6 @@ final class LocationSharingCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: LocationSharingCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
@@ -55,7 +55,6 @@ enum LocationSharingViewError {
     case failedSharingLocation
 }
 
-@available(iOS 14, *)
 struct LocationSharingViewState: BindableState {
     
     /// Map style URL

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingScreenState.swift
@@ -18,7 +18,6 @@ import Foundation
 import SwiftUI
 import CoreLocation
 
-@available(iOS 14.0, *)
 enum MockLocationSharingScreenState: MockScreenState, CaseIterable {
     case shareUserLocation
     

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingViewModel.swift
@@ -18,11 +18,9 @@ import SwiftUI
 import Combine
 import CoreLocation
 
-@available(iOS 14, *)
 typealias LocationSharingViewModelType = StateStoreViewModel<LocationSharingViewState,
                                                              Never,
                                                              LocationSharingViewAction>
-@available(iOS 14, *)
 class LocationSharingViewModel: LocationSharingViewModelType, LocationSharingViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/LocationSharing/Service/Mock/MockLocationSharingService.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/Service/Mock/MockLocationSharingService.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import CoreLocation
 
-@available(iOS 14.0, *)
 class MockLocationSharingService: LocationSharingServiceProtocol {
     func requestAuthorization(_ handler: @escaping LocationAuthorizationHandler) {
         handler(.authorizedAlways)

--- a/RiotSwiftUI/Modules/Room/LocationSharing/Test/UI/LocationSharingUITests.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/Test/UI/LocationSharingUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class LocationSharingUITests: XCTestCase {
     
     private var app: XCUIApplication!

--- a/RiotSwiftUI/Modules/Room/LocationSharing/Test/Unit/LocationSharingViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/Test/Unit/LocationSharingViewModelTests.swift
@@ -20,7 +20,6 @@ import CoreLocation
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class LocationSharingViewModelTests: XCTestCase {
     
     var cancellables = Set<AnyCancellable>()

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingMapView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingMapView.swift
@@ -18,7 +18,6 @@ import SwiftUI
 import Combine
 import Mapbox
 
-@available(iOS 14, *)
 struct LocationSharingMapView: UIViewRepresentable {
     
     // MARK: - Constants
@@ -109,7 +108,6 @@ struct LocationSharingMapView: UIViewRepresentable {
 }
 
 // MARK: - Coordinator
-@available(iOS 14, *)
 extension LocationSharingMapView {
     
     class Coordinator: NSObject, MGLMapViewDelegate, UIGestureRecognizerDelegate {

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingMarkerView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingMarkerView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct LocationSharingMarkerView<Content: View>: View {
     
     // MARK: - Properties
@@ -45,7 +44,6 @@ struct LocationSharingMarkerView<Content: View>: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct LocationSharingUserMarkerView_Previews: PreviewProvider {
     static var previews: some View {
         let avatarData = AvatarInput(mxContentUri: "",

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingOptionButton.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingOptionButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct LocationSharingOptionButton<Content: View>: View {
     
     // MARK: - Properties
@@ -42,7 +41,6 @@ struct LocationSharingOptionButton<Content: View>: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct LocationSharingOptionButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment: .leading) {

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/LocationSharingView.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 import CoreLocation
 
-@available(iOS 14.0, *)
 struct LocationSharingView: View {
     
     // MARK: - Properties
@@ -164,7 +163,6 @@ struct LocationSharingView: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct LocationSharingView_Previews: PreviewProvider {
     static let stateRenderer = MockLocationSharingScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/MapCreditsView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/MapCreditsView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct MapCreditsView: View {
     
     // MARK: - Properties
@@ -36,7 +35,6 @@ struct MapCreditsView: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct MapCreditsView_Previews: PreviewProvider {
     static var previews: some View {
         MapCreditsView()

--- a/RiotSwiftUI/Modules/Room/LocationSharing/View/UserLocationAnnotationView.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/View/UserLocationAnnotationView.swift
@@ -18,7 +18,6 @@ import Foundation
 import SwiftUI
 import Mapbox
 
-@available(iOS 14, *)
 class LocationAnnotationView: MGLUserLocationAnnotationView {
     
     // MARK: - Constants

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/Coordinator/RoomNotificationSettingsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/Coordinator/RoomNotificationSettingsCoordinator.swift
@@ -37,45 +37,21 @@ final class RoomNotificationSettingsCoordinator: RoomNotificationSettingsCoordin
     
     init(room: MXRoom, presentedModally: Bool = true) {
         let roomNotificationService = MXRoomNotificationSettingsService(room: room)
-        let avatarData: AvatarProtocol?
         let showAvatar = presentedModally
-        if #available(iOS 14.0.0, *) {
-            avatarData = showAvatar ? AvatarInput(
-                mxContentUri: room.summary.avatar,
-                matrixItemId: room.roomId,
-                displayName: room.summary.displayname
-            ) : nil
-        } else {
-            avatarData = showAvatar ? RoomAvatarViewData(
-                roomId: room.roomId,
-                displayName: room.summary.displayname,
-                avatarUrl: room.summary.avatar,
-                mediaManager: room.mxSession.mediaManager
-            ) : nil
-        }
-        
-        let viewModel: RoomNotificationSettingsViewModel
-        let viewController: UIViewController
-        if #available(iOS 14.0.0, *) {
-            let swiftUIViewModel = RoomNotificationSettingsSwiftUIViewModel(
-                roomNotificationService: roomNotificationService,
-                avatarData: avatarData,
-                displayName: room.summary.displayname,
-                roomEncrypted: room.summary.isEncrypted)
-            let avatarService: AvatarServiceProtocol = AvatarService(mediaManager: room.mxSession.mediaManager)
-            let view = RoomNotificationSettings(viewModel: swiftUIViewModel, presentedModally: presentedModally)
-                .addDependency(avatarService)
-            let host = VectorHostingController(rootView: view)
-            viewModel = swiftUIViewModel
-            viewController = host
-        } else {
-            viewModel = RoomNotificationSettingsViewModel(
-                roomNotificationService: roomNotificationService,
-                avatarData: avatarData,
-                displayName: room.summary.displayname,
-                roomEncrypted: room.summary.isEncrypted)
-            viewController = RoomNotificationSettingsViewController.instantiate(with: viewModel)
-        }
+        let avatarData = showAvatar ? AvatarInput(
+            mxContentUri: room.summary.avatar,
+            matrixItemId: room.roomId,
+            displayName: room.summary.displayname
+        ) : nil
+        let viewModel = RoomNotificationSettingsSwiftUIViewModel(
+            roomNotificationService: roomNotificationService,
+            avatarData: avatarData,
+            displayName: room.summary.displayname,
+            roomEncrypted: room.summary.isEncrypted)
+        let avatarService: AvatarServiceProtocol = AvatarService(mediaManager: room.mxSession.mediaManager)
+        let view = RoomNotificationSettings(viewModel: viewModel, presentedModally: presentedModally)
+            .addDependency(avatarService)
+        let viewController = VectorHostingController(rootView: view)
         self.roomNotificationSettingsViewModel = viewModel
         self.roomNotificationSettingsViewController = viewController
     }

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormItemButtonStyle.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormItemButtonStyle.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct FormItemButtonStyle: ButtonStyle {
     @Environment(\.theme) var theme: ThemeSwiftUI
     func makeBody(configuration: Self.Configuration) -> some View {

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormPickerItem.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormPickerItem.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct FormPickerItem: View {
     
     typealias TapCallback = () -> Void
@@ -53,7 +52,6 @@ struct FormPickerItem: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct FormPickerItem_Previews: PreviewProvider {
     
     static let items = ["Item 1", "Item 2", "Item 3"]

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormSectionFooter.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormSectionFooter.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct FormSectionFooter: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -32,7 +31,6 @@ struct FormSectionFooter: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct FormSectionFooter_Previews: PreviewProvider {
     static var previews: some View {
         VectorForm {

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormSectionHeader.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/FormSectionHeader.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct FormSectionHeader: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -34,7 +33,6 @@ struct FormSectionHeader: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct FormSectionHeader_Previews: PreviewProvider {
     static var previews: some View {
         VectorForm {

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/RoomNotificationSettings.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/RoomNotificationSettings.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0.0, *)
 struct RoomNotificationSettings: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -74,7 +73,6 @@ struct RoomNotificationSettings: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct RoomNotificationSettings_Previews: PreviewProvider {
     
     static let mockViewModel = RoomNotificationSettingsSwiftUIViewModel(

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/RoomNotificationSettingsHeader.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/RoomNotificationSettingsHeader.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomNotificationSettingsHeader: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -41,7 +40,6 @@ struct RoomNotificationSettingsHeader: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct RoomNotificationSettingsHeader_Previews: PreviewProvider {
     static let name = "Element"
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/View/VectorForm.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/View/VectorForm.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct VectorForm<Content: View>: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -43,7 +42,6 @@ struct VectorForm<Content: View>: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct VectorForm_Previews: PreviewProvider {
     
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/ViewModel/RoomNotificationSettingsSwiftUIViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/ViewModel/RoomNotificationSettingsSwiftUIViewModel.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class RoomNotificationSettingsSwiftUIViewModel: RoomNotificationSettingsViewModel, ObservableObject {
 
     @Published var viewState: RoomNotificationSettingsViewState

--- a/RiotSwiftUI/Modules/Room/PollEditForm/Coordinator/PollEditFormCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/Coordinator/PollEditFormCoordinator.swift
@@ -64,11 +64,6 @@ final class PollEditFormCoordinator: Coordinator, Presentable {
     
     // MARK: - Public
     func start() {
-        guard #available(iOS 14.0, *) else {
-            MXLog.error("[PollEditFormCoordinator] start: Invalid iOS version, returning.")
-            return
-        }
-        
         pollEditFormViewModel.completion = { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/RiotSwiftUI/Modules/Room/PollEditForm/Coordinator/PollEditFormCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/Coordinator/PollEditFormCoordinator.swift
@@ -41,7 +41,6 @@ final class PollEditFormCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: PollEditFormCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Room/PollEditForm/PollEditFormScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/PollEditFormScreenState.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 enum MockPollEditFormScreenState: MockScreenState, CaseIterable {
     case standard
     

--- a/RiotSwiftUI/Modules/Room/PollEditForm/PollEditFormViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/PollEditFormViewModel.swift
@@ -22,11 +22,9 @@ struct PollEditFormViewModelParameters {
     let pollDetails: EditFormPollDetails
 }
 
-@available(iOS 14, *)
 typealias PollEditFormViewModelType = StateStoreViewModel <PollEditFormViewState,
                                                            Never,
                                                            PollEditFormViewAction>
-@available(iOS 14, *)
 class PollEditFormViewModel: PollEditFormViewModelType, PollEditFormViewModelProtocol {
     
     private struct Constants {

--- a/RiotSwiftUI/Modules/Room/PollEditForm/Test/UI/PollEditFormUITests.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/Test/UI/PollEditFormUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class PollEditFormUITests: XCTestCase {
     
     private var app: XCUIApplication!

--- a/RiotSwiftUI/Modules/Room/PollEditForm/Test/Unit/PollEditFormViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/Test/Unit/PollEditFormViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class PollEditFormViewModelTests: XCTestCase {
     var viewModel: PollEditFormViewModel!
     var context: PollEditFormViewModelType.Context!

--- a/RiotSwiftUI/Modules/Room/PollEditForm/View/PollEditForm.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/View/PollEditForm.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct PollEditForm: View {
     
     // MARK: - Properties
@@ -128,7 +127,6 @@ struct PollEditForm: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct PollEditForm_Previews: PreviewProvider {
     static let stateRenderer = MockPollEditFormScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/PollEditForm/View/PollEditFormAnswerOptionView.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/View/PollEditFormAnswerOptionView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct PollEditFormAnswerOptionView: View {
     
     @Environment(\.theme) private var theme: ThemeSwiftUI
@@ -48,7 +47,6 @@ struct PollEditFormAnswerOptionView: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct PollEditFormAnswerOptionView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 32.0) {

--- a/RiotSwiftUI/Modules/Room/PollEditForm/View/PollEditFormTypePicker.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/View/PollEditFormTypePicker.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct PollEditFormTypePicker: View {
     @Environment(\.theme) private var theme: ThemeSwiftUI
     
@@ -33,7 +32,6 @@ struct PollEditFormTypePicker: View {
     }
 }
 
-@available(iOS 14.0, *)
 private struct PollEditFormTypeButton: View {
     @Environment(\.theme) private var theme: ThemeSwiftUI
     
@@ -87,7 +85,6 @@ private struct PollEditFormTypeButton: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct PollEditFormTypePicker_Previews: PreviewProvider {
     static var previews: some View {
         VStack {

--- a/RiotSwiftUI/Modules/Room/RoomAccess/Coordinator/RoomAccessCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/Coordinator/RoomAccessCoordinator.swift
@@ -25,7 +25,6 @@ enum RoomAccessCoordinatorCoordinatorAction {
 }
 
 @objcMembers
-@available(iOS 14.0, *)
 final class RoomAccessCoordinator: Coordinator {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/RoomAccess/Coordinator/RoomAccessCoordinatorBridgePresenter.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/Coordinator/RoomAccessCoordinatorBridgePresenter.swift
@@ -16,7 +16,6 @@
 import UIKit
 import MatrixSDK
 
-@available(iOS 14.0, *)
 @objc protocol RoomAccessCoordinatorBridgePresenterDelegate {
     func roomAccessCoordinatorBridgePresenterDelegate(_ coordinatorBridgePresenter: RoomAccessCoordinatorBridgePresenter, didCancelRoomWithId roomId: String)
     func roomAccessCoordinatorBridgePresenterDelegate(_ coordinatorBridgePresenter: RoomAccessCoordinatorBridgePresenter, didCompleteRoomWithId roomId: String)
@@ -27,7 +26,6 @@ import MatrixSDK
 /// It breaks the Coordinator abstraction and it has been introduced for Objective-C compatibility (mainly for integration in legacy view controllers).
 /// Each bridge should be removed once the underlying Coordinator has been integrated by another Coordinator.
 @objcMembers
-@available(iOS 14.0, *)
 final class RoomAccessCoordinatorBridgePresenter: NSObject {
     
     // MARK: - Properties
@@ -99,7 +97,6 @@ final class RoomAccessCoordinatorBridgePresenter: NSObject {
 
 // MARK: - UIAdaptivePresentationControllerDelegate
 
-@available(iOS 14.0, *)
 extension RoomAccessCoordinatorBridgePresenter: UIAdaptivePresentationControllerDelegate {
     
     func roomNotificationSettingsCoordinatorDidComplete(_ presentationController: UIPresentationController) {

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Coordinator/RoomAccessTypeChooserCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Coordinator/RoomAccessTypeChooserCoordinator.swift
@@ -40,7 +40,6 @@ final class RoomAccessTypeChooserCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: RoomAccessTypeChooserCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = RoomAccessTypeChooserViewModel(roomAccessTypeChooserService: RoomAccessTypeChooserService(roomId: parameters.roomId, allowsRoomUpgrade: parameters.allowsRoomUpgrade, session: parameters.session))

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/MockRoomAccessTypeChooserScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/MockRoomAccessTypeChooserScreenState.swift
@@ -20,7 +20,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockRoomAccessTypeChooserScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/RoomAccessTypeChooserViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/RoomAccessTypeChooserViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import Combine
     
-@available(iOS 14, *)
 typealias RoomAccessTypeChooserViewModelType = StateStoreViewModel<RoomAccessTypeChooserViewState,
                                                               RoomAccessTypeChooserStateAction,
                                                               RoomAccessTypeChooserViewAction>
-@available(iOS 14.0, *)
 class RoomAccessTypeChooserViewModel: RoomAccessTypeChooserViewModelType, RoomAccessTypeChooserViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/RoomAccessTypeChooserViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/RoomAccessTypeChooserViewModelProtocol.swift
@@ -18,7 +18,6 @@ import Foundation
 
 protocol RoomAccessTypeChooserViewModelProtocol {
     var callback: ((RoomAccessTypeChooserViewModelAction) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: RoomAccessTypeChooserViewModelType.Context { get }
     
     func handleRoomUpgradeResult(_ result: RoomUpgradeCoordinatorResult)

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/MatrixSDK/RoomAccessTypeChooserService.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/MatrixSDK/RoomAccessTypeChooserService.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import MatrixSDK
 
-@available(iOS 14.0, *)
 class RoomAccessTypeChooserService: RoomAccessTypeChooserServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/Mock/MockRoomAccessTypeChooserService.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/Mock/MockRoomAccessTypeChooserService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockRoomAccessTypeChooserService: RoomAccessTypeChooserServiceProtocol {
     
     static let mockAccessItems: [RoomAccessTypeChooserAccessItem] = [

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/RoomAccessTypeChooserServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/RoomAccessTypeChooserServiceProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol RoomAccessTypeChooserServiceProtocol {
     var accessItemsSubject: CurrentValueSubject<[RoomAccessTypeChooserAccessItem], Never> { get }
     var roomUpgradeRequiredSubject: CurrentValueSubject<Bool, Never> { get }

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Test/UI/RoomAccessTypeChooserUITests.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Test/UI/RoomAccessTypeChooserUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class RoomAccessTypeChooserUITests: MockScreenTest {
     // Tests to be implemented.
 }

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Test/Unit/RoomAccessTypeChooserViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Test/Unit/RoomAccessTypeChooserViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class RoomAccessTypeChooserViewModelTests: XCTestCase {
 
 }

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/View/RoomAccessTypeChooser.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/View/RoomAccessTypeChooser.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomAccessTypeChooser: View {
     
     // MARK: - Properties
@@ -84,7 +83,6 @@ struct RoomAccessTypeChooser: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct RoomAccessTypeChooser_Previews: PreviewProvider {
     
     static let stateRenderer = MockRoomAccessTypeChooserScreenState.stateRenderer

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/View/RoomAccessTypeChooserRow.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/View/RoomAccessTypeChooserRow.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomAccessTypeChooserRow: View {
 
     // MARK: - Properties
@@ -70,7 +69,6 @@ struct RoomAccessTypeChooserRow: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct RoomAccessTypeChooserRow_Previews: PreviewProvider {
     static var previews: some View {
         VStack {

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomRestrictedAccessSpaceChooser/Coordinator/RoomRestrictedAccessSpaceChooserViewProvider.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomRestrictedAccessSpaceChooser/Coordinator/RoomRestrictedAccessSpaceChooserViewProvider.swift
@@ -24,7 +24,6 @@ class RoomRestrictedAccessSpaceChooserViewProvider: MatrixItemChooserCoordinator
         self.navTitle = navTitle
     }
     
-    @available(iOS 14, *)
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView {
         return AnyView(RoomRestrictedAccessSpaceChooserSelector(viewModel: viewModel, navTitle: navTitle))
     }

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomRestrictedAccessSpaceChooser/View/RoomRestrictedAccessSpaceChooserSelector.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomRestrictedAccessSpaceChooser/View/RoomRestrictedAccessSpaceChooserSelector.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomRestrictedAccessSpaceChooserSelector: View {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Room/RoomSuggestion/Coordinator/RoomSuggestionCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/RoomSuggestion/Coordinator/RoomSuggestionCoordinator.swift
@@ -23,7 +23,6 @@ enum RoomSuggestionCoordinatorCoordinatorAction {
 }
 
 @objcMembers
-@available(iOS 14.0, *)
 final class RoomSuggestionCoordinator: Coordinator {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/RoomSuggestion/Coordinator/RoomSuggestionCoordinatorBridgePresenter.swift
+++ b/RiotSwiftUI/Modules/Room/RoomSuggestion/Coordinator/RoomSuggestionCoordinatorBridgePresenter.swift
@@ -15,7 +15,6 @@
 //
 import UIKit
 
-@available(iOS 14.0, *)
 @objc protocol RoomSuggestionCoordinatorBridgePresenterDelegate {
     func roomSuggestionCoordinatorBridgePresenterDelegateDidCancel(_ coordinatorBridgePresenter: RoomSuggestionCoordinatorBridgePresenter)
     func roomSuggestionCoordinatorBridgePresenterDelegateDidComplete(_ coordinatorBridgePresenter: RoomSuggestionCoordinatorBridgePresenter)
@@ -26,7 +25,6 @@ import UIKit
 /// It breaks the Coordinator abstraction and it has been introduced for Objective-C compatibility (mainly for integration in legacy view controllers).
 /// Each bridge should be removed once the underlying Coordinator has been integrated by another Coordinator.
 @objcMembers
-@available(iOS 14.0, *)
 final class RoomSuggestionCoordinatorBridgePresenter: NSObject {
     
     // MARK: - Properties
@@ -87,7 +85,6 @@ final class RoomSuggestionCoordinatorBridgePresenter: NSObject {
 
 // MARK: - UIAdaptivePresentationControllerDelegate
 
-@available(iOS 14.0, *)
 extension RoomSuggestionCoordinatorBridgePresenter: UIAdaptivePresentationControllerDelegate {
     
     func roomNotificationSettingsCoordinatorDidComplete(_ presentationController: UIPresentationController) {

--- a/RiotSwiftUI/Modules/Room/RoomSuggestion/RoomSuggestionSpaceChooser/Coordinator/RoomSuggestionSpaceChooserViewProvider.swift
+++ b/RiotSwiftUI/Modules/Room/RoomSuggestion/RoomSuggestionSpaceChooser/Coordinator/RoomSuggestionSpaceChooserViewProvider.swift
@@ -24,7 +24,6 @@ class RoomSuggestionSpaceChooserViewProvider: MatrixItemChooserCoordinatorViewPr
         self.navTitle = navTitle
     }
     
-    @available(iOS 14, *)
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView {
         return AnyView(RoomSuggestionSpaceChooserSelector(viewModel: viewModel, navTitle: navTitle))
     }

--- a/RiotSwiftUI/Modules/Room/RoomSuggestion/RoomSuggestionSpaceChooser/View/RoomSuggestionSpaceChooserSelector.swift
+++ b/RiotSwiftUI/Modules/Room/RoomSuggestion/RoomSuggestionSpaceChooser/View/RoomSuggestionSpaceChooserSelector.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomSuggestionSpaceChooserSelector: View {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/Coordinator/RoomUpgradeCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/Coordinator/RoomUpgradeCoordinator.swift
@@ -42,7 +42,6 @@ final class RoomUpgradeCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: RoomUpgradeCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = RoomUpgradeViewModel.makeRoomUpgradeViewModel(roomUpgradeService: RoomUpgradeService(session: parameters.session, roomId: parameters.roomId, parentSpaceId: parameters.parentSpaceId, versionOverride: parameters.versionOverride))

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/MockRoomUpgradeScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/MockRoomUpgradeScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockRoomUpgradeScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/RoomUpgradeViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/RoomUpgradeViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias RoomUpgradeViewModelType = StateStoreViewModel<RoomUpgradeViewState,
                                                                  Never,
                                                                  RoomUpgradeViewAction>
-@available(iOS 14, *)
 class RoomUpgradeViewModel: RoomUpgradeViewModelType, RoomUpgradeViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/RoomUpgradeViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/RoomUpgradeViewModelProtocol.swift
@@ -19,8 +19,6 @@ import Foundation
 protocol RoomUpgradeViewModelProtocol {
     
     var completion: ((RoomUpgradeViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     static func makeRoomUpgradeViewModel(roomUpgradeService: RoomUpgradeServiceProtocol) -> RoomUpgradeViewModelProtocol
-    @available(iOS 14, *)
     var context: RoomUpgradeViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/Service/MatrixSDK/RoomUpgradeService.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/Service/MatrixSDK/RoomUpgradeService.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import MatrixSDK
 
-@available(iOS 14.0, *)
 class RoomUpgradeService: RoomUpgradeServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/Service/Mock/MockRoomUpgradeService.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/Service/Mock/MockRoomUpgradeService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockRoomUpgradeService: RoomUpgradeServiceProtocol {
     var currentRoomId: String = "!sfdlksjdflkfjds:matrix.org"
     

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/Service/RoomUpgradeServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/Service/RoomUpgradeServiceProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol RoomUpgradeServiceProtocol {
     var currentRoomId: String { get }
     var parentSpaceName: String? { get }

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/Test/UI/RoomUpgradeUITests.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/Test/UI/RoomUpgradeUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class RoomUpgradeUITests: MockScreenTest {
     // Tests to be implemented.
 }

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/Test/Unit/RoomUpgradeViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/Test/Unit/RoomUpgradeViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class RoomUpgradeViewModelTests: XCTestCase {
     var service: MockRoomUpgradeService!
     var viewModel: RoomUpgradeViewModelProtocol!

--- a/RiotSwiftUI/Modules/Room/RoomUpgrade/View/RoomUpgrade.swift
+++ b/RiotSwiftUI/Modules/Room/RoomUpgrade/View/RoomUpgrade.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomUpgrade: View {
 
     // MARK: - Properties
@@ -102,7 +101,6 @@ struct RoomUpgrade: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct RoomUpgrade_Previews: PreviewProvider {
     static let stateRenderer = MockRoomUpgradeScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/Coordinator/StaticLocationViewingCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/Coordinator/StaticLocationViewingCoordinator.swift
@@ -46,7 +46,6 @@ final class StaticLocationViewingCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: StaticLocationViewingCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/MockStaticLocationViewingScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/MockStaticLocationViewingScreenState.swift
@@ -20,7 +20,6 @@ import CoreLocation
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockStaticLocationViewingScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/StaticLocationViewingModels.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/StaticLocationViewingModels.swift
@@ -32,7 +32,6 @@ enum StaticLocationViewingViewModelResult {
 
 // MARK: View
 
-@available(iOS 14, *)
 struct StaticLocationViewingViewState: BindableState {
     
     /// Map style URL

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import CoreLocation
 
-@available(iOS 14, *)
 typealias StaticLocationViewingViewModelType = StateStoreViewModel<StaticLocationViewingViewState,
                                                                   Never,
                                                                    StaticLocationViewingViewAction>
-@available(iOS 14, *)
 class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, StaticLocationViewingViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/StaticLocationViewingViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/StaticLocationViewingViewModelProtocol.swift
@@ -19,6 +19,5 @@ import Foundation
 protocol StaticLocationViewingViewModelProtocol {
     
     var completion: ((StaticLocationViewingViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: StaticLocationViewingViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/Test/UI/StaticLocationViewingUITests.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/Test/UI/StaticLocationViewingUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class StaticLocationViewingUITests: MockScreenTest {
     
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/Test/Unit/StaticLocationViewingViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/Test/Unit/StaticLocationViewingViewModelTests.swift
@@ -20,7 +20,6 @@ import CoreLocation
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class StaticLocationViewingViewModelTests: XCTestCase {
 
     var cancellables = Set<AnyCancellable>()

--- a/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/View/StaticLocationView.swift
+++ b/RiotSwiftUI/Modules/Room/StaticLocationSharingViewer/View/StaticLocationView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct StaticLocationView: View {
 
     // MARK: - Properties
@@ -89,7 +88,6 @@ struct StaticLocationView: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct StaticLocationSharingViewer_Previews: PreviewProvider {
     static let stateRenderer = MockStaticLocationViewingScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -24,7 +24,6 @@ struct TimelinePollCoordinatorParameters {
     let pollStartEvent: MXEvent
 }
 
-@available(iOS 14.0, *)
 final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDelegate {
     
     // MARK: - Properties
@@ -45,7 +44,6 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: TimelinePollCoordinatorParameters) throws {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
@@ -16,7 +16,6 @@
 
 import Foundation
 
-@available(iOS 14, *)
 class TimelinePollProvider {
     static let shared = TimelinePollProvider()
     

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Test/UI/TimelinePollUITests.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Test/UI/TimelinePollUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TimelinePollUITests: XCTestCase {
     
     private var app: XCUIApplication!

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Test/Unit/TimelinePollViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Test/Unit/TimelinePollViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class TimelinePollViewModelTests: XCTestCase {
     var viewModel: TimelinePollViewModel!
     var context: TimelinePollViewModelType.Context!

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 enum MockTimelinePollScreenState: MockScreenState, CaseIterable {
     case openDisclosed
     case closedDisclosed

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias TimelinePollViewModelType = StateStoreViewModel<TimelinePollViewState,
                                                           Never,
                                                           TimelinePollViewAction>
-@available(iOS 14, *)
 class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModelProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 protocol TimelinePollViewModelProtocol {
-    @available(iOS 14, *)
     var context: TimelinePollViewModelType.Context { get }
     var completion: ((TimelinePollViewModelResult) -> Void)? { get set }
     

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollAnswerOptionButton.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollAnswerOptionButton.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TimelinePollAnswerOptionButton: View {
     
     // MARK: - Properties
@@ -97,7 +96,6 @@ struct TimelinePollAnswerOptionButton: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct TimelinePollAnswerOptionButton_Previews: PreviewProvider {
     static let stateRenderer = MockTimelinePollScreenState.stateRenderer
     

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct TimelinePollView: View {
     
     // MARK: - Properties
@@ -94,7 +93,6 @@ struct TimelinePollView: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct TimelinePollView_Previews: PreviewProvider {
     static let stateRenderer = MockTimelinePollScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinator.swift
@@ -18,7 +18,6 @@ import Foundation
 import UIKit
 import SwiftUI
 
-@available(iOS 14.0, *)
 protocol UserSuggestionCoordinatorDelegate: AnyObject {
     func userSuggestionCoordinator(_ coordinator: UserSuggestionCoordinator, didRequestMentionForMember member: MXRoomMember, textTrigger: String?)
 }
@@ -28,7 +27,6 @@ struct UserSuggestionCoordinatorParameters {
     let room: MXRoom
 }
 
-@available(iOS 14.0, *)
 final class UserSuggestionCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties
@@ -52,7 +50,6 @@ final class UserSuggestionCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: UserSuggestionCoordinatorParameters) {
         self.parameters = parameters
         

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinatorBridge.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinatorBridge.swift
@@ -25,7 +25,6 @@ protocol UserSuggestionCoordinatorBridgeDelegate: AnyObject {
 final class UserSuggestionCoordinatorBridge: NSObject {
     
     private var _userSuggestionCoordinator: Any? = nil
-    @available(iOS 14.0, *)
     fileprivate var userSuggestionCoordinator: UserSuggestionCoordinator {
         return _userSuggestionCoordinator as! UserSuggestionCoordinator
     }
@@ -61,7 +60,6 @@ final class UserSuggestionCoordinatorBridge: NSObject {
     }
 }
 
-@available(iOS 14.0, *)
 extension UserSuggestionCoordinatorBridge: UserSuggestionCoordinatorDelegate {
     func userSuggestionCoordinator(_ coordinator: UserSuggestionCoordinator, didRequestMentionForMember member: MXRoomMember, textTrigger: String?) {
         delegate?.userSuggestionCoordinatorBridge(self, didRequestMentionForMember: member, textTrigger: textTrigger)

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinatorBridge.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinatorBridge.swift
@@ -33,30 +33,20 @@ final class UserSuggestionCoordinatorBridge: NSObject {
     
     init(mediaManager: MXMediaManager, room: MXRoom) {
         let parameters = UserSuggestionCoordinatorParameters(mediaManager: mediaManager, room: room)
-        if #available(iOS 14.0, *) {
-            let userSuggestionCoordinator = UserSuggestionCoordinator(parameters: parameters)
-            self._userSuggestionCoordinator = userSuggestionCoordinator
-        }
+        let userSuggestionCoordinator = UserSuggestionCoordinator(parameters: parameters)
+        self._userSuggestionCoordinator = userSuggestionCoordinator
         
         super.init()
         
-        if #available(iOS 14.0, *) {
-            userSuggestionCoordinator.delegate = self
-        }
+        userSuggestionCoordinator.delegate = self
     }
     
     func processTextMessage(_ textMessage: String) {
-        if #available(iOS 14.0, *) {
-            return self.userSuggestionCoordinator.processTextMessage(textMessage)
-        }
+        return self.userSuggestionCoordinator.processTextMessage(textMessage)
     }
     
     func toPresentable() -> UIViewController? {
-        if #available(iOS 14.0, *) {
-            return self.userSuggestionCoordinator.toPresentable()
-        }
-        
-        return nil
+        return self.userSuggestionCoordinator.toPresentable()
     }
 }
 

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Service/UserSuggestionService.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Service/UserSuggestionService.swift
@@ -33,7 +33,6 @@ struct UserSuggestionServiceItem: UserSuggestionItemProtocol {
     let avatarUrl: String?
 }
 
-@available(iOS 14.0, *)
 class UserSuggestionService: UserSuggestionServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Service/UserSuggestionServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Service/UserSuggestionServiceProtocol.swift
@@ -23,7 +23,6 @@ protocol UserSuggestionItemProtocol: Avatarable {
     var avatarUrl: String? { get }
 }
 
-@available(iOS 14.0, *)
 protocol UserSuggestionServiceProtocol {
     
     var items: CurrentValueSubject<[UserSuggestionItemProtocol], Never> { get }

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Test/UI/UserSuggestionUITests.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Test/UI/UserSuggestionUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class UserSuggestionUITests: MockScreenTest {
     
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Test/Unit/UserSuggestionServiceTests.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Test/Unit/UserSuggestionServiceTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class UserSuggestionServiceTests: XCTestCase {
     
     var service: UserSuggestionService?
@@ -106,7 +105,6 @@ class UserSuggestionServiceTests: XCTestCase {
     }
 }
 
-@available(iOS 14.0, *)
 extension UserSuggestionServiceTests: RoomMembersProviderProtocol {
     func fetchMembers(_ members: @escaping ([RoomMembersProviderMember]) -> Void) {
         

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/UserSuggestionScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/UserSuggestionScreenState.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 enum MockUserSuggestionScreenState: MockScreenState, CaseIterable {
     case multipleResults
     
@@ -43,7 +42,6 @@ enum MockUserSuggestionScreenState: MockScreenState, CaseIterable {
     }
 }
 
-@available(iOS 14.0, *)
 extension MockUserSuggestionScreenState: RoomMembersProviderProtocol {
     func fetchMembers(_ members: ([RoomMembersProviderMember]) -> Void) {
         if Self.members == nil {

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/UserSuggestionViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/UserSuggestionViewModel.swift
@@ -17,12 +17,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14.0, *)
 typealias UserSuggestionViewModelType = StateStoreViewModel <UserSuggestionViewState,
                                                              Never,
                                                              UserSuggestionViewAction>
 
-@available(iOS 14.0, *)
 class UserSuggestionViewModel: UserSuggestionViewModelType, UserSuggestionViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/View/UserSuggestionList.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/View/UserSuggestionList.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct UserSuggestionList: View {
     private struct Constants {
         static let topPadding: CGFloat = 8.0
@@ -76,7 +75,6 @@ struct UserSuggestionList: View {
     }
 }
 
-@available(iOS 14.0, *)
 private struct BackgroundView<Content: View>: View {
     
     var content: () -> Content
@@ -100,7 +98,6 @@ private struct BackgroundView<Content: View>: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct UserSuggestion_Previews: PreviewProvider {
     static let stateRenderer = MockUserSuggestionScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/View/UserSuggestionListItem.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/View/UserSuggestionListItem.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct UserSuggestionListItem: View {
     
     // MARK: - Properties
@@ -52,7 +51,6 @@ struct UserSuggestionListItem: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct UserSuggestionHeader_Previews: PreviewProvider {
     static var previews: some View {
         UserSuggestionListItem(avatar: MockAvatarInput.example, displayName: "Alice", userId: "@alice:matrix.org")

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/View/UserSuggestionListWithInput.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/View/UserSuggestionListWithInput.swift
@@ -16,13 +16,11 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct UserSuggestionListWithInputViewModel {
     let listViewModel: UserSuggestionViewModel
     let callback: (String)->()
 }
 
-@available(iOS 14.0, *)
 struct UserSuggestionListWithInput: View {
     
     // MARK: - Properties
@@ -51,7 +49,6 @@ struct UserSuggestionListWithInput: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct UserSuggestionListWithInput_Previews: PreviewProvider {
     static let stateRenderer = MockUserSuggestionScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Settings/ChangePassword/MockChangePasswordScreenState.swift
+++ b/RiotSwiftUI/Modules/Settings/ChangePassword/MockChangePasswordScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockChangePasswordScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Settings/Notifications/Coordinator/NotificationSettingsBridgePresenter.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Coordinator/NotificationSettingsBridgePresenter.swift
@@ -15,7 +15,6 @@
 //
 import Foundation
 
-@available(iOS 14.0, *)
 @objc protocol NotificationSettingsCoordinatorBridgePresenterDelegate {
     func notificationSettingsCoordinatorBridgePresenterDelegateDidComplete(_ coordinatorBridgePresenter: NotificationSettingsCoordinatorBridgePresenter)
 }
@@ -24,7 +23,6 @@ import Foundation
 /// This bridge is used while waiting for global usage of coordinator pattern.
 /// It breaks the Coordinator abstraction and it has been introduced for Objective-C compatibility (mainly for integration in legacy view controllers).
 /// Each bridge should be removed once the underlying Coordinator has been integrated by another Coordinator.
-@available(iOS 14.0, *)
 @objcMembers
 final class NotificationSettingsCoordinatorBridgePresenter: NSObject {
     
@@ -82,7 +80,6 @@ final class NotificationSettingsCoordinatorBridgePresenter: NSObject {
 }
 
 // MARK: - NotificationSettingsCoordinatorDelegate
-@available(iOS 14.0, *)
 extension NotificationSettingsCoordinatorBridgePresenter: NotificationSettingsCoordinatorDelegate {
     func notificationSettingsCoordinatorDidComplete(_ coordinator: NotificationSettingsCoordinatorType) {
         self.delegate?.notificationSettingsCoordinatorBridgePresenterDelegateDidComplete(self)
@@ -91,7 +88,6 @@ extension NotificationSettingsCoordinatorBridgePresenter: NotificationSettingsCo
 
 // MARK: - UIAdaptivePresentationControllerDelegate
 
-@available(iOS 14.0, *)
 extension NotificationSettingsCoordinatorBridgePresenter: UIAdaptivePresentationControllerDelegate {
     
     func notificationSettingsCoordinatorDidComplete(_ presentationController: UIPresentationController) {

--- a/RiotSwiftUI/Modules/Settings/Notifications/Coordinator/NotificationSettingsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Coordinator/NotificationSettingsCoordinator.swift
@@ -17,7 +17,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, *)
 final class NotificationSettingsCoordinator: NotificationSettingsCoordinatorType {
     
     // MARK: - Properties
@@ -66,7 +65,6 @@ final class NotificationSettingsCoordinator: NotificationSettingsCoordinatorType
 }
 
 // MARK: - NotificationSettingsViewModelCoordinatorDelegate
-@available(iOS 14.0, *)
 extension NotificationSettingsCoordinator: NotificationSettingsViewModelCoordinatorDelegate {
     func notificationSettingsViewModelDidComplete(_ viewModel: NotificationSettingsViewModelType) {
         self.delegate?.notificationSettingsCoordinatorDidComplete(self)

--- a/RiotSwiftUI/Modules/Settings/Notifications/Service/MatrixSDK/MXNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Service/MatrixSDK/MXNotificationSettingsService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MXNotificationSettingsService: NotificationSettingsServiceType {
     
     private let session: MXSession

--- a/RiotSwiftUI/Modules/Settings/Notifications/Service/Mock/MockNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Service/Mock/MockNotificationSettingsService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockNotificationSettingsService: NotificationSettingsServiceType, ObservableObject {
     static let example = MockNotificationSettingsService()
     

--- a/RiotSwiftUI/Modules/Settings/Notifications/Service/NotificationSettingsServiceType.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Service/NotificationSettingsServiceType.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 
 /// A service for changing notification settings and keywords
-@available(iOS 14.0, *)
 protocol NotificationSettingsServiceType {
     /// Publisher of all push rules.
     var rulesPublisher: AnyPublisher<[NotificationPushRuleType], Never> { get }

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/Chip.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/Chip.swift
@@ -18,7 +18,6 @@ import SwiftUI
 
 
 /// A single rounded rect chip to be rendered within `Chips` collection
-@available(iOS 14.0, *)
 struct Chip: View {
     
     @Environment(\.isEnabled) var isEnabled
@@ -62,7 +61,6 @@ struct Chip: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct Chip_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/Chips.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/Chips.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 /// Renders multiple chips in a flow layout.
-@available(iOS 14.0, *)
 struct Chips: View {
     
     @State private var frame: CGRect = CGRect.zero
@@ -75,7 +74,6 @@ struct Chips: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct Chips_Previews: PreviewProvider {
     static var chips: [String] = ["Chip1", "Chip2", "Chip3", "Chip4", "Chip5", "Chip6"]
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/ChipsInput.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/ChipsInput.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 /// Renders an input field and a collection of chips.
-@available(iOS 14.0, *)
 struct ChipsInput: View {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -47,7 +46,6 @@ struct ChipsInput: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct ChipsInput_Previews: PreviewProvider {
     static var chips = Set<String>(["Website", "Element", "Design", "Matrix/Element"])
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/DefaultNotificationSettings.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/DefaultNotificationSettings.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct DefaultNotificationSettings: View {
     
     @ObservedObject var viewModel: NotificationSettingsViewModel
@@ -28,7 +27,6 @@ struct DefaultNotificationSettings: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct DefaultNotifications_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/FormInputFieldStyle.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/FormInputFieldStyle.swift
@@ -18,7 +18,6 @@ import Foundation
 import SwiftUI
 
 /// An input field style for forms.
-@available(iOS 14.0, *)
 struct FormInputFieldStyle: TextFieldStyle {
     
     @Environment(\.theme) var theme: ThemeSwiftUI
@@ -49,7 +48,6 @@ struct FormInputFieldStyle: TextFieldStyle {
 }
 
 
-@available(iOS 14.0, *)
 struct FormInputFieldStyle_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/MentionsAndKeywordNotificationSettings.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/MentionsAndKeywordNotificationSettings.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct MentionsAndKeywordNotificationSettings: View {
     
     @ObservedObject var viewModel: NotificationSettingsViewModel
@@ -39,7 +38,6 @@ struct MentionsAndKeywordNotificationSettings: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct MentionsAndKeywords_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/NotificationSettings.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/NotificationSettings.swift
@@ -20,7 +20,6 @@ import SwiftUI
 ///
 /// Also renders an optional bottom section.
 /// Used in the case of keywords, for the keyword chips and input.
-@available(iOS 14.0, *)
 struct NotificationSettings<BottomSection: View>: View {
     
     @ObservedObject var viewModel: NotificationSettingsViewModel
@@ -45,14 +44,12 @@ struct NotificationSettings<BottomSection: View>: View {
     }
 }
 
-@available(iOS 14.0, *)
 extension NotificationSettings where BottomSection == EmptyView {
     init(viewModel: NotificationSettingsViewModel) {
         self.init(viewModel: viewModel, bottomSection: nil)
     }
 }
 
-@available(iOS 14.0, *)
 struct NotificationSettings_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/NotificationSettingsKeywords.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/NotificationSettingsKeywords.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 /// Renders the keywords input, driven by 'NotificationSettingsViewModel'.
-@available(iOS 14.0, *)
 struct NotificationSettingsKeywords: View {
     @ObservedObject var viewModel: NotificationSettingsViewModel
     var body: some View {
@@ -32,7 +31,6 @@ struct NotificationSettingsKeywords: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct Keywords_Previews: PreviewProvider {
     static let viewModel = NotificationSettingsViewModel(
         notificationSettingsService: MockNotificationSettingsService.example,

--- a/RiotSwiftUI/Modules/Settings/Notifications/View/OtherNotificationSettings.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/View/OtherNotificationSettings.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct OtherNotificationSettings: View {
     @ObservedObject var viewModel: NotificationSettingsViewModel
     
@@ -27,7 +26,6 @@ struct OtherNotificationSettings: View {
     }
 }
 
-@available(iOS 14.0, *)
 struct OtherNotifications_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/RiotSwiftUI/Modules/Settings/Notifications/ViewModel/NotificationSettingsViewModel.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/ViewModel/NotificationSettingsViewModel.swift
@@ -20,7 +20,6 @@ import Foundation
 import Combine
 import SwiftUI
 
-@available(iOS 14.0, *)
 final class NotificationSettingsViewModel: NotificationSettingsViewModelType, ObservableObject {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/AddRoomSelector/Coordinator/AddRoomSelectorViewProvider.swift
+++ b/RiotSwiftUI/Modules/Spaces/AddRoomSelector/Coordinator/AddRoomSelectorViewProvider.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 class AddRoomSelectorViewProvider: MatrixItemChooserCoordinatorViewProvider {
-    @available(iOS 14, *)
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView {
         return AnyView(AddRoomSelector(viewModel: viewModel))
     }

--- a/RiotSwiftUI/Modules/Spaces/AddRoomSelector/View/AddRoomSelector.swift
+++ b/RiotSwiftUI/Modules/Spaces/AddRoomSelector/View/AddRoomSelector.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct AddRoomSelector: View {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Spaces/LeaveSpace/Coordinator/LeaveSpaceViewProvider.swift
+++ b/RiotSwiftUI/Modules/Spaces/LeaveSpace/Coordinator/LeaveSpaceViewProvider.swift
@@ -24,7 +24,6 @@ class LeaveSpaceViewProvider: MatrixItemChooserCoordinatorViewProvider {
         self.navTitle = navTitle
     }
     
-    @available(iOS 14, *)
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView {
         return AnyView(LeaveSpace(viewModel: viewModel, navTitle: navTitle))
     }

--- a/RiotSwiftUI/Modules/Spaces/LeaveSpace/View/LeaveSpace.swift
+++ b/RiotSwiftUI/Modules/Spaces/LeaveSpace/View/LeaveSpace.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct LeaveSpace: View {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Coordinator/MatrixItemChooserCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Coordinator/MatrixItemChooserCoordinator.swift
@@ -18,12 +18,10 @@ import Foundation
 import UIKit
 import SwiftUI
 
-@available(iOS 14.0, *)
 internal protocol MatrixItemChooserCoordinatorViewProvider {
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView
 }
 
-@available(iOS 14.0, *)
 struct MatrixItemChooserCoordinatorParameters {
     let session: MXSession
     let title: String?
@@ -50,7 +48,6 @@ struct MatrixItemChooserCoordinatorParameters {
     }
 }
 
-@available(iOS 14.0.0, *)
 final class MatrixItemChooserCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties
@@ -69,7 +66,6 @@ final class MatrixItemChooserCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: MatrixItemChooserCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = MatrixItemChooserViewModel.makeMatrixItemChooserViewModel(matrixItemChooserService: MatrixItemChooserService(session: parameters.session, selectedItemIds: parameters.selectedItemsIds, itemsProcessor: parameters.itemsProcessor), title: parameters.title, detail: parameters.detail, selectionHeader: parameters.selectionHeader)

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/MatrixItemChooserViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/MatrixItemChooserViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias MatrixItemChooserViewModelType = StateStoreViewModel<MatrixItemChooserViewState,
                                                                  Never,
                                                                  MatrixItemChooserViewAction>
-@available(iOS 14, *)
 class MatrixItemChooserViewModel: MatrixItemChooserViewModelType, MatrixItemChooserViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/MatrixItemChooserViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/MatrixItemChooserViewModelProtocol.swift
@@ -19,8 +19,6 @@ import Foundation
 protocol MatrixItemChooserViewModelProtocol {
     
     var completion: ((MatrixItemChooserViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     static func makeMatrixItemChooserViewModel(matrixItemChooserService: MatrixItemChooserServiceProtocol, title: String?, detail: String?, selectionHeader: MatrixItemChooserSelectionHeader?) -> MatrixItemChooserViewModelProtocol
-    @available(iOS 14, *)
     var context: MatrixItemChooserViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/MockMatrixItemChooserScreenState.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/MockMatrixItemChooserScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockMatrixItemChooserScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/MatrixItemChooserServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/MatrixItemChooserServiceProtocol.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol MatrixItemChooserServiceProtocol {
     var sectionsSubject: CurrentValueSubject<[MatrixListItemSectionData], Never> { get }
     var selectedItemIdsSubject: CurrentValueSubject<Set<String>, Never> { get }

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/MatrixSDK/MatrixItemChooserService.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/MatrixSDK/MatrixItemChooserService.swift
@@ -29,7 +29,6 @@ protocol MatrixItemChooserProcessorProtocol {
     func isItemIncluded(_ item: (MatrixListItemData)) -> Bool
 }
 
-@available(iOS 14.0, *)
 class MatrixItemChooserService: MatrixItemChooserServiceProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/Mock/MockMatrixItemChooserService.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/Mock/MockMatrixItemChooserService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockMatrixItemChooserService: MatrixItemChooserServiceProtocol {
     
     static let mockSections = [

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Test/UI/MatrixItemChooserUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Test/UI/MatrixItemChooserUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class MatrixItemChooserUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Test/Unit/MatrixItemChooserViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Test/Unit/MatrixItemChooserViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class MatrixItemChooserViewModelTests: XCTestCase {
     var creationParameters = SpaceCreationParameters()
     var service: MockMatrixItemChooserService!

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/View/MatrixItemChooser.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/View/MatrixItemChooser.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct MatrixItemChooser: View {
     
     // MARK: Properties
@@ -151,7 +150,6 @@ struct MatrixItemChooser: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct MatrixItemChooser_Previews: PreviewProvider {
     
     static let stateRenderer = MockMatrixItemChooserScreenState.stateRenderer

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/View/MatrixItemChooserListRow.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/View/MatrixItemChooserListRow.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct MatrixItemChooserListRow: View {
 
     // MARK: - Properties
@@ -69,7 +68,6 @@ struct MatrixItemChooserListRow: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct MatrixItemChooserListRow_Previews: PreviewProvider {
     static var previews: some View {
         TemplateRoomListRow(avatar: MockAvatarInput.example, displayName: "Alice")

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/View/MatrixItemChooserSectionHeader.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/View/MatrixItemChooserSectionHeader.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct MatrixItemChooserSectionHeader: View {
 
     // MARK: - Properties
@@ -63,7 +62,6 @@ struct MatrixItemChooserSectionHeader: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct MatrixItemChooserSectionHeader_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Spaces/RoomAncestorSelector/Coordinator/RoomAncestorSelectorViewProvider.swift
+++ b/RiotSwiftUI/Modules/Spaces/RoomAncestorSelector/Coordinator/RoomAncestorSelectorViewProvider.swift
@@ -24,7 +24,6 @@ class RoomAncestorSelectorViewProvider: MatrixItemChooserCoordinatorViewProvider
         self.navTitle = navTitle
     }
     
-    @available(iOS 14, *)
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView {
         return AnyView(RoomAncestorSelector(viewModel: viewModel, navTitle: navTitle))
     }

--- a/RiotSwiftUI/Modules/Spaces/RoomAncestorSelector/View/RoomAncestorSelector.swift
+++ b/RiotSwiftUI/Modules/Spaces/RoomAncestorSelector/View/RoomAncestorSelector.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct RoomAncestorSelector: View {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/Coordinator/SpaceCreationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/Coordinator/SpaceCreationCoordinator.swift
@@ -77,24 +77,22 @@ final class SpaceCreationCoordinator: Coordinator {
     // MARK: - Public
     
     func start() {
-        if #available(iOS 14.0, *) {
-            MXLog.debug("[SpaceCreationCoordinator] did start.")
-            
-            let rootCoordinator = self.createMenuCoordinator(with: spaceVisibilityMenuParameters)
-            rootCoordinator.start()
-            
-            self.add(childCoordinator: rootCoordinator)
-            
-            self.toPresentable().isModalInPresentation = true
-            
-            if self.navigationRouter.modules.isEmpty == false {
-                self.navigationRouter.push(rootCoordinator, animated: true, popCompletion: { [weak self] in
-                    self?.remove(childCoordinator: rootCoordinator)
-                })
-            } else {
-                self.navigationRouter.setRootModule(rootCoordinator) { [weak self] in
-                    self?.remove(childCoordinator: rootCoordinator)
-                }
+        MXLog.debug("[SpaceCreationCoordinator] did start.")
+        
+        let rootCoordinator = self.createMenuCoordinator(with: spaceVisibilityMenuParameters)
+        rootCoordinator.start()
+        
+        self.add(childCoordinator: rootCoordinator)
+        
+        self.toPresentable().isModalInPresentation = true
+        
+        if self.navigationRouter.modules.isEmpty == false {
+            self.navigationRouter.push(rootCoordinator, animated: true, popCompletion: { [weak self] in
+                self?.remove(childCoordinator: rootCoordinator)
+            })
+        } else {
+            self.navigationRouter.setRootModule(rootCoordinator) { [weak self] in
+                self?.remove(childCoordinator: rootCoordinator)
             }
         }
     }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/Coordinator/SpaceCreationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/Coordinator/SpaceCreationCoordinator.swift
@@ -105,7 +105,6 @@ final class SpaceCreationCoordinator: Coordinator {
     
     // MARK: - Private
     
-    @available(iOS 14.0, *)
     func pushScreen(with coordinator: Coordinator & Presentable) {
         add(childCoordinator: coordinator)
         
@@ -116,7 +115,6 @@ final class SpaceCreationCoordinator: Coordinator {
         coordinator.start()
     }
 
-    @available(iOS 14.0, *)
     private func createMenuCoordinator(with parameters: SpaceCreationMenuCoordinatorParameters) -> SpaceCreationMenuCoordinator {
         let coordinator: SpaceCreationMenuCoordinator = SpaceCreationMenuCoordinator(parameters: parameters)
         
@@ -142,7 +140,6 @@ final class SpaceCreationCoordinator: Coordinator {
         return coordinator
     }
     
-    @available(iOS 14.0, *)
     private func createSettingsCoordinator() -> SpaceCreationSettingsCoordinator {
         let coordinator = SpaceCreationSettingsCoordinator(parameters: SpaceCreationSettingsCoordinatorParameters(session: parameters.session, creationParameters: parameters.creationParameters))
         coordinator.callback = { [weak self] result in
@@ -163,7 +160,6 @@ final class SpaceCreationCoordinator: Coordinator {
         return coordinator
     }
     
-    @available(iOS 14.0, *)
     private func createRoomsCoordinator() -> SpaceCreationRoomsCoordinator {
         let coordinator = SpaceCreationRoomsCoordinator(parameters: SpaceCreationRoomsCoordinatorParameters(session: parameters.session, creationParams: parameters.creationParameters))
         coordinator.callback = { [weak self] result in
@@ -186,7 +182,6 @@ final class SpaceCreationCoordinator: Coordinator {
         return coordinator
     }
     
-    @available(iOS 14.0, *)
     private func createEmailInvitesCoordinator() -> SpaceCreationEmailInvitesCoordinator {
         let coordinator = SpaceCreationEmailInvitesCoordinator(parameters: SpaceCreationEmailInvitesCoordinatorParameters(session: parameters.session, creationParams: parameters.creationParameters))
         coordinator.callback = { [weak self] result in
@@ -205,7 +200,6 @@ final class SpaceCreationCoordinator: Coordinator {
         return coordinator
     }
 
-    @available(iOS 14.0, *)
     private func createPeopleChooserCoordinator() -> MatrixItemChooserCoordinator {
         let parameters = MatrixItemChooserCoordinatorParameters(
             session: parameters.session,
@@ -229,7 +223,6 @@ final class SpaceCreationCoordinator: Coordinator {
         return coordinator
     }
 
-    @available(iOS 14.0, *)
     private func createRoomChooserCoordinator() -> MatrixItemChooserCoordinator {
         let parameters = MatrixItemChooserCoordinatorParameters(
             session: parameters.session,
@@ -253,7 +246,6 @@ final class SpaceCreationCoordinator: Coordinator {
         return coordinator
     }
 
-    @available(iOS 14.0, *)
     private func createPostProcessCoordinator() -> SpaceCreationPostProcessCoordinator {
         let coordinator = SpaceCreationPostProcessCoordinator(parameters: SpaceCreationPostProcessCoordinatorParameters(session: parameters.session, creationParams: parameters.creationParameters))
         coordinator.callback = { [weak self] result in

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Coordinator/SpaceCreationEmailInvitesCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Coordinator/SpaceCreationEmailInvitesCoordinator.swift
@@ -38,7 +38,6 @@ final class SpaceCreationEmailInvitesCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: SpaceCreationEmailInvitesCoordinatorParameters) {
         self.parameters = parameters
         let service = SpaceCreationEmailInvitesService(session: parameters.session)

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/MatrixSDK/SpaceCreationEmailInvitesService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/MatrixSDK/SpaceCreationEmailInvitesService.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class SpaceCreationEmailInvitesService: SpaceCreationEmailInvitesServiceProtocol {
     
     private let session: MXSession

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/Mock/MockSpaceCreationEmailInvitesScreenState.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/Mock/MockSpaceCreationEmailInvitesScreenState.swift
@@ -21,7 +21,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockSpaceCreationEmailInvitesScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/Mock/MockSpaceCreationEmailInvitesService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/Mock/MockSpaceCreationEmailInvitesService.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockSpaceCreationEmailInvitesService: SpaceCreationEmailInvitesServiceProtocol {
     var isLoadingSubject: CurrentValueSubject<Bool, Never>
     

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/SpaceCreationEmailInvitesServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Service/SpaceCreationEmailInvitesServiceProtocol.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol SpaceCreationEmailInvitesServiceProtocol {
     var isIdentityServiceReady: Bool { get }
     var isLoadingSubject: CurrentValueSubject<Bool, Never> { get }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Test/UI/SpaceCreationEmailInvitesUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Test/UI/SpaceCreationEmailInvitesUITests.swift
@@ -19,7 +19,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationEmailInvitesUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Test/Unit/SpaceCreationEmailInvitesViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/Test/Unit/SpaceCreationEmailInvitesViewModelTests.swift
@@ -21,7 +21,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationEmailInvitesViewModelTests: XCTestCase {
     var creationParameters = SpaceCreationParameters()
     var service: MockSpaceCreationEmailInvitesService!

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/View/SpaceCreationEmailInvites.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/View/SpaceCreationEmailInvites.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceCreationEmailInvites: View {
 
     // MARK: - Properties
@@ -114,7 +113,6 @@ struct SpaceCreationEmailInvites: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceCreationEmailInvites_Previews: PreviewProvider {
     static let stateRenderer = MockSpaceCreationEmailInvitesScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/ViewModel/SpaceCreationEmailInvitesViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/ViewModel/SpaceCreationEmailInvitesViewModel.swift
@@ -19,11 +19,9 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias SpaceCreationEmailInvitesViewModelType = StateStoreViewModel<SpaceCreationEmailInvitesViewState,
                                                                  SpaceCreationEmailInvitesStateAction,
                                                                  SpaceCreationEmailInvitesViewAction>
-@available(iOS 14, *)
 class SpaceCreationEmailInvitesViewModel: SpaceCreationEmailInvitesViewModelType, SpaceCreationEmailInvitesViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/ViewModel/SpaceCreationEmailInvitesViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationEmailInvites/ViewModel/SpaceCreationEmailInvitesViewModelProtocol.swift
@@ -21,6 +21,5 @@ import Foundation
 protocol SpaceCreationEmailInvitesViewModelProtocol {
     
     var completion: ((SpaceCreationEmailInvitesViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: SpaceCreationEmailInvitesViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMatrixItemChooser/Coordinator/SpaceCreationMatrixItemChooserViewProvider.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMatrixItemChooser/Coordinator/SpaceCreationMatrixItemChooserViewProvider.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 class SpaceCreationMatrixItemChooserViewProvider: MatrixItemChooserCoordinatorViewProvider {
-    @available(iOS 14, *)
     func view(with viewModel: MatrixItemChooserViewModelType.Context) -> AnyView {
         return AnyView(SpaceCreationMatrixItemChooser(viewModel: viewModel))
     }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMatrixItemChooser/View/SpaceCreationMatrixItemChooser.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMatrixItemChooser/View/SpaceCreationMatrixItemChooser.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceCreationMatrixItemChooser: View {
     
     // MARK: Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/Coordinator/SpaceCreationMenuCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/Coordinator/SpaceCreationMenuCoordinator.swift
@@ -38,7 +38,6 @@ final class SpaceCreationMenuCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: SpaceCreationMenuCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = SpaceCreationMenuViewModel(navTitle: parameters.navTitle, creationParams: parameters.creationParams, title: parameters.title, detail: parameters.detail, options: parameters.options)

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/Test/UI/SpaceCreationMenuUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/Test/UI/SpaceCreationMenuUITests.swift
@@ -19,7 +19,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationMenuUITests: MockScreenTest {
     
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/Test/Unit/SpaceCreationMenuViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/Test/Unit/SpaceCreationMenuViewModelTests.swift
@@ -21,7 +21,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationMenuViewModelTests: XCTestCase {
     private enum Constants {
     }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/View/SpaceCreationMenu.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/View/SpaceCreationMenu.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceCreationMenu: View {
     
     // MARK: - Properties
@@ -100,7 +99,6 @@ struct SpaceCreationMenu: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceCreationMenu_Previews: PreviewProvider {
     
     static let stateRenderer = MockSpaceCreationMenuScreenState.stateRenderer
@@ -117,7 +115,6 @@ struct SpaceCreationMenu_Previews: PreviewProvider {
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockSpaceCreationMenuScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/ViewModel/SpaceCreationMenuViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/ViewModel/SpaceCreationMenuViewModel.swift
@@ -19,11 +19,9 @@
 import SwiftUI
 import Combine
     
-@available(iOS 14, *)
 typealias SpaceCreationMenuViewModelType = StateStoreViewModel<SpaceCreationMenuViewState,
                                                               SpaceCreationMenuStateAction,
                                                               SpaceCreationMenuViewAction>
-@available(iOS 14.0, *)
 class SpaceCreationMenuViewModel: SpaceCreationMenuViewModelType, SpaceCreationMenuViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/ViewModel/SpaceCreationMenuViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationMenu/ViewModel/SpaceCreationMenuViewModelProtocol.swift
@@ -20,6 +20,5 @@ import Foundation
 
 protocol SpaceCreationMenuViewModelProtocol {
     var callback: ((SpaceCreationMenuViewModelAction) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: SpaceCreationMenuViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Coordinator/SpaceCreationPostProcessCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Coordinator/SpaceCreationPostProcessCoordinator.swift
@@ -38,7 +38,6 @@ final class SpaceCreationPostProcessCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: SpaceCreationPostProcessCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = SpaceCreationPostProcessViewModel.makeSpaceCreationPostProcessViewModel(spaceCreationPostProcessService: SpaceCreationPostProcessService(session: parameters.session, creationParams: parameters.creationParams))

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/MatrixSDK/SpaceCreationPostProcessService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/MatrixSDK/SpaceCreationPostProcessService.swift
@@ -20,7 +20,6 @@ import Foundation
 import Combine
 import MatrixSDK
 
-@available(iOS 14.0, *)
 class SpaceCreationPostProcessService: SpaceCreationPostProcessServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/Mock/MockSpaceCreationPostProcessScreenState.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/Mock/MockSpaceCreationPostProcessScreenState.swift
@@ -21,7 +21,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockSpaceCreationPostProcessScreenState: MockScreenState {
     static var screenStates: [MockScreenState] = [MockSpaceCreationPostProcessScreenState.running, MockSpaceCreationPostProcessScreenState.done, MockSpaceCreationPostProcessScreenState.doneWithError]
     

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/Mock/MockSpaceCreationPostProcessService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/Mock/MockSpaceCreationPostProcessService.swift
@@ -20,7 +20,6 @@ import Foundation
 import Combine
 import UIKit
 
-@available(iOS 14.0, *)
 class MockSpaceCreationPostProcessService: SpaceCreationPostProcessServiceProtocol {
     
     static let defaultTasks: [SpaceCreationPostProcessTask] = [

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/SpaceCreationPostProcessServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Service/SpaceCreationPostProcessServiceProtocol.swift
@@ -20,7 +20,6 @@ import Foundation
 import Combine
 import UIKit
 
-@available(iOS 14.0, *)
 protocol SpaceCreationPostProcessServiceProtocol: AnyObject {
     var tasksSubject: CurrentValueSubject<[SpaceCreationPostProcessTask], Never> { get }
     var createdSpaceId: String? { get }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Test/UI/SpaceCreationPostProcessUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Test/UI/SpaceCreationPostProcessUITests.swift
@@ -19,7 +19,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationPostProcessUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Test/Unit/SpaceCreationPostProcessViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/Test/Unit/SpaceCreationPostProcessViewModelTests.swift
@@ -21,7 +21,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationPostProcessViewModelTests: XCTestCase {
     
     var service: MockSpaceCreationPostProcessService!

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/View/SpaceCreationPostProcess.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/View/SpaceCreationPostProcess.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceCreationPostProcess: View {
 
     // MARK: - Properties
@@ -101,7 +100,6 @@ struct SpaceCreationPostProcess: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceCreationPostProcess_Previews: PreviewProvider {
     static let stateRenderer = MockSpaceCreationPostProcessScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/View/SpaceCreationPostProcessItem.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/View/SpaceCreationPostProcessItem.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceCreationPostProcessItem: View {
     // MARK: - Properties
     
@@ -65,7 +64,6 @@ struct SpaceCreationPostProcessItem: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceCreationPostProcessItem_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/ViewModel/SpaceCreationPostProcessViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/ViewModel/SpaceCreationPostProcessViewModel.swift
@@ -21,11 +21,9 @@ import Combine
 
 
 
-@available(iOS 14, *)
 typealias SpaceCreationPostProcessViewModelType = StateStoreViewModel<SpaceCreationPostProcessViewState,
                                                                  SpaceCreationPostProcessStateAction,
                                                                  SpaceCreationPostProcessViewAction>
-@available(iOS 14, *)
 class SpaceCreationPostProcessViewModel: SpaceCreationPostProcessViewModelType, SpaceCreationPostProcessViewModelProtocol {
 
     // MARK: - Properties
@@ -133,7 +131,6 @@ class SpaceCreationPostProcessViewModel: SpaceCreationPostProcessViewModelType, 
 }
 
 // MARK: - MXSpaceService notification constants
-@available(iOS 14, *)
 extension SpaceCreationPostProcessViewModel {
     /// Posted once the process is finished
     public static let didUpdate = Notification.Name("SpaceCreationPostProcessViewModelDidUpdate")

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/ViewModel/SpaceCreationPostProcessViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationPostProcess/ViewModel/SpaceCreationPostProcessViewModelProtocol.swift
@@ -21,8 +21,6 @@ import Foundation
 protocol SpaceCreationPostProcessViewModelProtocol {
     
     var completion: ((SpaceCreationPostProcessViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     static func makeSpaceCreationPostProcessViewModel(spaceCreationPostProcessService: SpaceCreationPostProcessServiceProtocol) -> SpaceCreationPostProcessViewModelProtocol
-    @available(iOS 14, *)
     var context: SpaceCreationPostProcessViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Coordinator/SpaceCreationRoomsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Coordinator/SpaceCreationRoomsCoordinator.swift
@@ -38,7 +38,6 @@ final class SpaceCreationRoomsCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: SpaceCreationRoomsCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = SpaceCreationRoomsViewModel(creationParameters: parameters.creationParams)

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Service/Mock/MockSpaceCreationRoomsScreenState.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Service/Mock/MockSpaceCreationRoomsScreenState.swift
@@ -21,7 +21,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockSpaceCreationRoomsScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Test/UI/SpaceCreationRoomsUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Test/UI/SpaceCreationRoomsUITests.swift
@@ -19,7 +19,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationRoomsUITests: MockScreenTest {
 
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Test/Unit/SpaceCreationRoomsViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/Test/Unit/SpaceCreationRoomsViewModelTests.swift
@@ -21,7 +21,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationRoomsViewModelTests: XCTestCase {
     var creationParameters = SpaceCreationParameters()
     var viewModel: SpaceCreationRoomsViewModelProtocol!

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/View/SpaceCreationRooms.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/View/SpaceCreationRooms.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceCreationRooms: View {
 
     // MARK: - Properties
@@ -84,7 +83,6 @@ struct SpaceCreationRooms: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceCreationRooms_Previews: PreviewProvider {
     static let stateRenderer = MockSpaceCreationRoomsScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/ViewModel/SpaceCreationRoomsViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/ViewModel/SpaceCreationRoomsViewModel.swift
@@ -21,11 +21,9 @@ import Combine
 
 
 
-@available(iOS 14, *)
 typealias SpaceCreationRoomsViewModelType = StateStoreViewModel<SpaceCreationRoomsViewState,
                                                                  SpaceCreationRoomsStateAction,
                                                                  SpaceCreationRoomsViewAction>
-@available(iOS 14, *)
 class SpaceCreationRoomsViewModel: SpaceCreationRoomsViewModelType, SpaceCreationRoomsViewModelProtocol {
 
     // MARK: - Setup

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/ViewModel/SpaceCreationRoomsViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationRooms/ViewModel/SpaceCreationRoomsViewModelProtocol.swift
@@ -21,6 +21,5 @@ import Foundation
 protocol SpaceCreationRoomsViewModelProtocol {
     
     var callback: ((SpaceCreationRoomsViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     var context: SpaceCreationRoomsViewModelType.Context { get }
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Coordinator/SpaceCreationSettingsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Coordinator/SpaceCreationSettingsCoordinator.swift
@@ -44,7 +44,6 @@ final class SpaceCreationSettingsCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: SpaceCreationSettingsCoordinatorParameters) {
         self.parameters = parameters
         let service = SpaceCreationSettingsService(roomName: parameters.creationParameters.name ?? "", userDefinedAddress: parameters.creationParameters.userDefinedAddress, session: parameters.session)

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/MatrixSDK/SpaceCreationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/MatrixSDK/SpaceCreationSettingsService.swift
@@ -20,7 +20,6 @@ import Foundation
 import Combine
 import MatrixSDK
 
-@available(iOS 14.0, *)
 class SpaceCreationSettingsService: SpaceCreationSettingsServiceProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/Mock/MockSpaceCreationSettingsScreenState.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/Mock/MockSpaceCreationSettingsScreenState.swift
@@ -22,7 +22,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockSpaceCreationSettingsScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/Mock/MockSpaceCreationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/Mock/MockSpaceCreationSettingsService.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockSpaceCreationSettingsService: SpaceCreationSettingsServiceProtocol {
     
 

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/SpaceCreationSettingsServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Service/SpaceCreationSettingsServiceProtocol.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 protocol SpaceCreationSettingsServiceProtocol: AnyObject {
     var defaultAddressSubject: CurrentValueSubject<String, Never> { get }
     var addressValidationSubject: CurrentValueSubject<SpaceCreationSettingsAddressValidationStatus, Never> { get }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Test/UI/SpaceCreationSettingsUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Test/UI/SpaceCreationSettingsUITests.swift
@@ -19,7 +19,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationSettingsUITests: MockScreenTest {
     
     override class var screenType: MockScreenState.Type {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Test/Unit/SpaceCreationSettingsViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/Test/Unit/SpaceCreationSettingsViewModelTests.swift
@@ -21,7 +21,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceCreationSettingsViewModelTests: XCTestCase {
 
     let creationParameters = SpaceCreationParameters()

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/View/SpaceCreationSettings.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/View/SpaceCreationSettings.swift
@@ -19,7 +19,6 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14.0, *)
 struct SpaceCreationSettings: View {
     
     // MARK: - Properties
@@ -159,7 +158,6 @@ struct SpaceCreationSettings: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceCreationSettings_Previews: PreviewProvider {
     static let stateRenderer = MockSpaceCreationSettingsScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/ViewModel/SpaceCreationSettingsViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/SpaceCreationSettings/ViewModel/SpaceCreationSettingsViewModel.swift
@@ -19,12 +19,10 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias SpaceCreationSettingsViewModelType = StateStoreViewModel<SpaceCreationSettingsViewState,
                                                               SpaceCreationSettingsStateAction,
                                                               SpaceCreationSettingsViewAction>
 
-@available(iOS 14, *)
 class SpaceCreationSettingsViewModel: SpaceCreationSettingsViewModelType, SpaceCreationSettingsViewModelProtocol {
     
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/Coordinator/SpaceSettingsModalCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/Coordinator/SpaceSettingsModalCoordinator.swift
@@ -23,7 +23,6 @@ enum SpaceSettingsModalCoordinatorAction {
 }
 
 @objcMembers
-@available(iOS 14.0, *)
 final class SpaceSettingsModalCoordinator: Coordinator {
     
     // MARK: - Properties
@@ -80,7 +79,6 @@ final class SpaceSettingsModalCoordinator: Coordinator {
     
     // MARK: - Private
     
-    @available(iOS 14.0, *)
     func pushScreen(with coordinator: Coordinator & Presentable) {
         add(childCoordinator: coordinator)
         
@@ -165,7 +163,6 @@ final class SpaceSettingsModalCoordinator: Coordinator {
 }
 
 // MARK: - ExploreRoomCoordinatorDelegate
-@available(iOS 14.0, *)
 extension SpaceSettingsModalCoordinator: ExploreRoomCoordinatorDelegate {
     func exploreRoomCoordinatorDidComplete(_ coordinator: ExploreRoomCoordinatorType) {
         self.navigationRouter.dismissModule(animated: true, completion: {
@@ -175,7 +172,6 @@ extension SpaceSettingsModalCoordinator: ExploreRoomCoordinatorDelegate {
 }
 
 // MARK: - SpaceMembersCoordinatorDelegate
-@available(iOS 14.0, *)
 extension SpaceSettingsModalCoordinator: SpaceMembersCoordinatorDelegate {
     func spaceMembersCoordinatorDidCancel(_ coordinator: SpaceMembersCoordinatorType) {
         self.navigationRouter.dismissModule(animated: true, completion: {

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/Coordinator/SpaceSettingsModalCoordinatorBridgePresenter.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/Coordinator/SpaceSettingsModalCoordinatorBridgePresenter.swift
@@ -16,7 +16,6 @@
 
 import UIKit
 
-@available(iOS 14.0, *)
 @objc protocol SpaceSettingsModalCoordinatorBridgePresenterDelegate {
     func spaceSettingsModalCoordinatorBridgePresenterDelegateDidCancel(_ coordinatorBridgePresenter: SpaceSettingsModalCoordinatorBridgePresenter)
     func spaceSettingsModalCoordinatorBridgePresenterDelegateDidFinish(_ coordinatorBridgePresenter: SpaceSettingsModalCoordinatorBridgePresenter)
@@ -27,7 +26,6 @@ import UIKit
 /// It breaks the Coordinator abstraction and it has been introduced for Objective-C compatibility (mainly for integration in legacy view controllers).
 /// Each bridge should be removed once the underlying Coordinator has been integrated by another Coordinator.
 @objcMembers
-@available(iOS 14.0, *)
 final class SpaceSettingsModalCoordinatorBridgePresenter: NSObject {
     
     // MARK: - Properties
@@ -92,7 +90,6 @@ final class SpaceSettingsModalCoordinatorBridgePresenter: NSObject {
 
 // MARK: - UIAdaptivePresentationControllerDelegate
 
-@available(iOS 14.0, *)
 extension SpaceSettingsModalCoordinatorBridgePresenter: UIAdaptivePresentationControllerDelegate {
     
     func roomNotificationSettingsCoordinatorDidComplete(_ presentationController: UIPresentationController) {

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Coordinator/SpaceSettingsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Coordinator/SpaceSettingsCoordinator.swift
@@ -45,7 +45,6 @@ final class SpaceSettingsCoordinator: Coordinator, Presentable {
     
     // MARK: - Setup
     
-    @available(iOS 14.0, *)
     init(parameters: SpaceSettingsCoordinatorParameters) {
         self.parameters = parameters
         let viewModel = SpaceSettingsViewModel.makeSpaceSettingsViewModel(service: SpaceSettingsService(session: parameters.session, spaceId: parameters.spaceId))

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/MockSpaceSettingsScreenState.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/MockSpaceSettingsScreenState.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// Using an enum for the screen allows you define the different state cases with
 /// the relevant associated data for each case.
-@available(iOS 14.0, *)
 enum MockSpaceSettingsScreenState: MockScreenState, CaseIterable {
     // A case for each state you want to represent
     // with specific, minimal associated data that will allow you

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Service/MatrixSDK/SpaceSettingsService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Service/MatrixSDK/SpaceSettingsService.swift
@@ -18,7 +18,6 @@ import Foundation
 import Combine
 import MatrixSDK
 
-@available(iOS 14.0, *)
 class SpaceSettingsService: SpaceSettingsServiceProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Service/Mock/MockSpaceSettingsService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Service/Mock/MockSpaceSettingsService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import Combine
 
-@available(iOS 14.0, *)
 class MockSpaceSettingsService: SpaceSettingsServiceProtocol {
     
     var spaceId: String

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Service/SpaceSettingsServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Service/SpaceSettingsServiceProtocol.swift
@@ -22,7 +22,6 @@ enum SpaceSettingsServiceCompletionResult {
     case failure(Error)
 }
 
-@available(iOS 14.0, *)
 protocol SpaceSettingsServiceProtocol: Avatarable {
     var spaceId: String { get }
     var roomProperties: SpaceSettingsRoomProperties? { get }
@@ -39,7 +38,6 @@ protocol SpaceSettingsServiceProtocol: Avatarable {
 
 // MARK: Avatarable
 
-@available(iOS 14.0, *)
 extension SpaceSettingsServiceProtocol {
     var mxContentUri: String? {
         roomProperties?.avatarUrl

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -17,11 +17,9 @@
 import SwiftUI
 import Combine
 
-@available(iOS 14, *)
 typealias SpaceSettingsViewModelType = StateStoreViewModel<SpaceSettingsViewState,
                                                                  Never,
                                                                  SpaceSettingsViewAction>
-@available(iOS 14, *)
 class SpaceSettingsViewModel: SpaceSettingsViewModelType, SpaceSettingsViewModelProtocol {
 
     // MARK: - Properties

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/SpaceSettingsViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/SpaceSettingsViewModelProtocol.swift
@@ -19,9 +19,7 @@ import Foundation
 protocol SpaceSettingsViewModelProtocol {
     
     var completion: ((SpaceSettingsViewModelResult) -> Void)? { get set }
-    @available(iOS 14, *)
     static func makeSpaceSettingsViewModel(service: SpaceSettingsServiceProtocol) -> SpaceSettingsViewModelProtocol
-    @available(iOS 14, *)
     var context: SpaceSettingsViewModelType.Context { get }
     func updateAvatarImage(with image: UIImage?)
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Test/UI/SpaceSettingsUITests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Test/UI/SpaceSettingsUITests.swift
@@ -17,7 +17,6 @@
 import XCTest
 import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceSettingsUITests: MockScreenTest {
     // Tests to be implemented.
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Test/Unit/SpaceSettingsViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/Test/Unit/SpaceSettingsViewModelTests.swift
@@ -19,7 +19,6 @@ import Combine
 
 @testable import RiotSwiftUI
 
-@available(iOS 14.0, *)
 class SpaceSettingsViewModelTests: XCTestCase {
     let creationParameters = SpaceCreationParameters()
     var service: MockSpaceSettingsService!

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/View/SpaceSettings.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/View/SpaceSettings.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceSettings: View {
 
     // MARK: - Properties
@@ -199,7 +198,6 @@ struct SpaceSettings: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceSettings_Previews: PreviewProvider {
     static let stateRenderer = MockSpaceSettingsScreenState.stateRenderer
     static var previews: some View {

--- a/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/View/SpaceSettingsOptionListItem.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSettings/SpaceSettings/View/SpaceSettingsOptionListItem.swift
@@ -16,7 +16,6 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
 struct SpaceSettingsOptionListItem: View {
     
     // MARK: Private
@@ -85,7 +84,6 @@ struct SpaceSettingsOptionListItem: View {
 
 // MARK: - Previews
 
-@available(iOS 14.0, *)
 struct SpaceSettingsOptionListItem_Previews: PreviewProvider {
     
     static var previews: some View {

--- a/RiotSwiftUI/RiotSwiftUIApp.swift
+++ b/RiotSwiftUI/RiotSwiftUIApp.swift
@@ -15,7 +15,6 @@
 //
 import SwiftUI
 
-@available(iOS 14.0, *)
 @main
 /// RiotSwiftUI screens rendered for UI Tests.
 struct RiotSwiftUIApp: App {

--- a/changelog.d/pr-6333.misc
+++ b/changelog.d/pr-6333.misc
@@ -1,0 +1,1 @@
+ Clean up iOS 14 availability checks


### PR DESCRIPTION
Now that the minimum deployment target is iOS 14, we can remove a bunch of availability checks. This PR contains two commits.

The first commit removes all `@available(iOS 14...`. This was done with a regex replace.

The second commit expands `if`s and `guard`s that involved `@available(iOS 14...` or `#available(iOS 14...`. This one I have done by hand so you probably want to look at it more closely.

Note that there are still availability checks pre-iOS14 left. I haven't touched those to note make this PR bigger than it already is.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
