### PR TITLE
Fix deep links not working until AuthenticationViewController has been presented.

### DIFF
--- a/Riot/Modules/Authentication/Legacy/LegacyAuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/Legacy/LegacyAuthenticationCoordinator.swift
@@ -71,7 +71,16 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
         authenticationViewController.authVCDelegate = self
         // Set (or clear) any soft-logout credentials.
         authenticationViewController.softLogoutCredentials = authenticationService.softLogoutCredentials
-        // Listen for changes from deep links.
+        
+        // Configure custom servers if already customised by a deep link.
+        let homeserver = authenticationService.state.homeserver.address
+        let identityServer = authenticationService.state.identityServer
+        if homeserver != BuildSettings.serverConfigDefaultHomeserverUrlString
+            || (identityServer != nil && identityServer != BuildSettings.serverConfigDefaultIdentityServerUrlString) {
+            authenticationViewController.showCustomHomeserver(homeserver, andIdentityServer: identityServer)
+        }
+        
+        // Listen for further changes from deep links.
         AuthenticationService.shared.delegate = self
     }
     

--- a/changelog.d/6425.bugfix
+++ b/changelog.d/6425.bugfix
@@ -1,0 +1,1 @@
+AuthenticationViewController is now correctly configured for a deep link if the link is opened before the view gets shown.


### PR DESCRIPTION
The `LegacyAuthenticationCoordinator` would listen for deep links after presentation, but didn't look to the authentication service in case a deep link had already been opened. This PR fixes that. As `AuthenticationCoordinator` uses the authentication service directly, this issue doesn't affect the new flow.

Closes #6425

![Simulator Screen Recording - iPhone 13 Pro - 2022-07-15 at 18 23 36](https://user-images.githubusercontent.com/6060466/179276302-456be6b4-6b1b-4a2a-b7eb-12fc7a216686.gif)