### PR TITLE
Stop using an ephemeral web browser session on SSO

### DIFF
--- a/Riot.xcodeproj/xcshareddata/xcschemes/Riot.xcscheme
+++ b/Riot.xcodeproj/xcshareddata/xcschemes/Riot.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -16,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "57B13CC4586E9D43ED24DE1E"
-               BuildableName = "Riot.app"
+               BuildableName = "Element.app"
                BlueprintName = "Riot"
                ReferencedContainer = "container:Riot.xcodeproj">
             </BuildableReference>
@@ -27,9 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES"
       disableMainThreadChecker = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "57B13CC4586E9D43ED24DE1E"
+            BuildableName = "Element.app"
+            BlueprintName = "Riot"
+            ReferencedContainer = "container:Riot.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -42,41 +49,28 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "57B13CC4586E9D43ED24DE1E"
-            BuildableName = "Riot.app"
-            BlueprintName = "Riot"
-            ReferencedContainer = "container:Riot.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "57B13CC4586E9D43ED24DE1E"
-            BuildableName = "Riot.app"
+            BuildableName = "Element.app"
             BlueprintName = "Riot"
             ReferencedContainer = "container:Riot.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -89,13 +83,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "57B13CC4586E9D43ED24DE1E"
-            BuildableName = "Riot.app"
+            BuildableName = "Element.app"
             BlueprintName = "Riot"
             ReferencedContainer = "container:Riot.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Riot/Common.xcconfig
+++ b/Riot/Common.xcconfig
@@ -20,7 +20,7 @@
 #include "Config/AppIdentifiers.xcconfig"
 #include "Config/AppVersion.xcconfig"
 
-PRODUCT_NAME = Riot
+PRODUCT_NAME = Element
 PRODUCT_BUNDLE_IDENTIFIER = $(BASE_BUNDLE_IDENTIFIER)
 
 INFOPLIST_FILE = Riot/SupportingFiles/Info.plist
@@ -28,7 +28,7 @@ ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
 
 CODE_SIGN_ENTITLEMENTS = Riot/SupportingFiles/Riot.entitlements
 
-SWIFT_OBJC_BRIDGING_HEADER = $(SRCROOT)/$(PRODUCT_NAME)/SupportingFiles/Riot-Bridging-Header.h
+SWIFT_OBJC_BRIDGING_HEADER = $(SRCROOT)/Riot/SupportingFiles/Riot-Bridging-Header.h
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
 
 SWIFT_OBJC_INTERFACE_HEADER_NAME = GeneratedInterface-Swift.h

--- a/Riot/Modules/Authentication/SSO/SSOAuthentificationSession.swift
+++ b/Riot/Modules/Authentication/SSO/SSOAuthentificationSession.swift
@@ -64,18 +64,11 @@ final class SSOAuthentificationSession: SSOAuthentificationSessionProtocol {
             
             completionHandler(callbackURL, finalError)
         }
-
-        // Ask the browser for a private authentication session
-        if #available(iOS 13.0, *) {
-            authentificationSession.prefersEphemeralWebBrowserSession = true
-        }
         
         self.authentificationSession = authentificationSession
         
-        if #available(iOS 13.0, *) {
-            if let asWebContextProvider = contextProvider as? ASWebAuthenticationPresentationContextProviding {
-                authentificationSession.presentationContextProvider = asWebContextProvider
-            }
+        if let asWebContextProvider = contextProvider as? ASWebAuthenticationPresentationContextProviding {
+            authentificationSession.presentationContextProvider = asWebContextProvider
         }
         
         authentificationSession.start()

