### PR TITLE
Target `SiriIntents`: Split `IntentHandler` into smaller files (#6203)

### DIFF
--- a/SiriIntents/ContactResolver/ContactResolver.h
+++ b/SiriIntents/ContactResolver/ContactResolver.h
@@ -1,0 +1,26 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "GeneratedInterface-Swift.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ContactResolver: NSObject <ContactResolving>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SiriIntents/ContactResolver/ContactResolver.m
+++ b/SiriIntents/ContactResolver/ContactResolver.m
@@ -1,0 +1,176 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "ContactResolver.h"
+@import Intents;
+#import "MXKAccountManager.h"
+
+@implementation ContactResolver
+
+- (void)resolveContacts:(nullable NSArray<INPerson *> *)contacts
+         withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion {
+    if (contacts.count == 0)
+    {
+        completion(@[[INPersonResolutionResult needsValue]]);
+        return;
+    }
+    else
+    {
+        // We don't iterate over array of contacts from passed intent
+        // since it's hard to imagine scenario with several callee
+        // so we just extract the first one
+        INPerson *callee = contacts.firstObject;
+        
+        // If this method is called after selection of the appropriate user, it will hold userId of an user to whom we must call
+        NSString *selectedUserId;
+        
+        // Check if the user has selected right room among several direct rooms from previous resolution process run
+        if (callee.customIdentifier.length)
+        {
+            // If callee will have the same name as one of the contact in the system contacts app
+            // Siri will pass us this contact in the intent.contacts array and we must provide the same count of
+            // resolution results as elements count in the intent.contact.
+            // So we just pass the same result at all iterations
+            NSMutableArray *resolutionResults = [NSMutableArray array];
+            for (NSInteger i = 0; i < contacts.count; ++i)
+                [resolutionResults addObject:[INPersonResolutionResult successWithResolvedPerson:callee]];
+            completion(resolutionResults);
+            return;
+        }
+        else
+        {
+            // This resolution process run after selecting appropriate user among suggested user list
+            selectedUserId = callee.personHandle.value;
+        }
+        
+        MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+        if (account)
+        {
+            MXFileStore *fileStore = [[MXFileStore alloc] initWithCredentials:account.mxCredentials];
+            [fileStore.roomSummaryStore fetchAllSummaries:^(NSArray<id<MXRoomSummaryProtocol>> * _Nonnull summaries) {
+                
+                // Contains userIds of all users with whom the current user has direct chats
+                // Use set to avoid duplicates
+                NSMutableSet<NSString *> *directUserIds = [NSMutableSet set];
+                
+                // Contains room summaries for all direct rooms connected with particular userId
+                NSMutableDictionary<NSString *, NSMutableArray<id<MXRoomSummaryProtocol>> *> *roomSummaries = [NSMutableDictionary dictionary];
+                
+                for (id<MXRoomSummaryProtocol> summary in summaries)
+                {
+                    // TODO: We also need to check if joined room members count equals 2
+                    // It is pointlessly to save rooms with 1 joined member or room with more than 2 joined members
+                    if (summary.isDirect)
+                    {
+                        NSString *directUserId = summary.directUserId;
+                        
+                        // Collect room summaries only for specified user
+                        if (selectedUserId && ![directUserId isEqualToString:selectedUserId])
+                            continue;
+                        
+                        // Save userId
+                        [directUserIds addObject:directUserId];
+                        
+                        // Save associated with diretUserId room summary
+                        NSMutableArray<id<MXRoomSummaryProtocol>> *userRoomSummaries = roomSummaries[directUserId];
+                        if (userRoomSummaries)
+                            [userRoomSummaries addObject:summary];
+                        else
+                            roomSummaries[directUserId] = [NSMutableArray arrayWithObject:summary];
+                    }
+                }
+                
+                [fileStore asyncUsersWithUserIds:directUserIds.allObjects success:^(NSArray<MXUser *> * _Nonnull users) {
+                    
+                    // Find users whose display name contains string presented us by Siri
+                    NSMutableArray<MXUser *> *matchingUsers = [NSMutableArray array];
+                    for (MXUser *user in users)
+                    {
+                        if (!user.displayname)
+                            continue;
+                        
+                        if (!NSEqualRanges([callee.displayName rangeOfString:user.displayname options:NSCaseInsensitiveSearch], (NSRange){NSNotFound,0}))
+                        {
+                            [matchingUsers addObject:user];
+                        }
+                    }
+
+                    NSMutableArray<INPerson *> *persons = [NSMutableArray array];
+                    
+                    if (matchingUsers.count == 1)
+                    {
+                        MXUser *user = matchingUsers.firstObject;
+                        
+                        // Provide to the user a list of direct rooms to choose from
+                        NSArray<id<MXRoomSummaryProtocol>> *summaries = roomSummaries[user.userId];
+                        for (id<MXRoomSummaryProtocol> summary in summaries)
+                        {
+                            INPersonHandle *personHandle = [[INPersonHandle alloc] initWithValue:user.userId type:INPersonHandleTypeUnknown];
+                            
+                            // For rooms we try to use room display name
+                            NSString *displayName = summary.displayname ? summary.displayname : user.displayname;
+                            
+                            INPerson *person = [[INPerson alloc] initWithPersonHandle:personHandle
+                                                                       nameComponents:nil
+                                                                          displayName:displayName
+                                                                                image:nil
+                                                                    contactIdentifier:nil
+                                                                     customIdentifier:summary.roomId];
+                            
+                            [persons addObject:person];
+                        }
+                    }
+                    else if (matchingUsers.count > 1)
+                    {
+                        // Provide to the user a list of users to choose from
+                        // This is the case when there are several users with the same name
+                        for (MXUser *user in matchingUsers)
+                        {
+                            INPersonHandle *personHandle = [[INPersonHandle alloc] initWithValue:user.userId type:INPersonHandleTypeUnknown];
+                            INPerson *person = [[INPerson alloc] initWithPersonHandle:personHandle
+                                                                       nameComponents:nil
+                                                                          displayName:user.displayname
+                                                                                image:nil
+                                                                    contactIdentifier:nil
+                                                                     customIdentifier:nil];
+                            
+                            [persons addObject:person];
+                        }
+                    }
+                    
+                    if (persons.count == 0)
+                    {
+                        completion(@[[INPersonResolutionResult unsupported]]);
+                    }
+                    else if (persons.count == 1)
+                    {
+                        completion(@[[INPersonResolutionResult successWithResolvedPerson:persons.firstObject]]);
+                    }
+                    else
+                    {
+                        completion(@[[INPersonResolutionResult disambiguationWithPeopleToDisambiguate:persons]]);
+                    }
+                } failure:nil];
+            }];
+        }
+        else
+        {
+            completion(@[[INPersonResolutionResult notRequired]]);
+        }
+    }
+}
+
+@end

--- a/SiriIntents/ContactResolver/ContactResolving.swift
+++ b/SiriIntents/ContactResolver/ContactResolving.swift
@@ -1,0 +1,22 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Intents
+
+@objc protocol ContactResolving {
+    func resolveContacts(_ contacts: [INPerson]?,
+                         withCompletion completion: @escaping ([INPersonResolutionResult]) -> Void)
+}

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -34,6 +34,8 @@
  */
 @property (nonatomic) MXRoom *selectedRoom;
 
+@property (nonatomic) id<ContactResolving> contactResolver;
+
 @end
 
 @interface IntentHandler (ContactResolving) <ContactResolving>
@@ -46,6 +48,8 @@
     self = [super init];
     if (self)
     {
+        _contactResolver = self;
+        
         // Set static application settings
         _configuration = [CommonConfiguration new];
         [_configuration setupSettings];
@@ -81,7 +85,7 @@
 
 - (void)resolveContactsForStartAudioCall:(INStartAudioCallIntent *)intent withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion
 {
-    [self resolveContacts:intent.contacts withCompletion:completion];
+    [self.contactResolver resolveContacts:intent.contacts withCompletion:completion];
 }
 
 - (void)confirmStartAudioCall:(INStartAudioCallIntent *)intent completion:(void (^)(INStartAudioCallIntentResponse * _Nonnull))completion
@@ -132,7 +136,7 @@
 
 - (void)resolveContactsForStartVideoCall:(INStartVideoCallIntent *)intent withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion
 {
-    [self resolveContacts:intent.contacts withCompletion:completion];
+    [self.contactResolver resolveContacts:intent.contacts withCompletion:completion];
 }
 
 - (void)confirmStartVideoCall:(INStartVideoCallIntent *)intent completion:(void (^)(INStartVideoCallIntentResponse * _Nonnull))completion
@@ -183,7 +187,7 @@
 
 - (void)resolveRecipientsForSendMessage:(INSendMessageIntent *)intent completion:(void (^)(NSArray<INSendMessageRecipientResolutionResult *> * _Nonnull))completion
 {
-    [self resolveContacts:intent.recipients withCompletion:completion];
+    [self.contactResolver resolveContacts:intent.recipients withCompletion:completion];
 }
 
 - (void)resolveContentForSendMessage:(INSendMessageIntent *)intent withCompletion:(void (^)(INStringResolutionResult * _Nonnull))completion

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -36,6 +36,7 @@
 @property (nonatomic) MXRoom *selectedRoom;
 
 @property (nonatomic) id<ContactResolving> contactResolver;
+@property (nonatomic) id<INStartAudioCallIntentHandling> startAudioCallIntentHandler;
 
 @end
 
@@ -47,6 +48,7 @@
     if (self)
     {
         _contactResolver = [[ContactResolver alloc] init];
+        _startAudioCallIntentHandler = self;
         
         // Set static application settings
         _configuration = [CommonConfiguration new];
@@ -76,6 +78,10 @@
 
 - (id)handlerForIntent:(INIntent *)intent
 {
+    if ([intent isKindOfClass:[INStartAudioCallIntent class]]) {
+        return self.startAudioCallIntentHandler;
+    }
+    
     return self;
 }
 

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -21,21 +21,16 @@
 #import "ContactResolver.h"
 #import "StartAudioCallIntentHandler.h"
 #import "StartVideoCallIntentHandler.h"
+#import "SendMessageIntentHandler.h"
 
 #if __has_include(<MatrixSDK/MXJingleCallStack.h>)
 #define CALL_STACK_JINGLE
 #endif
 
-@interface IntentHandler () <INSendMessageIntentHandling>
+@interface IntentHandler ()
 
 // Build Settings
 @property (nonatomic) id<Configurable> configuration;
-
-/**
- The room that is currently being used to send a message. This is to ensure a
- strong ref is maintained on the `MXRoom` until sending has completed.
- */
-@property (nonatomic) MXRoom *selectedRoom;
 
 @property (nonatomic) id<ContactResolving> contactResolver;
 @property (nonatomic) id<INStartAudioCallIntentHandling> startAudioCallIntentHandler;
@@ -54,7 +49,7 @@
         _contactResolver = [[ContactResolver alloc] init];
         _startAudioCallIntentHandler = [[StartAudioCallIntentHandler alloc] init];
         _startVideoCallIntentHandler = [[StartVideoCallIntentHandler alloc] init];
-        _sendMessageIntentHandler = self;
+        _sendMessageIntentHandler = [[SendMessageIntentHandler alloc] init];
         
         // Set static application settings
         _configuration = [CommonConfiguration new];
@@ -93,122 +88,6 @@
     }
     
     return self;
-}
-
-#pragma mark - INSendMessageIntentHandling
-
-- (void)resolveRecipientsForSendMessage:(INSendMessageIntent *)intent completion:(void (^)(NSArray<INSendMessageRecipientResolutionResult *> * _Nonnull))completion
-{
-    [self.contactResolver resolveContacts:intent.recipients withCompletion:completion];
-}
-
-- (void)resolveContentForSendMessage:(INSendMessageIntent *)intent withCompletion:(void (^)(INStringResolutionResult * _Nonnull))completion
-{
-    NSString *message = intent.content;
-    if (message && ![message isEqualToString:@""])
-        completion([INStringResolutionResult successWithResolvedString:message]);
-    else
-        completion([INStringResolutionResult needsValue]);
-}
-
-- (void)confirmSendMessage:(INSendMessageIntent *)intent completion:(void (^)(INSendMessageIntentResponse * _Nonnull))completion
-{
-    INSendMessageIntentResponse *response = nil;
-    
-    MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
-    if (account)
-    {
-        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass([INSendMessageIntent class])];
-        response = [[INSendMessageIntentResponse alloc] initWithCode:INSendMessageIntentResponseCodeReady userActivity:userActivity];
-    }
-    else
-    {
-        // User hasn't logged in
-        response = [[INSendMessageIntentResponse alloc] initWithCode:INSendMessageIntentResponseCodeFailureRequiringAppLaunch userActivity:nil];
-    }
-    
-    completion(response);
-}
-
-- (void)handleSendMessage:(INSendMessageIntent *)intent completion:(void (^)(INSendMessageIntentResponse * _Nonnull))completion
-{
-    void (^completeWithCode)(INSendMessageIntentResponseCode) = ^(INSendMessageIntentResponseCode code) {
-        NSUserActivity *userActivity = nil;
-        if (code == INSendMessageIntentResponseCodeSuccess)
-            userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass([INSendMessageIntent class])];
-        INSendMessageIntentResponse *response = [[INSendMessageIntentResponse alloc] initWithCode:INSendMessageIntentResponseCodeSuccess
-                                                                                     userActivity:userActivity];
-        completion(response);
-    };
-    
-    INPerson *person = intent.recipients.firstObject;
-    if (person && person.customIdentifier)
-    {
-        MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
-        MXFileStore *fileStore = [[MXFileStore alloc] initWithCredentials:account.mxCredentials];
-        [fileStore.roomSummaryStore fetchAllSummaries:^(NSArray<id<MXRoomSummaryProtocol>> * _Nonnull summaries) {
-            NSString *roomID = person.customIdentifier;
-            
-            BOOL isEncrypted = NO;
-            for (id<MXRoomSummaryProtocol> summary in summaries)
-            {
-                if ([summary.roomId isEqualToString:roomID])
-                {
-                    isEncrypted = summary.isEncrypted;
-                    break;
-                }
-            }
-
-            if (isEncrypted)
-            {
-                [MXFileStore setPreloadOptions:0];
-
-                MXSession *session = [[MXSession alloc] initWithMatrixRestClient:account.mxRestClient];
-                MXWeakify(session);
-                [session setStore:fileStore success:^{
-                    MXStrongifyAndReturnIfNil(session);
-
-                    self.selectedRoom = [MXRoom loadRoomFromStore:fileStore withRoomId:roomID matrixSession:session];
-
-                    // Do not warn for unknown devices. We have cross-signing now
-                    session.crypto.warnOnUnknowDevices = NO;
-
-                    MXWeakify(self);
-                    [self.selectedRoom sendTextMessage:intent.content
-                                              threadId:nil
-                                               success:^(NSString *eventId) {
-                        completeWithCode(INSendMessageIntentResponseCodeSuccess);
-                        MXStrongifyAndReturnIfNil(self);
-                        self.selectedRoom = nil;
-                    } failure:^(NSError *error) {
-                        completeWithCode(INSendMessageIntentResponseCodeFailure);
-                        MXStrongifyAndReturnIfNil(self);
-                        self.selectedRoom = nil;
-                    }];
-
-                } failure:^(NSError *error) {
-                    completeWithCode(INSendMessageIntentResponseCodeFailure);
-                }];
-
-                return;
-            }
-            
-            [account.mxRestClient sendTextMessageToRoom:roomID
-                                               threadId:nil
-                                                   text:intent.content
-                                                success:^(NSString *eventId) {
-                completeWithCode(INSendMessageIntentResponseCodeSuccess);
-            }
-                                                failure:^(NSError *error) {
-                completeWithCode(INSendMessageIntentResponseCodeFailure);
-            }];
-            
-        }];
-    }
-    else
-    {
-        completeWithCode(INSendMessageIntentResponseCodeFailure);
-    }
 }
 
 @end

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -18,6 +18,7 @@
 
 #import "GeneratedInterface-Swift.h"
 #import "MXKAccountManager.h"
