### PR TITLE
Fix pasteboard banner when editing text.

### DIFF
--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -1373,12 +1373,11 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
         UIPasteboard *pasteboard = MXKPasteboardManager.shared.pasteboard;
         if (pasteboard.numberOfItems)
         {
-            for (NSDictionary* dict in pasteboard.items)
+            for (NSArray<NSString *> *types in [pasteboard pasteboardTypesForItemSet:nil])
             {
-                NSArray* allKeys = dict.allKeys;
-                for (NSString* key in allKeys)
+                for (NSString *type in types)
                 {
-                    NSString* MIMEType = (__bridge_transfer NSString *) UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)key, kUTTagClassMIMEType);
+                    NSString* MIMEType = (__bridge_transfer NSString *) UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
                     
                     if ([MIMEType hasPrefix:@"image/"] && [self.delegate respondsToSelector:@selector(roomInputToolbarView:sendImage:)])
                     {

--- a/changelog.d/5324.bugfix
+++ b/changelog.d/5324.bugfix
@@ -1,0 +1,1 @@
+Message Composer: Element no longer shows a banner about pasting from another app when selecting text.


### PR DESCRIPTION
Inspecting the items on the pasteboard to determine whether pasting is possible causes the banner to appear. This PR updates the check to inspect the types on the pasteboard instead. I didn't seem to see this when copying an image from Safari (presumably as there is also text on the pasteboard in the form of a URL so it doesn't go up the responder chain to check), but could reproduce it when copying an image from the photos app.

Fixes #5324