--- a/RiotTests/AnalyticsTests.swift
+++ b/RiotTests/AnalyticsTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 import AnalyticsEvents
 
 class AnalyticsTests: XCTestCase {

--- a/RiotTests/EmojiServiceTests.swift
+++ b/RiotTests/EmojiServiceTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class EmojiServiceTests: XCTestCase {
     

--- a/RiotTests/EmojiStoreTests.swift
+++ b/RiotTests/EmojiStoreTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class EmojiStoreTests: XCTestCase {
 

--- a/RiotTests/EventMenuBuilderTests.swift
+++ b/RiotTests/EventMenuBuilderTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 import UIKit
-@testable import Riot
+@testable import Element
 
 class EventMenuBuilderTests: XCTestCase {
     

--- a/RiotTests/HomeserverConfigurationTests.swift
+++ b/RiotTests/HomeserverConfigurationTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class HomeserverConfigurationTests: XCTestCase {
 

--- a/RiotTests/JitsiWellKnownTests.swift
+++ b/RiotTests/JitsiWellKnownTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class JitsiWellKnownTests: XCTestCase {
 

--- a/RiotTests/MarkdownToHTMLRendererTests.swift
+++ b/RiotTests/MarkdownToHTMLRendererTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 final class MarkdownToHTMLRendererTests: XCTestCase {
     // MARK: - Tests

--- a/RiotTests/MatrixKitTests/MXKRoomDataSourceTests.swift
+++ b/RiotTests/MatrixKitTests/MXKRoomDataSourceTests.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class MXKRoomDataSourceTests: XCTestCase {
 

--- a/RiotTests/MatrixKitTests/UTI/MXKUTITests.swift
+++ b/RiotTests/MatrixKitTests/UTI/MXKUTITests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 import MobileCoreServices
 

--- a/RiotTests/Modules/Authentication/AuthenticationServiceTests.swift
+++ b/RiotTests/Modules/Authentication/AuthenticationServiceTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 @MainActor class AuthenticationServiceTests: XCTestCase {
     var service: AuthenticationService!

--- a/RiotTests/Modules/Authentication/LoginTests.swift
+++ b/RiotTests/Modules/Authentication/LoginTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class LoginTests: XCTestCase {
     func testUserParameterIdentifier() {

--- a/RiotTests/Modules/Authentication/Mocks/MockAuthenticationRestClient.swift
+++ b/RiotTests/Modules/Authentication/Mocks/MockAuthenticationRestClient.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@testable import Riot
+@testable import Element
 
 /// A mock REST client that can be used for authentication.
 class MockAuthenticationRestClient: AuthenticationRestClient {

--- a/RiotTests/Modules/Authentication/Mocks/MockSessionCreator.swift
+++ b/RiotTests/Modules/Authentication/Mocks/MockSessionCreator.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@testable import Riot
+@testable import Element
 
 struct MockSessionCreator: SessionCreatorProtocol {
     /// Returns a basic session created from the supplied credentials. This prevents the app from setting up the account during tests.

--- a/RiotTests/Modules/Authentication/RegistrationTests.swift
+++ b/RiotTests/Modules/Authentication/RegistrationTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class RegistrationTests: XCTestCase {
     /// Makes an authentication session that mimics the matrix.org flow.

--- a/RiotTests/Modules/Common/Recents/DataSources/RecentsDataSourceSectionsTests.swift
+++ b/RiotTests/Modules/Common/Recents/DataSources/RecentsDataSourceSectionsTests.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import XCTest
-@testable import Riot
+@testable import Element
 
 class RecentsDataSourceSectionsTests: XCTestCase {
     func test_canCreateWithNSNumbers() {

--- a/RiotTests/Modules/Common/UserIndicators/UserIndicatorStoreTests.swift
+++ b/RiotTests/Modules/Common/UserIndicators/UserIndicatorStoreTests.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 @testable import CommonKit
-@testable import Riot
+@testable import Element
 import MatrixSDK
 
 class UserIndicatorStoreTests: XCTestCase {

--- a/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
+++ b/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import XCTest
-@testable import Riot
+@testable import Element
 
 class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
     func test_fragmentIsNilForInvalidResolution() {

--- a/RiotTests/OnboardingTests.swift
+++ b/RiotTests/OnboardingTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class OnboardingTests: XCTestCase {
     

--- a/RiotTests/PasswordValidatorTests.swift
+++ b/RiotTests/PasswordValidatorTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class PasswordValidatorTests: XCTestCase {
 

--- a/RiotTests/PillsFormatterTests.swift
+++ b/RiotTests/PillsFormatterTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 // MARK: - Inputs
 private enum Inputs {

--- a/RiotTests/RoomNotificationSettingsViewModelTests.swift
+++ b/RiotTests/RoomNotificationSettingsViewModelTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class MockRoomNotificationSettingsView: RoomNotificationSettingsViewModelViewDelegate {
     

--- a/RiotTests/SessionCreatorTests.swift
+++ b/RiotTests/SessionCreatorTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class SessionCreatorTests: XCTestCase {
 

--- a/RiotTests/String+Element.swift
+++ b/RiotTests/String+Element.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class String_Element: XCTestCase {
 

--- a/RiotTests/URLPreviewStoreTests.swift
+++ b/RiotTests/URLPreviewStoreTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class URLPreviewStoreTests: XCTestCase {
     var store: URLPreviewStore!

--- a/RiotTests/URLValidatorTests.swift
+++ b/RiotTests/URLValidatorTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class URLValidatorTests: XCTestCase {
 

--- a/RiotTests/UniversalLinkTests.swift
+++ b/RiotTests/UniversalLinkTests.swift
@@ -15,7 +15,7 @@
 //
 
 import XCTest
-@testable import Riot
+@testable import Element
 
 class UniversalLinkTests: XCTestCase {
 

--- a/RiotTests/UserInteractiveAuthenticationServiceTests.swift
+++ b/RiotTests/UserInteractiveAuthenticationServiceTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class UserInteractiveAuthenticationServiceTests: XCTestCase {
 

--- a/RiotTests/VectorWellKnownTests.swift
+++ b/RiotTests/VectorWellKnownTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import Riot
+@testable import Element
 
 class VectorWellKnownTests: XCTestCase {
 

--- a/RiotTests/target.yml
+++ b/RiotTests/target.yml
@@ -46,7 +46,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: org.matrix.$(PRODUCT_NAME:rfc1034identifier)
         PRODUCT_NAME: RiotTests
         SWIFT_OBJC_BRIDGING_HEADER: RiotTests/RiotTests-Bridging-Header.h
-        TEST_HOST: $(BUILT_PRODUCTS_DIR)/Riot.app/Riot
+        TEST_HOST: $(BUILT_PRODUCTS_DIR)/Element.app/Element
       configs:
         Debug:
         Release:

--- a/changelog.d/6462.api
+++ b/changelog.d/6462.api
@@ -1,0 +1,1 @@
+Update the app's bundle name to show Element during SSO.

--- a/changelog.d/6462.bugfix
+++ b/changelog.d/6462.bugfix
@@ -1,0 +1,1 @@
+Stop using an ephemeral web browser session for SSO authentication.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,6 +179,7 @@ platform :ios do
       workspace: "Riot.xcworkspace",
       proj: "Riot.xcodeproj",
       scheme: "Riot",
+      binary_file: "Element",
     )
   end
   

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,7 +179,7 @@ platform :ios do
       workspace: "Riot.xcworkspace",
       proj: "Riot.xcodeproj",
       scheme: "Riot",
-      binary_file: "Element",
+      binary_basename: "Element",
     )
   end
   


### PR DESCRIPTION
The app has been using an ephemeral web browser session meaning users have to re-enter their username and password for accounts that are already signed in through Safari. This PR fixes that. It also renames the bundle name to Element for the SSO alert. Additionally

- The second commit fixes build errors in the unit tests target
- The last 2 commits fix an error on CI at the end of the unit tests lane.

Fixes #6462.

| Old bundle name | New bundle name |
| - | - |
| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-07-21 at 14 30 04](https://user-images.githubusercontent.com/6060466/180267080-7d6e69f0-959a-47c6-83ab-d0309f0c8d6f.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-07-21 at 17 18 13](https://user-images.githubusercontent.com/6060466/180267096-94f53f6d-7f3a-4d55-8fa3-688cd66779c0.png) |

