### PR TITLE
Use ZXing library to generate QR codes

### DIFF
--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
@@ -17,6 +17,7 @@
  */
 
 import UIKit
+import MatrixSDK
 
 final class KeyVerificationVerifyByScanningViewController: UIViewController {
     
@@ -215,7 +216,12 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
     
     private func qrCodeImage(from data: Data) -> UIImage? {
         let codeGenerator = QRCodeGenerator()
-        return codeGenerator.generateCode(from: data, with: self.codeImageView.frame.size)
+        do {
+            return try codeGenerator.generateCode(from: data, with: codeImageView.frame.size)
+        } catch {
+            MXLog.error("[KeyVerificationVerifyByScanningViewController] qrCodeImage: cannot generate QR code - \(error)")
+            return nil
+        }
     }
     
     private func presentQRCodeReader(animated: Bool) {

--- a/changelog.d/6358.bugfix
+++ b/changelog.d/6358.bugfix
@@ -1,0 +1,1 @@
+Cross-Signing: Use ZXing library to generate QR codes


### PR DESCRIPTION
Resolves https://github.com/vector-im/element-ios/issues/6358

I do not have a ton of historical context here ...

At the moment cross-signing works between most clients but when scanning QR code generated on iOS by an Android device, the cross-signing fails (the opposite direction works). Both clients use ZXing library to scan QR code image, but only Android uses it to also generate one. On iOS we (used to) use native `CIFilter`.

After some rabbit hole investigation as to why Android cannot parse the iOS image I found that parsing works correctly if all data is a so-called [byte mode](https://github.com/zxingify/zxingify-objc/blob/e75eeff2089d66fc94514b43db3678a8812a9bbe/ZXingObjC/qrcode/decoder/ZXQRCodeMode.h#L49). This is similar to an issue discovered in [Rust-SDK](https://github.com/matrix-org/matrix-rust-sdk/commit/63dc939081c3a892bda0be905c7c954324c63c3e#diff-8d31e2f19de5fc895265d12f3dc9ae3fd32c7db30b63c023dc775b6927b9f57aR77-R87). When using `CIFilter` however the client has no control over the format of the data and in fact it gets scanned as a series of [alphanumeric](https://github.com/zxingify/zxingify-objc/blob/e75eeff2089d66fc94514b43db3678a8812a9bbe/ZXingObjC/qrcode/decoder/ZXQRCodeMode.h#L47), [numeric](https://github.com/zxingify/zxingify-objc/blob/e75eeff2089d66fc94514b43db3678a8812a9bbe/ZXingObjC/qrcode/decoder/ZXQRCodeMode.h#L46) and byte modes. As a result not all tokens get parsed properly and verification fails.

I could not find out whether the parsing failure is due to bad parsing implementation or flaky QR code format that we use. The simplest solution for the time being is simply to swap `CIFilter` to use `ZXing` instead (as it already does for reading a QR code). With this switch iOS <> iOS as well as iOS <> Android cross-signing works correctly.