### PR TITLE
Trim whitespace from email address on register.

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/VerifyEmail/Coordinator/AuthenticationVerifyEmailCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyEmail/Coordinator/AuthenticationVerifyEmailCoordinator.swift
@@ -110,7 +110,7 @@ final class AuthenticationVerifyEmailCoordinator: Coordinator, Presentable {
     
     /// Sends a validation email to the supplied address and then begins polling the server.
     @MainActor private func sendEmail(_ address: String) {
-        let threePID = RegisterThreePID.email(address)
+        let threePID = RegisterThreePID.email(address.trimmingCharacters(in: .whitespaces))
         
         startLoading()
         

--- a/changelog.d/2594.bugfix
+++ b/changelog.d/2594.bugfix
@@ -1,0 +1,1 @@
+Registration: Trim any whitespace away when verifying the user's email address.


### PR DESCRIPTION
Small PR to trim whitespace when verifying an email address during registration. In testing it seems that synapse handles this automatically but could be useful for other homeservers.

Closes #2594.