+#import "ContactResolver.h"
 
 #if __has_include(<MatrixSDK/MXJingleCallStack.h>)
 #define CALL_STACK_JINGLE
@@ -36,9 +37,6 @@
 
 @property (nonatomic) id<ContactResolving> contactResolver;
 
-@end
-
-@interface ContactResolver: NSObject <ContactResolving>
 @end
 
 @implementation IntentHandler
@@ -300,161 +298,3 @@
 }
 
 @end
-
-@implementation ContactResolver
-
-- (void)resolveContacts:(nullable NSArray<INPerson *> *)contacts
-         withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion {
-    if (contacts.count == 0)
-    {
-        completion(@[[INPersonResolutionResult needsValue]]);
-        return;
-    }
-    else
-    {
-        // We don't iterate over array of contacts from passed intent
-        // since it's hard to imagine scenario with several callee
-        // so we just extract the first one
-        INPerson *callee = contacts.firstObject;
-        
-        // If this method is called after selection of the appropriate user, it will hold userId of an user to whom we must call
-        NSString *selectedUserId;
-        
-        // Check if the user has selected right room among several direct rooms from previous resolution process run
-        if (callee.customIdentifier.length)
-        {
-            // If callee will have the same name as one of the contact in the system contacts app
-            // Siri will pass us this contact in the intent.contacts array and we must provide the same count of
-            // resolution results as elements count in the intent.contact.
-            // So we just pass the same result at all iterations
-            NSMutableArray *resolutionResults = [NSMutableArray array];
-            for (NSInteger i = 0; i < contacts.count; ++i)
-                [resolutionResults addObject:[INPersonResolutionResult successWithResolvedPerson:callee]];
-            completion(resolutionResults);
-            return;
-        }
-        else
-        {
-            // This resolution process run after selecting appropriate user among suggested user list
-            selectedUserId = callee.personHandle.value;
-        }
-        
-        MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
-        if (account)
-        {
-            MXFileStore *fileStore = [[MXFileStore alloc] initWithCredentials:account.mxCredentials];
-            [fileStore.roomSummaryStore fetchAllSummaries:^(NSArray<id<MXRoomSummaryProtocol>> * _Nonnull summaries) {
-                
-                // Contains userIds of all users with whom the current user has direct chats
-                // Use set to avoid duplicates
-                NSMutableSet<NSString *> *directUserIds = [NSMutableSet set];
-                
-                // Contains room summaries for all direct rooms connected with particular userId
-                NSMutableDictionary<NSString *, NSMutableArray<id<MXRoomSummaryProtocol>> *> *roomSummaries = [NSMutableDictionary dictionary];
-                
-                for (id<MXRoomSummaryProtocol> summary in summaries)
-                {
-                    // TODO: We also need to check if joined room members count equals 2
-                    // It is pointlessly to save rooms with 1 joined member or room with more than 2 joined members
-                    if (summary.isDirect)
-                    {
-                        NSString *directUserId = summary.directUserId;
-                        
-                        // Collect room summaries only for specified user
-                        if (selectedUserId && ![directUserId isEqualToString:selectedUserId])
-                            continue;
-                        
-                        // Save userId
-                        [directUserIds addObject:directUserId];
-                        
-                        // Save associated with diretUserId room summary
-                        NSMutableArray<id<MXRoomSummaryProtocol>> *userRoomSummaries = roomSummaries[directUserId];
-                        if (userRoomSummaries)
-                            [userRoomSummaries addObject:summary];
-                        else
-                            roomSummaries[directUserId] = [NSMutableArray arrayWithObject:summary];
-                    }
-                }
-                
-                [fileStore asyncUsersWithUserIds:directUserIds.allObjects success:^(NSArray<MXUser *> * _Nonnull users) {
-                    
-                    // Find users whose display name contains string presented us by Siri
-                    NSMutableArray<MXUser *> *matchingUsers = [NSMutableArray array];
-                    for (MXUser *user in users)
-                    {
-                        if (!user.displayname)
-                            continue;
-                        
-                        if (!NSEqualRanges([callee.displayName rangeOfString:user.displayname options:NSCaseInsensitiveSearch], (NSRange){NSNotFound,0}))
-                        {
-                            [matchingUsers addObject:user];
-                        }
-                    }
-
-                    NSMutableArray<INPerson *> *persons = [NSMutableArray array];
-                    
-                    if (matchingUsers.count == 1)
-                    {
-                        MXUser *user = matchingUsers.firstObject;
-                        
-                        // Provide to the user a list of direct rooms to choose from
-                        NSArray<id<MXRoomSummaryProtocol>> *summaries = roomSummaries[user.userId];
-                        for (id<MXRoomSummaryProtocol> summary in summaries)
-                        {
-                            INPersonHandle *personHandle = [[INPersonHandle alloc] initWithValue:user.userId type:INPersonHandleTypeUnknown];
-                            
-                            // For rooms we try to use room display name
-                            NSString *displayName = summary.displayname ? summary.displayname : user.displayname;
-                            
-                            INPerson *person = [[INPerson alloc] initWithPersonHandle:personHandle
-                                                                       nameComponents:nil
-                                                                          displayName:displayName
-                                                                                image:nil
-                                                                    contactIdentifier:nil
-                                                                     customIdentifier:summary.roomId];
-                            
-                            [persons addObject:person];
-                        }
-                    }
-                    else if (matchingUsers.count > 1)
-                    {
-                        // Provide to the user a list of users to choose from
-                        // This is the case when there are several users with the same name
-                        for (MXUser *user in matchingUsers)
-                        {
-                            INPersonHandle *personHandle = [[INPersonHandle alloc] initWithValue:user.userId type:INPersonHandleTypeUnknown];
-                            INPerson *person = [[INPerson alloc] initWithPersonHandle:personHandle
-                                                                       nameComponents:nil
-                                                                          displayName:user.displayname
-                                                                                image:nil
-                                                                    contactIdentifier:nil
-                                                                     customIdentifier:nil];
-                            
-                            [persons addObject:person];
-                        }
-                    }
-                    
-                    if (persons.count == 0)
-                    {
-                        completion(@[[INPersonResolutionResult unsupported]]);
-                    }
-                    else if (persons.count == 1)
-                    {
-                        completion(@[[INPersonResolutionResult successWithResolvedPerson:persons.firstObject]]);
-                    }
-                    else
-                    {
-                        completion(@[[INPersonResolutionResult disambiguationWithPeopleToDisambiguate:persons]]);
-                    }
-                } failure:nil];
-            }];
-        }
-        else
-        {
-            completion(@[[INPersonResolutionResult notRequired]]);
-        }
-    }
-}
-
-@end
-

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -32,7 +32,6 @@
 // Build Settings
 @property (nonatomic) id<Configurable> configuration;
 
