### PR TITLE
Fix a bug setting nil soft logout credentials.

### DIFF
--- a/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -899,18 +899,21 @@
     // This is required before updating view's textfields (homeserver url...)
     [self loadViewIfNeeded];
 
-    // Force register mode
-    self.authType = MXKAuthenticationTypeLogin;
+    if (softLogoutCredentials)
+    {
+        // Force register mode
+        self.authType = MXKAuthenticationTypeLogin;
 
-    [self setHomeServerTextFieldText:softLogoutCredentials.homeServer];
-    [self setIdentityServerTextFieldText:softLogoutCredentials.identityServer];
+        [self setHomeServerTextFieldText:softLogoutCredentials.homeServer];
+        [self setIdentityServerTextFieldText:softLogoutCredentials.identityServer];
 
-    // Cancel potential request in progress
-    [mxCurrentOperation cancel];
-    mxCurrentOperation = nil;
+        // Cancel potential request in progress
+        [mxCurrentOperation cancel];
+        mxCurrentOperation = nil;
 
-    // Remove the current auth inputs view
-    self.authInputsView = nil;
+        // Remove the current auth inputs view
+        self.authInputsView = nil;
+    }
 
     // Set parameters and trigger a refresh (the parameters will be taken into account during [handleAuthenticationSession:])
     _softLogoutCredentials = softLogoutCredentials;

--- a/changelog.d/pr-6417.bugfix
+++ b/changelog.d/pr-6417.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where the login screen is shown after choosing to create an account.


### PR DESCRIPTION
When selecting "Create account" from the splash screen, the soft logout credentials were set to `nil` which was causing the login screen to be shown instead of the registration screen. This adds the a check for `nil` credentials to `MXKAuthenticationViewController` like the one in `AuthenticationViewController`.