### PR TITLE
Fix the font when using an Apple Silicon Mac.

### DIFF
--- a/Riot/Utils/EventFormatter+DTCoreTextFix.m
+++ b/Riot/Utils/EventFormatter+DTCoreTextFix.m
@@ -38,7 +38,7 @@ limitations under the License.
 
     // On iOS 13+ "TimesNewRomanPSMT" will be used instead of "SFUI"
     // In case of "Times New Roman" fallback, use system font and reuse UIFontDescriptorSymbolicTraits.
-    if ([font.familyName.lowercaseString containsString:@"times new roman"])
+    if ([font.familyName.lowercaseString containsString:@"times"])
     {
         UIFontDescriptorSymbolicTraits symbolicTraits = (UIFontDescriptorSymbolicTraits)CTFontGetSymbolicTraits(ctFont);
         

--- a/changelog.d/pr-6340.bugfix
+++ b/changelog.d/pr-6340.bugfix
@@ -1,0 +1,1 @@
+Timeline: Fixes the font when running Element on a Mac with Apple Silicon.


### PR DESCRIPTION
A tiny fix that updates the swizzle to match [ElementX](https://github.com/vector-im/element-x-ios/blob/b6b8b4be26b0d14a172f24b4a2818e17c490fd5e/ElementX/Sources/Other/HTMLParsing/UIFont%2BAttributedStringBuilder.m#L33) as it doesn't work when using the Designed for iPad version of Element on M1.

| Before | After |
| - | - |
| <img alt="Screenshot 2022-06-24 at 11 08 21 am" src="https://user-images.githubusercontent.com/6060466/175514056-5b55effa-477b-49ef-a4f8-4929f32b1310.png"> | <img alt="Screenshot 2022-06-24 at 11 09 17 am" src="https://user-images.githubusercontent.com/6060466/175514063-5079c358-33b5-4614-a076-49405f6fdf3d.png"> |

