### PR TITLE
Upload Dsyms to Sentry when building Alpha

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -91,6 +91,7 @@ jobs:
           FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           DIAWI_API_TOKEN: ${{ secrets.DIAWI_API_TOKEN }}
+          SENTRY_API_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
 
       - name: Add or update PR comment with Ad-hoc release informations
         uses: NejcZdovc/comment-pr@v1

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -49,13 +49,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
 
+      # Note: it is recommended to use setup-ruby action to cache gems
+      # https://github.com/actions/cache/blob/main/examples.md#ruby---bundler
       - name: Cache Ruby gems
-        uses: actions/cache@v2
+        uses: ruby/setup-ruby@v1
         with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          ruby-version: 2.6.9
+          bundler-cache: true
 
       # Make sure we use the latest version of MatrixSDK
       - name: Reset MatrixSDK pod

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -91,7 +91,7 @@ jobs:
           FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           DIAWI_API_TOKEN: ${{ secrets.DIAWI_API_TOKEN }}
-          SENTRY_API_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Add or update PR comment with Ad-hoc release informations
         uses: NejcZdovc/comment-pr@v1

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -49,13 +49,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
 
-      # Note: it is recommended to use setup-ruby action to cache gems
-      # https://github.com/actions/cache/blob/main/examples.md#ruby---bundler
       - name: Cache Ruby gems
-        uses: ruby/setup-ruby@v1
+        uses: actions/cache@v2
         with:
-          ruby-version: 2.6.9
-          bundler-cache: true
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
       # Make sure we use the latest version of MatrixSDK
       - name: Reset MatrixSDK pod
@@ -69,7 +69,6 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-          bundle exec fastlane update_plugins
       - name: Use right MatrixSDK versions
         run: bundle exec fastlane point_dependencies_to_related_branches
 

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+          bundle exec fastlane update_plugins
       - name: Use right MatrixSDK versions
         run: bundle exec fastlane point_dependencies_to_related_branches
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "xcodegen"
 brew "mint"
+brew "getsentry/tools/sentry-cli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     fastlane-plugin-brew (0.1.1)
     fastlane-plugin-diawi (2.1.0)
       rest-client (>= 2.0.0)
+    fastlane-plugin-sentry (1.12.1)
     fastlane-plugin-versioning (0.5.0)
     fastlane-plugin-xcodegen (1.1.0)
       fastlane-plugin-brew (~> 0.1.1)
@@ -310,10 +311,11 @@ DEPENDENCIES
   cocoapods (~> 1.11.2)
   fastlane
   fastlane-plugin-diawi
+  fastlane-plugin-sentry
   fastlane-plugin-versioning
   fastlane-plugin-xcodegen
   slather
   xcode-install
 
 BUNDLED WITH
-   2.3.9
+   2.3.14

--- a/changelog.d/pr-6413.misc
+++ b/changelog.d/pr-6413.misc
@@ -1,0 +1,1 @@
+Sentry: Upload Dsyms to Sentry when building Alpha 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,7 @@ platform :ios do
   desc "Builds an Alpha ipa for pull request branches"
   lane :alpha do
     UI.user_error!("'DIAWI_API_TOKEN' environment variable should be set to use this lane") unless !ENV["DIAWI_API_TOKEN"].to_s.empty?
+    UI.user_error!("'SENTRY_API_TOKEN' environment variable should be set to use this lane") unless !ENV["SENTRY_API_TOKEN"].to_s.empty?
             
     # Generate the "Alpha" app variant    
     setup_app_variant(name: "Alpha")    

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,8 +47,10 @@ platform :ios do
 
   desc "Builds an Alpha ipa for pull request branches"
   lane :alpha do
+    # Check we have all the tokens and tools necessary
     UI.user_error!("'DIAWI_API_TOKEN' environment variable should be set to use this lane") unless !ENV["DIAWI_API_TOKEN"].to_s.empty?
     UI.user_error!("'SENTRY_AUTH_TOKEN' environment variable should be set to use this lane") unless !ENV["SENTRY_AUTH_TOKEN"].to_s.empty?
+    sentry_check_cli_installed
             
     # Generate the "Alpha" app variant    
     setup_app_variant(name: "Alpha")    

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,7 +48,7 @@ platform :ios do
   desc "Builds an Alpha ipa for pull request branches"
   lane :alpha do
     UI.user_error!("'DIAWI_API_TOKEN' environment variable should be set to use this lane") unless !ENV["DIAWI_API_TOKEN"].to_s.empty?
