### PR TITLE
Add support for in-app notifications.

### DIFF
--- a/Riot/Managers/PushNotification/PushNotificationService.m
+++ b/Riot/Managers/PushNotification/PushNotificationService.m
@@ -335,7 +335,7 @@ Matrix session observer used to detect new opened sessions.
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
     NSDictionary *userInfo = notification.request.content.userInfo;
-    if (userInfo[Constants.userInfoKeyPresentNotificationOnForeground])
+    if (RiotSettings.shared.showInAppNotifications || userInfo[Constants.userInfoKeyPresentNotificationOnForeground])
     {
         if (!userInfo[Constants.userInfoKeyPresentNotificationInRoom]
             && [[AppDelegate theDelegate].visibleRoomId isEqualToString:userInfo[@"room_id"]])
@@ -347,7 +347,7 @@ Matrix session observer used to detect new opened sessions.
         {
             completionHandler(UNNotificationPresentationOptionBadge
                               | UNNotificationPresentationOptionSound
-                              | UNNotificationPresentationOptionAlert);
+                              | UNNotificationPresentationOptionBanner);
         }
     }
     else

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -80,6 +80,10 @@ final class RiotSettings: NSObject {
         return RiotSettings.defaults.object(forKey: UserDefaultsKeys.notificationsShowDecryptedContent) != nil
     }
     
+    /// Indicate if notifications should be shown whilst the app is in the foreground.
+    @UserDefault(key: "showInAppNotifications", defaultValue: true, storage: defaults)
+    var showInAppNotifications
+    
     /// Indicate if encrypted messages content should be displayed in notifications.
     @UserDefault(key: UserDefaultsKeys.notificationsShowDecryptedContent, defaultValue: false, storage: defaults)
     var showDecryptedContentInNotifications

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -102,6 +102,7 @@ typedef NS_ENUM(NSUInteger, LINKS_SHOW_URL_PREVIEWS)
 typedef NS_ENUM(NSUInteger, NOTIFICATION_SETTINGS)
 {
     NOTIFICATION_SETTINGS_ENABLE_PUSH_INDEX = 0,
+    NOTIFICATION_SETTINGS_SHOW_IN_APP_INDEX,
     NOTIFICATION_SETTINGS_SYSTEM_SETTINGS,
     NOTIFICATION_SETTINGS_SHOW_DECODED_CONTENT,
     NOTIFICATION_SETTINGS_PIN_MISSED_NOTIFICATIONS_INDEX,
@@ -409,6 +410,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     
     Section *sectionNotificationSettings = [Section sectionWithTag:SECTION_TAG_NOTIFICATIONS];
     [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_ENABLE_PUSH_INDEX];
+    [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_SHOW_IN_APP_INDEX];
     [sectionNotificationSettings addRowWithTag:NOTIFICATION_SETTINGS_SYSTEM_SETTINGS];
     if (RiotSettings.shared.settingsScreenShowNotificationDecodedContentOption)
     {
@@ -2060,6 +2062,18 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
             
             cell = labelAndSwitchCell;
         }
+        else if (row == NOTIFICATION_SETTINGS_SHOW_IN_APP_INDEX)
+        {
+            MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
+            
+            labelAndSwitchCell.mxkLabel.text = VectorL10n.settingsEnableInappNotifications;
+            labelAndSwitchCell.mxkSwitch.on = RiotSettings.shared.showInAppNotifications;
+            labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
+            labelAndSwitchCell.mxkSwitch.enabled = account.pushNotificationServiceIsActive;
+            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleShowInAppNotifications:) forControlEvents:UIControlEventTouchUpInside];
+            
+            cell = labelAndSwitchCell;
+        }
         else if (row == NOTIFICATION_SETTINGS_SYSTEM_SETTINGS)
         {
             cell = [tableView dequeueReusableCellWithIdentifier:kSettingsViewControllerPhoneBookCountryCellId];
@@ -3163,6 +3177,11 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
             }];
         }
     }
+}
+
+- (void)toggleShowInAppNotifications:(UISwitch *)sender
+{
+    RiotSettings.shared.showInAppNotifications = sender.isOn;
 }
 
 - (void)openSystemSettingsApp

--- a/changelog.d/1108.feature
+++ b/changelog.d/1108.feature
@@ -1,0 +1,1 @@
+Notifications: Add a setting for in-app notifications and use the value with existing functionality in PushNotificationService.


### PR DESCRIPTION
The old in app notifications UI from the app delegate was an alert which was rather obtrusive. However `PushNotificationService` included a way for a notification to request in-app presentation (and makes sure to only do so if the room is not currently visible). This PR adds a setting that is checked in the service alongside the notification content and removes the old UI.

Could do with direction from Product on whether
1. A setting is definitely needed or this should be always on?
2. If the setting is kept, whether it should be enabled or disabled by default?
3. The string (re-used from MatrixKit) should be updated to use sentence case like the other settings?

| Settings | Notification |
| - | - |
| ![IMG_0422](https://user-images.githubusercontent.com/6060466/175529442-86d9f7a6-dfb7-4d8b-b486-40e88bdee2b5.PNG) | ![IMG_0423](https://user-images.githubusercontent.com/6060466/175529450-a662bb83-902d-4980-931b-eb0b37f8022e.PNG) |