### PR TITLE
Rename riot-keys.txt to element-keys.txt.

### DIFF
--- a/Riot/Modules/KeyBackup/ManualExport/EncryptionKeysExportPresenter.swift
+++ b/Riot/Modules/KeyBackup/ManualExport/EncryptionKeysExportPresenter.swift
@@ -21,7 +21,7 @@ final class EncryptionKeysExportPresenter: NSObject {
     // MARK: - Constants
     
     private enum Constants {
-        static let keyExportFileName = "riot-keys.txt"
+        static let keyExportFileName = "element-keys.txt"
     }
     
     // MARK: - Properties

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -1445,7 +1445,7 @@ TableViewSectionsDelegate>
     currentAlert = exportView.alertController;
 
     // Use a temporary file for the export
-    keyExportsFile = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"riot-keys.txt"]];
+    keyExportsFile = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"element-keys.txt"]];
 
     // Make sure the file is empty
     [self deleteKeyExportFile];

--- a/changelog.d/6391.bugfix
+++ b/changelog.d/6391.bugfix
@@ -1,0 +1,1 @@
+Rename riot-keys.txt to element-keys.txt.


### PR DESCRIPTION
Fixes #6391.