### PR TITLE
A11y: VoiceOver: Properly end the active AVAudioSession when recording finishes, causing VO audio to be routed back to the main speaker instead of the earpiece.

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioRecorder.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioRecorder.swift
@@ -75,6 +75,13 @@ class VoiceMessageAudioRecorder: NSObject, AVAudioRecorderDelegate {
 
     func stopRecording() {
         audioRecorder?.stop()
+        do {
+            try AVAudioSession.sharedInstance().setActive(false)
+        } catch {
+            delegateContainer.notifyDelegatesWithBlock { delegate in
+                (delegate as? VoiceMessageAudioRecorderDelegate)?.audioRecorder(self, didFailWithError: VoiceMessageAudioRecorderError.genericError) }
+        }
+
     }
     
     func peakPowerForChannelNumber(_ channelNumber: Int) -> Float {


### PR DESCRIPTION
### Issue Summary

When a VoiceOver user on iPhone records a voice message in Element, all VoiceOver speech and sounds are being routed to the earpiece instead of the main speaker once recording finishes.
This is quite a severe issue, as it makes VoiceOver almost unusable.

### Problem Resolution

The cause of this issue is that currently, the AVAudiosession is not being ended properly, and is thus being kept active by the OS even after voice message recording has stopped.

This PR resolves this by calling
AVAudioSession.sharedInstance().setActive(false)
when recording ends.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