-@property (nonatomic) id<ContactResolving> contactResolver;
 @property (nonatomic) id<INStartAudioCallIntentHandling> startAudioCallIntentHandler;
 @property (nonatomic) id<INStartVideoCallIntentHandling> startVideoCallIntentHandler;
 @property (nonatomic) id<INSendMessageIntentHandling> sendMessageIntentHandler;
@@ -46,7 +45,6 @@
     self = [super init];
     if (self)
     {
-        _contactResolver = [[ContactResolver alloc] init];
         _startAudioCallIntentHandler = [[StartAudioCallIntentHandler alloc] init];
         _startVideoCallIntentHandler = [[StartVideoCallIntentHandler alloc] init];
         _sendMessageIntentHandler = [[SendMessageIntentHandler alloc] init];

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -45,10 +45,6 @@
     self = [super init];
     if (self)
     {
-        _startAudioCallIntentHandler = [[StartAudioCallIntentHandler alloc] init];
-        _startVideoCallIntentHandler = [[StartVideoCallIntentHandler alloc] init];
-        _sendMessageIntentHandler = [[SendMessageIntentHandler alloc] init];
-        
         // Set static application settings
         _configuration = [CommonConfiguration new];
         [_configuration setupSettings];
@@ -71,6 +67,10 @@
         Analytics *analytics = Analytics.shared;
         [MXSDKOptions sharedInstance].analyticsDelegate = analytics;
         [analytics startIfEnabled];
+        
+        _startAudioCallIntentHandler = [[StartAudioCallIntentHandler alloc] init];
+        _startVideoCallIntentHandler = [[StartVideoCallIntentHandler alloc] init];
+        _sendMessageIntentHandler = [[SendMessageIntentHandler alloc] init];
     }
     return self;
 }

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -38,7 +38,7 @@
 
 @end
 
