### PR TITLE
Location sharing: Display clearer error message when the user doesn't have permission to share location in the room (PSG-619)

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2233,6 +2233,9 @@ Tap the + to start adding people.";
 
 "location_sharing_invalid_authorization_settings" = "Settings";
 
+"location_sharing_invalid_power_level_title" = "You don’t have permission to share live location";
+"location_sharing_invalid_power_level_message" = "You need to have the right permissions in order to share live location in this room.";
+
 "location_sharing_open_apple_maps" = "Open in Apple Maps";
 
 "location_sharing_open_google_maps" = "Open in Google Maps";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3007,6 +3007,14 @@ public class VectorL10n: NSObject {
   public static var locationSharingInvalidAuthorizationSettings: String { 
     return VectorL10n.tr("Vector", "location_sharing_invalid_authorization_settings") 
   }
+  /// You need to have the right permissions in order to share live location in this room.
+  public static var locationSharingInvalidPowerLevelMessage: String { 
+    return VectorL10n.tr("Vector", "location_sharing_invalid_power_level_message") 
+  }
+  /// You don’t have permission to share live location
+  public static var locationSharingInvalidPowerLevelTitle: String { 
+    return VectorL10n.tr("Vector", "location_sharing_invalid_power_level_title") 
+  }
   /// Live location error
   public static var locationSharingLiveError: String { 
     return VectorL10n.tr("Vector", "location_sharing_live_error") 

--- a/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/LocationSharingModels.swift
@@ -47,7 +47,12 @@ enum LocationSharingViewModelResult {
     case cancel
     case share(latitude: Double, longitude: Double, coordinateType: LocationSharingCoordinateType)
     case shareLiveLocation(timeout: TimeInterval)
-    case showLabFlagPromotionIfNeeded(_ completion: ((Bool) -> Void))
+    case checkLiveLocationCanBeStarted(_ completion: ((Result<Void, Error>) -> Void))
+}
+
+enum LiveLocationStartError: Error {
+    case powerLevelNotHighEnough
+    case labFlagNotEnabled
 }
 
 enum LocationSharingViewError {
@@ -105,4 +110,5 @@ enum LocationSharingAlertType {
     case authorizationError
     case locationSharingError
     case stopLocationSharingError
+    case locationSharingPowerLevelError
 }

--- a/RiotSwiftUI/Modules/Room/LocationSharing/Test/Unit/LocationSharingViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/LocationSharing/Test/Unit/LocationSharingViewModelTests.swift
@@ -50,7 +50,7 @@ class LocationSharingViewModelTests: XCTestCase {
                 expectation.fulfill()
             case .shareLiveLocation:
                 XCTFail()
-            case .showLabFlagPromotionIfNeeded:
+            case .checkLiveLocationCanBeStarted:
                 XCTFail()
             }
         }

--- a/changelog.d/6477.change
+++ b/changelog.d/6477.change
@@ -1,0 +1,1 @@
+Location sharing: Display clearer error message when the user doesn't have permission to share location in the room.


### PR DESCRIPTION
#6477