### PR TITLE
Show switch button if there are no public rooms on homeserver (to fix #4700)

### DIFF
--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewController.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewController.swift
@@ -190,8 +190,6 @@ final class ShowDirectoryViewController: UIViewController {
             self.renderLoaded(sections: sections)
         case .error(let error):
             self.render(error: error)
-        case .loadedWithoutUpdate:
-            self.renderLoadedWithoutUpdate()
         }
     }
     
@@ -203,10 +201,6 @@ final class ShowDirectoryViewController: UIViewController {
         removeSpinnerFooterView()
         self.sections = sections
         self.mainTableView.reloadData()
-    }
-    
-    private func renderLoadedWithoutUpdate() {
-        removeSpinnerFooterView()
     }
     
     private func render(error: Error) {

--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewModel.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewModel.swift
@@ -139,11 +139,7 @@ final class ShowDirectoryViewModel: NSObject, ShowDirectoryViewModelType {
         
         currentOperation = dataSource.paginate({ [weak self] (roomsAdded) in
             guard let self = self else { return }
-            if roomsAdded > 0 {
-                self.update(viewState: .loaded(self.sections))
-            } else {
-                self.update(viewState: .loadedWithoutUpdate)
-            }
+            self.update(viewState: .loaded(self.sections))
             self.currentOperation = nil
         }, failure: { [weak self] (error) in
             guard let self = self else { return }

--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewState.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewState.swift
@@ -21,7 +21,6 @@ import Foundation
 /// ShowDirectoryViewController view state
 enum ShowDirectoryViewState {
     case loading
-    case loadedWithoutUpdate
     case loaded(_ sections: [ShowDirectorySection])
     case error(Error)
 }

--- a/changelog.d/4700.bugfix
+++ b/changelog.d/4700.bugfix
@@ -1,0 +1,1 @@
+Room Directory: Show the "switch" button even if there are no public rooms in the homeserver's room directory.


### PR DESCRIPTION
Fixes #4700

![screenshot](https://user-images.githubusercontent.com/38211057/182035666-4ee8b2c4-7aa0-49a3-8aae-199f83ebdcaa.png)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)