-@interface IntentHandler (ContactResolving) <ContactResolving>
+@interface ContactResolver: NSObject <ContactResolving>
 @end
 
 @implementation IntentHandler
@@ -48,7 +48,7 @@
     self = [super init];
     if (self)
     {
-        _contactResolver = self;
+        _contactResolver = [[ContactResolver alloc] init];
         
         // Set static application settings
         _configuration = [CommonConfiguration new];
@@ -301,7 +301,7 @@
 
 @end
 
-@implementation IntentHandler (ContactResolving)
+@implementation ContactResolver
 
 - (void)resolveContacts:(nullable NSArray<INPerson *> *)contacts
          withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion {

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -40,6 +40,7 @@
 @property (nonatomic) id<ContactResolving> contactResolver;
 @property (nonatomic) id<INStartAudioCallIntentHandling> startAudioCallIntentHandler;
 @property (nonatomic) id<INStartVideoCallIntentHandling> startVideoCallIntentHandler;
+@property (nonatomic) id<INSendMessageIntentHandling> sendMessageIntentHandler;
 
 @end
 
@@ -53,6 +54,7 @@
         _contactResolver = [[ContactResolver alloc] init];
         _startAudioCallIntentHandler = [[StartAudioCallIntentHandler alloc] init];
         _startVideoCallIntentHandler = [[StartVideoCallIntentHandler alloc] init];
+        _sendMessageIntentHandler = self;
         
         // Set static application settings
         _configuration = [CommonConfiguration new];
@@ -86,6 +88,8 @@
         return self.startAudioCallIntentHandler;
     } else if ([intent isKindOfClass:[INStartVideoCallIntent class]]) {
         return self.startVideoCallIntentHandler;
+    } else if ([intent isKindOfClass:[INSendMessageIntent class]]) {
+        return self.sendMessageIntentHandler;
     }
     
     return self;

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -38,6 +38,7 @@
 
 @property (nonatomic) id<ContactResolving> contactResolver;
 @property (nonatomic) id<INStartAudioCallIntentHandling> startAudioCallIntentHandler;
+@property (nonatomic) id<INStartVideoCallIntentHandling> startVideoCallIntentHandler;
 
 @end
 
@@ -50,6 +51,7 @@
     {
         _contactResolver = [[ContactResolver alloc] init];
         _startAudioCallIntentHandler = [[StartAudioCallIntentHandler alloc] init];
+        _startVideoCallIntentHandler = self;
         
         // Set static application settings
         _configuration = [CommonConfiguration new];
@@ -81,6 +83,8 @@
 {
     if ([intent isKindOfClass:[INStartAudioCallIntent class]]) {
         return self.startAudioCallIntentHandler;
+    } else if ([intent isKindOfClass:[INStartVideoCallIntent class]]) {
+        return self.startVideoCallIntentHandler;
     }
     
     return self;

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -85,7 +85,7 @@
         return self.sendMessageIntentHandler;
     }
     
-    return self;
+    return nil;
 }
 
 @end

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -36,6 +36,9 @@
 
 @end
 
+@interface IntentHandler (ContactResolving) <ContactResolving>
+@end
+
 @implementation IntentHandler
 
 - (instancetype)init
@@ -292,10 +295,12 @@
     }
 }
 
