### PR TITLE
Always perform the registration dummy stage immediately after the first one.

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
@@ -268,17 +268,17 @@ class RegistrationWizard {
             let flowResult = authenticationSession.flowResult
             
             if isCreatingAccount || isRegistrationStarted {
-                return try await handleMandatoryDummyStage(flowResult: flowResult)
+                return try await handleDummyStage(flowResult: flowResult)
             }
             
             return .flowResponse(flowResult)
         }
     }
     
-    /// Checks for a mandatory dummy stage and handles it automatically when possible.
-    private func handleMandatoryDummyStage(flowResult: FlowResult) async throws -> RegistrationResult {
+    /// Checks for a dummy stage and handles it automatically when possible.
+    private func handleDummyStage(flowResult: FlowResult) async throws -> RegistrationResult {
         // If the dummy stage is mandatory, do the dummy stage now
-        guard flowResult.missingStages.contains(where: { $0.isDummy && $0.isMandatory }) else { return .flowResponse(flowResult) }
+        guard flowResult.missingStages.contains(where: { $0.isDummy }) else { return .flowResponse(flowResult) }
         return try await dummy()
     }
     

--- a/changelog.d/6459.wip
+++ b/changelog.d/6459.wip
@@ -1,0 +1,1 @@
+Always perform the dummy stage in the registration wizard, irregardless of whether it is mandatory or optional.


### PR DESCRIPTION
Dummy stages were only being performed when mandatory and not when optional. This PR no longer makes the distinction and performs the request when it can.

Fixes #6459.