-    UI.user_error!("'SENTRY_API_TOKEN' environment variable should be set to use this lane") unless !ENV["SENTRY_API_TOKEN"].to_s.empty?
+    UI.user_error!("'SENTRY_AUTH_TOKEN' environment variable should be set to use this lane") unless !ENV["SENTRY_AUTH_TOKEN"].to_s.empty?
             
     # Generate the "Alpha" app variant    
     setup_app_variant(name: "Alpha")    
@@ -446,13 +446,12 @@ platform :ios do
 
   desc "Upload dsym files to Sentry to symbolicate crashes"
   private_lane :upload_dsyms_to_sentry do
-    auth_token = ENV["SENTRY_AUTH_TOKEN"]
-    UI.user_error!("Invalid Sentry Auth token.") unless !auth_token.to_s.empty?
+    UI.user_error!("'SENTRY_AUTH_TOKEN' environment variable should be set to use this lane") unless !ENV["SENTRY_AUTH_TOKEN"].to_s.empty?
 
     dsym_path = "#{ENV["BUILD_OUTPUT_DIRECTORY"]}/#{ENV["IPA_NAME"]}.app.dSYM.zip"
   
     sentry_upload_dif(
-      auth_token: auth_token,
+      auth_token: ENV["SENTRY_AUTH_TOKEN"],
       org_slug: 'element',
       project_slug: 'element-ios',
       url: 'https://sentry.tools.element.io/',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,6 +55,8 @@ platform :ios do
     adhoc
     # Upload to Diawi
     upload_to_diawi
+
+    upload_dsyms_to_sentry
   end
 
   desc "Upload IPA to Diawi"
@@ -242,7 +244,7 @@ platform :ios do
     
     # Clear derived data
     clear_derived_data(derived_data_path: ENV["DERIVED_DATA_PATH"])
-
+    
     # Setup project provisioning profiles
     download_provisioning_profiles(adhoc: adhoc)
     disable_automatic_code_signing
@@ -441,6 +443,22 @@ platform :ios do
     UI.command_output("Content of modified Podfile:\n" + podfile_content)
   end
 
+  desc "Upload dsym files to Sentry to symbolicate crashes"
+  private_lane :upload_dsyms_to_sentry do
+    auth_token = ENV["SENTRY_AUTH_TOKEN"]
+    UI.user_error!("Invalid Sentry Auth token.") unless !auth_token.to_s.empty?
+
+    dsym_path = "#{ENV["BUILD_OUTPUT_DIRECTORY"]}/#{ENV["IPA_NAME"]}.app.dSYM.zip"
+  
+    sentry_upload_dif(
+      auth_token: auth_token,
+      org_slug: 'element',
+      project_slug: 'element-ios',
+      url: 'https://sentry.tools.element.io/',
+      path: dsym_path,
+    )
+  end
+
   # git_branch can return an empty screen with some CI tools (like GH actions) 
   # The CI build script needs to define MX_GIT_BRANCH with the right branch.
   def mx_git_branch
@@ -463,21 +481,21 @@ platform :ios do
   end
 end
 
-  # Update an arbitrary file by applying some RegExp replacements to its content
-  #
-  # @param [String] file The path to the file that needs replacing
-  # @param [Hash<RegExp, String>] replacements A list of replacements to apply
-  #
-  def update_file_content(file, replacements)
-    content = File.read(file)
-    replacements.each do |pattern, replacement|
-      content.gsub!(pattern, replacement)
-    end
-    File.write(file, content)
+# Update an arbitrary file by applying some RegExp replacements to its content
+#
+# @param [String] file The path to the file that needs replacing
+# @param [Hash<RegExp, String>] replacements A list of replacements to apply
+#
+def update_file_content(file, replacements)
+  content = File.read(file)
+  replacements.each do |pattern, replacement|
+    content.gsub!(pattern, replacement)
   end
+  File.write(file, content)
+end
 
-  # Generates a new build number based on timestamp
-  def generate_build_number()
-    require 'date'
-    return DateTime.now.strftime("%Y%m%d%H%M%S")
-  end
+# Generates a new build number based on timestamp
+def generate_build_number()
+  require 'date'
+  return DateTime.now.strftime("%Y%m%d%H%M%S")
+end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -5,3 +5,5 @@
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-xcodegen'
 gem 'fastlane-plugin-diawi'
+gem 'fastlane-plugin-sentry'
+


### PR DESCRIPTION
Automatically upload dsym files to [sentry](https://docs.sentry.io/platforms/apple/guides/ios/dsym/#dsym-without-bitcode) when Alpha build is produced and binary uploaded to Diawi