-#pragma mark - Private
+@end
 
-- (void)resolveContacts:(nullable NSArray<INPerson *> *)contacts withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion
-{
+@implementation IntentHandler (ContactResolving)
+
+- (void)resolveContacts:(nullable NSArray<INPerson *> *)contacts
+         withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion {
     if (contacts.count == 0)
     {
         completion(@[[INPersonResolutionResult needsValue]]);
@@ -448,3 +453,4 @@
 }
 
 @end
+

--- a/SiriIntents/IntentHandlers/SendMessage/SendMessageIntentHandler.h
+++ b/SiriIntents/IntentHandlers/SendMessage/SendMessageIntentHandler.h
@@ -1,0 +1,26 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+@import Intents;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SendMessageIntentHandler : NSObject <INSendMessageIntentHandling>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SiriIntents/IntentHandlers/SendMessage/SendMessageIntentHandler.m
+++ b/SiriIntents/IntentHandlers/SendMessage/SendMessageIntentHandler.m
@@ -1,0 +1,159 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "SendMessageIntentHandler.h"
+#import "ContactResolver.h"
+#import "MXKAccountManager.h"
+
+@interface SendMessageIntentHandler ()
+
+@property (nonatomic) id<ContactResolving> contactResolver;
+
+/**
+ The room that is currently being used to send a message. This is to ensure a
+ strong ref is maintained on the `MXRoom` until sending has completed.
+ */
+@property (nonatomic) MXRoom *selectedRoom;
+
+@end
+
+@implementation SendMessageIntentHandler
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _contactResolver = [[ContactResolver alloc] init];
+    }
+    
+    return self;
+}
+
+#pragma mark - INSendMessageIntentHandling
+
+- (void)resolveRecipientsForSendMessage:(INSendMessageIntent *)intent completion:(void (^)(NSArray<INSendMessageRecipientResolutionResult *> * _Nonnull))completion
+{
+    [self.contactResolver resolveContacts:intent.recipients withCompletion:completion];
+}
+
+- (void)resolveContentForSendMessage:(INSendMessageIntent *)intent withCompletion:(void (^)(INStringResolutionResult * _Nonnull))completion
+{
+    NSString *message = intent.content;
+    if (message && ![message isEqualToString:@""])
+        completion([INStringResolutionResult successWithResolvedString:message]);
+    else
+        completion([INStringResolutionResult needsValue]);
+}
+
+- (void)confirmSendMessage:(INSendMessageIntent *)intent completion:(void (^)(INSendMessageIntentResponse * _Nonnull))completion
+{
+    INSendMessageIntentResponse *response = nil;
+    
+    MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+    if (account)
+    {
+        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass([INSendMessageIntent class])];
+        response = [[INSendMessageIntentResponse alloc] initWithCode:INSendMessageIntentResponseCodeReady userActivity:userActivity];
+    }
+    else
+    {
+        // User hasn't logged in
+        response = [[INSendMessageIntentResponse alloc] initWithCode:INSendMessageIntentResponseCodeFailureRequiringAppLaunch userActivity:nil];
+    }
+    
+    completion(response);
+}
+
+- (void)handleSendMessage:(INSendMessageIntent *)intent completion:(void (^)(INSendMessageIntentResponse * _Nonnull))completion
+{
+    void (^completeWithCode)(INSendMessageIntentResponseCode) = ^(INSendMessageIntentResponseCode code) {
+        NSUserActivity *userActivity = nil;
+        if (code == INSendMessageIntentResponseCodeSuccess)
+            userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass([INSendMessageIntent class])];
+        INSendMessageIntentResponse *response = [[INSendMessageIntentResponse alloc] initWithCode:INSendMessageIntentResponseCodeSuccess
+                                                                                     userActivity:userActivity];
+        completion(response);
+    };
+    
+    INPerson *person = intent.recipients.firstObject;
+    if (person && person.customIdentifier)
+    {
+        MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+        MXFileStore *fileStore = [[MXFileStore alloc] initWithCredentials:account.mxCredentials];
+        [fileStore.roomSummaryStore fetchAllSummaries:^(NSArray<id<MXRoomSummaryProtocol>> * _Nonnull summaries) {
+            NSString *roomID = person.customIdentifier;
+            
+            BOOL isEncrypted = NO;
+            for (id<MXRoomSummaryProtocol> summary in summaries)
+            {
+                if ([summary.roomId isEqualToString:roomID])
+                {
+                    isEncrypted = summary.isEncrypted;
+                    break;
+                }
+            }
+
+            if (isEncrypted)
+            {
+                [MXFileStore setPreloadOptions:0];
+
+                MXSession *session = [[MXSession alloc] initWithMatrixRestClient:account.mxRestClient];
+                MXWeakify(session);
+                [session setStore:fileStore success:^{
+                    MXStrongifyAndReturnIfNil(session);
+
+                    self.selectedRoom = [MXRoom loadRoomFromStore:fileStore withRoomId:roomID matrixSession:session];
+
+                    // Do not warn for unknown devices. We have cross-signing now
+                    session.crypto.warnOnUnknowDevices = NO;
+
+                    MXWeakify(self);
+                    [self.selectedRoom sendTextMessage:intent.content
+                                              threadId:nil
+                                               success:^(NSString *eventId) {
+                        completeWithCode(INSendMessageIntentResponseCodeSuccess);
+                        MXStrongifyAndReturnIfNil(self);
+                        self.selectedRoom = nil;
+                    } failure:^(NSError *error) {
+                        completeWithCode(INSendMessageIntentResponseCodeFailure);
+                        MXStrongifyAndReturnIfNil(self);
+                        self.selectedRoom = nil;
+                    }];
+
+                } failure:^(NSError *error) {
+                    completeWithCode(INSendMessageIntentResponseCodeFailure);
+                }];
+
+                return;
+            }
+            
+            [account.mxRestClient sendTextMessageToRoom:roomID
+                                               threadId:nil
+                                                   text:intent.content
+                                                success:^(NSString *eventId) {
+                completeWithCode(INSendMessageIntentResponseCodeSuccess);
+            }
+                                                failure:^(NSError *error) {
+                completeWithCode(INSendMessageIntentResponseCodeFailure);
+            }];
+            
+        }];
+    }
+    else
+    {
+        completeWithCode(INSendMessageIntentResponseCodeFailure);
+    }
+}
+
+@end

