### PR TITLE
Reword account deactivation button in Settings.

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -706,7 +706,7 @@ Tap the + to start adding people.";
 "settings_crypto_export" = "Export keys";
 "settings_crypto_blacklist_unverified_devices" = "Encrypt to verified sessions only";
 
-"settings_deactivate_my_account" = "Deactivate my account";
+"settings_deactivate_my_account" = "Permanently deactivate my account";
 
 "settings_key_backup_info" = "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.";
 "settings_key_backup_info_checking" = "Checking…";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -706,7 +706,7 @@ Tap the + to start adding people.";
 "settings_crypto_export" = "Export keys";
 "settings_crypto_blacklist_unverified_devices" = "Encrypt to verified sessions only";
 
-"settings_deactivate_my_account" = "Permanently deactivate my account";
+"settings_deactivate_my_account" = "Deactivate account permanently";
 
 "settings_key_backup_info" = "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.";
 "settings_key_backup_info_checking" = "Checking…";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -6647,7 +6647,7 @@ public class VectorL10n: NSObject {
   public static var settingsDeactivateAccount: String { 
     return VectorL10n.tr("Vector", "settings_deactivate_account") 
   }
-  /// Permanently deactivate my account
+  /// Deactivate account permanently
   public static var settingsDeactivateMyAccount: String { 
     return VectorL10n.tr("Vector", "settings_deactivate_my_account") 
   }

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -6647,7 +6647,7 @@ public class VectorL10n: NSObject {
   public static var settingsDeactivateAccount: String { 
     return VectorL10n.tr("Vector", "settings_deactivate_account") 
   }
-  /// Deactivate my account
+  /// Permanently deactivate my account
   public static var settingsDeactivateMyAccount: String { 
     return VectorL10n.tr("Vector", "settings_deactivate_my_account") 
   }

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -617,7 +617,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     {
         Section *sectionDeactivate = [Section sectionWithTag:SECTION_TAG_DEACTIVATE_ACCOUNT];
         [sectionDeactivate addRowWithTag:0];
-        sectionDeactivate.headerTitle = [VectorL10n settingsDeactivateMyAccount];
+        sectionDeactivate.headerTitle = [VectorL10n settingsDeactivateAccount];
         [tmpSections addObject:sectionDeactivate];
     }
     

--- a/changelog.d/6436.change
+++ b/changelog.d/6436.change
@@ -1,0 +1,1 @@
+Reword account deactivation button on the Settings screen.


### PR DESCRIPTION
Rewords the account deactivation button to clarify that this is a permanent action before even tapping the button.

![Simulator Screen Shot - iPod touch (7th generation) - 2022-07-15 at 09 44 14](https://user-images.githubusercontent.com/6060466/179197310-30f5d14d-140a-4ab5-8913-23a6ae7e86a6.png)

Fixes #6436.