### PR TITLE
Location sharing: Show map credits on live location timeline tile only when map is shown (PSG-626)

### DIFF
--- a/Riot/Modules/Room/Location/RoomTimelineLocationView.swift
+++ b/Riot/Modules/Room/Location/RoomTimelineLocationView.swift
@@ -223,6 +223,7 @@ class RoomTimelineLocationView: UIView, NibLoadable, Themable, MGLMapViewDelegat
         placeholderBackground.isHidden = bannerViewData.showMap
         placeholderBackground.image = placeholderBackgroundImage
         mapView.isHidden = !bannerViewData.showMap
+        attributionLabel.isHidden = !bannerViewData.showMap
         
         switch bannerViewData.status {
         case .starting:
@@ -237,7 +238,7 @@ class RoomTimelineLocationView: UIView, NibLoadable, Themable, MGLMapViewDelegat
     
     private func liveLocationBannerViewData(from viewState: TimelineLiveLocationViewState) -> TimelineLiveLocationViewData {
         
-        var status: LiveLocationSharingStatus
+        let status: LiveLocationSharingStatus
         let iconTint: UIColor
         let title: String
         var titleColor: UIColor = theme.colors.primaryContent

--- a/changelog.d/6448.change
+++ b/changelog.d/6448.change
@@ -1,0 +1,1 @@
+Location sharing: Show map credits on live location timeline tile only when map is shown.


### PR DESCRIPTION
Fix #6448