--- a/SiriIntents/IntentHandlers/StartAudioCall/StartAudioCallIntentHandler.h
+++ b/SiriIntents/IntentHandlers/StartAudioCall/StartAudioCallIntentHandler.h
@@ -1,0 +1,27 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+@import Intents;
+#import "GeneratedInterface-Swift.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface StartAudioCallIntentHandler : NSObject <INStartAudioCallIntentHandling>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SiriIntents/IntentHandlers/StartAudioCall/StartAudioCallIntentHandler.m
+++ b/SiriIntents/IntentHandlers/StartAudioCall/StartAudioCallIntentHandler.m
@@ -1,0 +1,88 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "StartAudioCallIntentHandler.h"
+#import "MXKAccountManager.h"
+#import "ContactResolver.h"
+
+@interface StartAudioCallIntentHandler ()
+
+@property (nonatomic) id<ContactResolving> contactResolver;
+
+@end
+
+@implementation StartAudioCallIntentHandler
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _contactResolver = [[ContactResolver alloc] init];
+    }
+    
+    return self;
+}
+
+#pragma mark - INStartAudioCallIntentHandling
+
+- (void)resolveContactsForStartAudioCall:(INStartAudioCallIntent *)intent withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion
+{
+    [self.contactResolver resolveContacts:intent.contacts withCompletion:completion];
+}
+
+- (void)confirmStartAudioCall:(INStartAudioCallIntent *)intent completion:(void (^)(INStartAudioCallIntentResponse * _Nonnull))completion
+{
+    INStartAudioCallIntentResponse *response = nil;
+    
+    MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+    if (account)
+    {
+#if defined MX_CALL_STACK_OPENWEBRTC || defined MX_CALL_STACK_ENDPOINT || defined CALL_STACK_JINGLE
+        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass([INStartAudioCallIntent class])];
+        response = [[INStartAudioCallIntentResponse alloc] initWithCode:INStartAudioCallIntentResponseCodeReady userActivity:userActivity];
+#else
+        response = [[INStartAudioCallIntentResponse alloc] initWithCode:INStartAudioCallIntentResponseCodeFailureCallingServiceNotAvailable userActivity:nil];
+#endif
+    }
+    else
+    {
+        // User hasn't logged in
+        response = [[INStartAudioCallIntentResponse alloc] initWithCode:INStartAudioCallIntentResponseCodeFailureAppConfigurationRequired userActivity:nil];
+    }
+    
+    completion(response);
+}
+
+- (void)handleStartAudioCall:(INStartAudioCallIntent *)intent completion:(void (^)(INStartAudioCallIntentResponse * _Nonnull))completion
+{
+    INStartAudioCallIntentResponse *response = nil;
+    
+    INPerson *person = intent.contacts.firstObject;
+    if (person && person.customIdentifier)
+    {
+        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass(INStartAudioCallIntent.class)];
+        userActivity.userInfo = @{ @"roomID" : person.customIdentifier };
+        
+        response = [[INStartAudioCallIntentResponse alloc] initWithCode:INStartAudioCallIntentResponseCodeContinueInApp
+                                                           userActivity:userActivity];
+    }
+    else
+    {
+        response = [[INStartAudioCallIntentResponse alloc] initWithCode:INStartAudioCallIntentResponseCodeFailure userActivity:nil];
+    }
+
+    completion(response);
+}
+
+@end

