### PR TITLE
Fixes a glitch when dismissing a GIF in the media attachment viewer (#6475)

### DIFF
--- a/Riot/Modules/MatrixKit/Animators/MXKAttachmentAnimator.h
+++ b/Riot/Modules/MatrixKit/Animators/MXKAttachmentAnimator.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(NSInteger, PhotoBrowserAnimationType) {
 
 @protocol MXKDestinationAttachmentAnimatorDelegate <NSObject>
 
+- (BOOL)prepareSubviewsForTransition:(BOOL)isStartInteraction;
+
 - (UIImageView *)finalImageView;
 
 @end

--- a/Riot/Modules/MatrixKit/Animators/MXKAttachmentInteractionController.m
+++ b/Riot/Modules/MatrixKit/Animators/MXKAttachmentInteractionController.m
@@ -111,7 +111,9 @@
 - (void)startInteractiveTransition:(id <UIViewControllerContextTransitioning>)transitionContext
 {
     self.transitionContext = transitionContext;
-    
+
+    [self.destinationViewController prepareSubviewsForTransition:true];
+
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIImageView *destinationImageView = [self.destinationViewController finalImageView];
     destinationImageView.hidden = YES;
@@ -158,6 +160,8 @@
 
             [self.transitionContext cancelInteractiveTransition];
             [self.transitionContext completeTransition:NO];
+
+            [self.destinationViewController prepareSubviewsForTransition:false];
         }
     }];
 }

--- a/Riot/Modules/MatrixKit/Animators/MXKAttachmentInteractionController.m
+++ b/Riot/Modules/MatrixKit/Animators/MXKAttachmentInteractionController.m
@@ -112,7 +112,7 @@
 {
     self.transitionContext = transitionContext;
 
-    [self.destinationViewController prepareSubviewsForTransition:true];
+    [self.destinationViewController prepareSubviewsForTransition:YES];
 
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIImageView *destinationImageView = [self.destinationViewController finalImageView];

--- a/Riot/Modules/MatrixKit/Animators/MXKAttachmentInteractionController.m
+++ b/Riot/Modules/MatrixKit/Animators/MXKAttachmentInteractionController.m
@@ -161,7 +161,7 @@
             [self.transitionContext cancelInteractiveTransition];
             [self.transitionContext completeTransition:NO];
 
-            [self.destinationViewController prepareSubviewsForTransition:false];
+            [self.destinationViewController prepareSubviewsForTransition:NO];
         }
     }];
 }

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -1393,7 +1393,8 @@
         UIView *customView = cell.customView;
         for (UIView *v in customView.subviews)
         {
-            if ([v isKindOfClass:[WKWebView class]]) {
+            if ([v isKindOfClass:[WKWebView class]])
+            {
                 v.hidden = isStartInteraction;
                 return true;
             }

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -1391,7 +1391,8 @@
     if (attachment.type == MXKAttachmentTypeImage && attachment.contentURL && [mimeType isEqualToString:@"image/gif"])
     {
         UIView *customView = cell.customView;
-        for (UIView * v in customView.subviews) {
+        for (UIView *v in customView.subviews)
+        {
             if ([v isKindOfClass:[WKWebView class]]) {
                 v.hidden = isStartInteraction;
                 return true;

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -1396,7 +1396,7 @@
             if ([v isKindOfClass:[WKWebView class]])
             {
                 v.hidden = isStartInteraction;
-                return true;
+                return YES;
             }
         }
     }

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -701,7 +701,7 @@
                     width = minSize;
                     height = minSize;
                 }
-                
+
                 WKWebView *animatedGifViewer = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, width, height)];
                 animatedGifViewer.center = cell.customView.center;
                 animatedGifViewer.opaque = NO;
@@ -1377,6 +1377,28 @@
         [currentSharedAttachment onShareEnded];
         currentSharedAttachment = nil;
     }
+}
+
+#pragma mark - MXKDestinationAttachmentAnimatorDelegate
+
+- (BOOL)prepareSubviewsForTransition:(BOOL)isStartInteraction
+{
+    MXKMediaCollectionViewCell *cell = (MXKMediaCollectionViewCell *)[self.attachmentsCollection.visibleCells firstObject];
+    MXKAttachment *attachment = attachments[currentVisibleItemIndex];
+    NSString *mimeType = attachment.contentInfo[@"mimetype"];
+
+    // Check attachment type for GIFs - this is required because of the extra WKWebView
+    if (attachment.type == MXKAttachmentTypeImage && attachment.contentURL && [mimeType isEqualToString:@"image/gif"])
+    {
+        UIView *customView = cell.customView;
+        for (UIView * v in customView.subviews) {
+            if ([v isKindOfClass:[WKWebView class]]) {
+                v.hidden = isStartInteraction;
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 - (UIImageView *)finalImageView

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -1400,7 +1400,7 @@
             }
         }
     }
-    return false;
+    return NO;
 }
 
 - (UIImageView *)finalImageView

--- a/changelog.d/6475.bugfix
+++ b/changelog.d/6475.bugfix
@@ -1,0 +1,1 @@
+Media Attachments Viewer: Fixed an issue where dismissing GIFs would show the WebView playing the animation below the interaction transition animation.


### PR DESCRIPTION
### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

### Description

Fixes #6475 - Added logic to the interaction controller, when the interaction starts and cancels, so we can hide / show the WKWebView when the attachment is a GIF image type.

### Video clip of issue

https://user-images.githubusercontent.com/26399/180901176-15861e53-bc22-46b8-b65d-07addee026cc.mp4

### Video clip of solved issue

https://user-images.githubusercontent.com/26399/180900809-d9e99720-b125-4c5c-ad2c-5452e27c1790.mov


