### PR TITLE
Prevent login using keyboard when homeserver is loading.

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/Login/AuthenticationLoginModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/AuthenticationLoginModels.swift
@@ -66,9 +66,14 @@ struct AuthenticationLoginViewState: BindableState {
         !homeserver.ssoIdentityProviders.isEmpty
     }
     
-    /// `true` if it is possible to continue, otherwise `false`.
+    /// `true` if the username and password are ready to be submitted.
     var hasValidCredentials: Bool {
         !bindings.username.isEmpty && !bindings.password.isEmpty
+    }
+    
+    /// `true` if valid credentials have been entered and the homeserver is loaded.
+    var canSubmit: Bool {
+        hasValidCredentials && !isLoading
     }
 }
 

--- a/RiotSwiftUI/Modules/Authentication/Login/View/AuthenticationLoginScreen.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/View/AuthenticationLoginScreen.swift
@@ -127,7 +127,7 @@ struct AuthenticationLoginScreen: View {
                 Text(VectorL10n.next)
             }
             .buttonStyle(PrimaryActionButtonStyle())
-            .disabled(!viewModel.viewState.hasValidCredentials || viewModel.viewState.isLoading)
+            .disabled(!viewModel.viewState.canSubmit)
             .accessibilityIdentifier("nextButton")
         }
     }
@@ -166,9 +166,9 @@ struct AuthenticationLoginScreen: View {
         isPasswordFocused = false
     }
     
-    /// Sends the `next` view action so long as valid credentials have been input.
+    /// Sends the `next` view action so long as the form is ready to submit.
     func submit() {
-        guard viewModel.viewState.hasValidCredentials else { return }
+        guard viewModel.viewState.canSubmit else { return }
         viewModel.send(viewAction: .next)
     }
 

--- a/changelog.d/pr-6338.bugfix
+++ b/changelog.d/pr-6338.bugfix
@@ -1,0 +1,1 @@
+Authentication: Don't attempt to login if the user presses the return key whilst loading a homeserver parsed from a username.


### PR DESCRIPTION
Tiny bugfix I noticed whilst porting the screen over to ElementX where you could hit return whilst the service was loading a homeserver and it would attempt to login.