--- a/SiriIntents/IntentHandlers/StartVideoCall/StartVideoCallIntentHandler.h
+++ b/SiriIntents/IntentHandlers/StartVideoCall/StartVideoCallIntentHandler.h
@@ -1,0 +1,26 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+@import Intents;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface StartVideoCallIntentHandler : NSObject <INStartVideoCallIntentHandling>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SiriIntents/IntentHandlers/StartVideoCall/StartVideoCallIntentHandler.m
+++ b/SiriIntents/IntentHandlers/StartVideoCall/StartVideoCallIntentHandler.m
@@ -1,0 +1,88 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "StartVideoCallIntentHandler.h"
+#import "ContactResolver.h"
+#import "MXKAccountManager.h"
+
+@interface StartVideoCallIntentHandler ()
+
+@property (nonatomic) id<ContactResolving> contactResolver;
+
+@end
+
+@implementation StartVideoCallIntentHandler
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _contactResolver = [[ContactResolver alloc] init];
+    }
+    
+    return self;
+}
+
+#pragma mark - INStartVideoCallIntentHandling
+
+- (void)resolveContactsForStartVideoCall:(INStartVideoCallIntent *)intent withCompletion:(void (^)(NSArray<INPersonResolutionResult *> * _Nonnull))completion
+{
+    [self.contactResolver resolveContacts:intent.contacts withCompletion:completion];
+}
+
+- (void)confirmStartVideoCall:(INStartVideoCallIntent *)intent completion:(void (^)(INStartVideoCallIntentResponse * _Nonnull))completion
+{
+    INStartVideoCallIntentResponse *response = nil;
+    
+    MXKAccount *account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+    if (account)
+    {
+#if defined MX_CALL_STACK_OPENWEBRTC || defined MX_CALL_STACK_ENDPOINT || defined CALL_STACK_JINGLE
+        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass([INStartVideoCallIntent class])];
+        response = [[INStartVideoCallIntentResponse alloc] initWithCode:INStartVideoCallIntentResponseCodeReady userActivity:userActivity];
+#else
+        response = [[INStartVideoCallIntentResponse alloc] initWithCode:INStartVideoCallIntentResponseCodeFailureCallingServiceNotAvailable userActivity:nil];
+#endif
+    }
+    else
+    {
+        // User hasn't logged in
+        response = [[INStartVideoCallIntentResponse alloc] initWithCode:INStartVideoCallIntentResponseCodeFailureRequiringAppLaunch userActivity:nil];
+    }
+    
+    completion(response);
+}
+
+- (void)handleStartVideoCall:(INStartVideoCallIntent *)intent completion:(void (^)(INStartVideoCallIntentResponse * _Nonnull))completion
+{
+    INStartVideoCallIntentResponse *response = nil;
+    
+    INPerson *person = intent.contacts.firstObject;
+    if (person && person.customIdentifier)
+    {
+        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSStringFromClass(INStartVideoCallIntent.class)];
+        userActivity.userInfo = @{ @"roomID" : person.customIdentifier };
+        
+        response = [[INStartVideoCallIntentResponse alloc] initWithCode:INStartVideoCallIntentResponseCodeContinueInApp
+                                                           userActivity:userActivity];
+    }
+    else
+    {
+        response = [[INStartVideoCallIntentResponse alloc] initWithCode:INStartVideoCallIntentResponseCodeFailure userActivity:nil];
+    }
+    
+    completion(response);
+}
+
+@end

--- a/changelog.d/6203.build
+++ b/changelog.d/6203.build
@@ -1,0 +1,1 @@
+Split `IntentHandler` into smaller, dedicated entities


### PR DESCRIPTION
### Introduction

This branch splits the `IntentHandler` and moves the functionality into dedicated classes.
This makes the code easier to read and maintain, and prepares the structure to add unit tests.

<img width="897" alt="Screenshot 2022-06-30 at 21 29 37" src="https://user-images.githubusercontent.com/1681085/176762100-a060a0a3-f475-4ac4-8b32-574725d4ea6a.png">

The intent handlers depend on `ContactResolving`, a protocol for what was previously a private method. By moving the shared functionality to this dedicated class, the dependency can later be injected and mocked for unit tests. As for the implementation of the handlers, I have merely moved the code to another place.

Altogether, this restructuring brings the number of lines for `IntentHandler` down from 450 to 92.

Signed-off-by: Wolfgang Timme [element-signoff@milchbartstrasse.de](mailto:element-signoff@milchbartstrasse.de)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
