### PR TITLE
Move room info back button title for translation

### DIFF
--- a/Riot/Assets/en.lproj/Untranslated.strings
+++ b/Riot/Assets/en.lproj/Untranslated.strings
@@ -88,6 +88,3 @@
 "password_validation_error_contain_uppercase_letter" = "Contain an upper-case letter.";
 "password_validation_error_contain_number" = "Contain a number.";
 "password_validation_error_contain_symbol" = "Contain a symbol.";
-
-// MARK: Room Info
-"room_info_back_button_title" = "Room Info";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1824,6 +1824,7 @@ Tap the + to start adding people.";
 "room_info_list_one_member" = "1 member";
 "room_info_list_several_members" = "%@ members";
 "room_info_list_section_other" = "Other";
+"room_info_back_button_title" = "Room Info";
 
 // MARK: - Dial Pad
 "dialpad_title" = "Dial pad";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -5251,6 +5251,10 @@ public class VectorL10n: NSObject {
   public static var roomEventFailedToSend: String { 
     return VectorL10n.tr("Vector", "room_event_failed_to_send") 
   }
+  /// Room Info
+  public static var roomInfoBackButtonTitle: String { 
+    return VectorL10n.tr("Vector", "room_info_back_button_title") 
+  }
   /// 1 member
   public static var roomInfoListOneMember: String { 
     return VectorL10n.tr("Vector", "room_info_list_one_member") 

--- a/Riot/Generated/UntranslatedStrings.swift
+++ b/Riot/Generated/UntranslatedStrings.swift
@@ -234,10 +234,6 @@ public extension VectorL10n {
   static var passwordValidationInfoHeader: String { 
     return VectorL10n.tr("Untranslated", "password_validation_info_header") 
   }
-  /// Room Info
-  static var roomInfoBackButtonTitle: String { 
-    return VectorL10n.tr("Untranslated", "room_info_back_button_title") 
-  }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 


### PR DESCRIPTION
This simply moves the "Room Info" back button title (visible on long press gestures) for translations, as discussed with Product. 
It's probably not worth a changelog unless someone thinks otherwise ? 