### PR TITLE
Fix missing errors after #6498.

### DIFF
--- a/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.m
+++ b/Riot/Modules/PublicRoomList/DataSources/PublicRoomsDirectoryDataSource.m
@@ -299,7 +299,7 @@ static NSString *const kNSFWKeyword = @"nsfw";
         {
             typeof(self) self = weakSelf;
 
-            if (!newPublicRoomsRequest || newPublicRoomsRequest.isCancelled)
+            if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled)
             {
                 // Do not take into account error coming from a cancellation
                 return;

--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewController.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewController.swift
@@ -190,8 +190,6 @@ final class ShowDirectoryViewController: UIViewController {
             self.renderLoaded(sections: sections)
         case .error(let error):
             self.render(error: error)
-        case .loadedWithoutUpdate:
-            self.renderLoadedWithoutUpdate()
         }
     }
     
@@ -203,10 +201,6 @@ final class ShowDirectoryViewController: UIViewController {
         removeSpinnerFooterView()
         self.sections = sections
         self.mainTableView.reloadData()
-    }
-    
-    private func renderLoadedWithoutUpdate() {
-        removeSpinnerFooterView()
     }
     
     private func render(error: Error) {

--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewModel.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewModel.swift
@@ -139,11 +139,7 @@ final class ShowDirectoryViewModel: NSObject, ShowDirectoryViewModelType {
         
         currentOperation = dataSource.paginate({ [weak self] (roomsAdded) in
             guard let self = self else { return }
-            if roomsAdded > 0 {
-                self.update(viewState: .loaded(self.sections))
-            } else {
-                self.update(viewState: .loadedWithoutUpdate)
-            }
+            self.update(viewState: .loaded(self.sections))
             self.currentOperation = nil
         }, failure: { [weak self] (error) in
             guard let self = self else { return }

--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewState.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewState.swift
@@ -21,7 +21,6 @@ import Foundation
 /// ShowDirectoryViewController view state
 enum ShowDirectoryViewState {
     case loading
-    case loadedWithoutUpdate
     case loaded(_ sections: [ShowDirectorySection])
     case error(Error)
 }

--- a/changelog.d/4700.bugfix
+++ b/changelog.d/4700.bugfix
@@ -1,0 +1,1 @@
+Room Directory: Show the "switch" button even if there are no public rooms in the homeserver's room directory.


### PR DESCRIPTION
Adds a small addition to #6498 in commit 54e4351. The rest of the PR has been reviewed.

Previously the data source was capturing an operation that was unassigned, and so would never error as it was always `nil`. This change checks the `NSError` instead.

This missing errors could be seen when using a local (unfederated) synapse and switching networks, as the loading spinner would never get dismissed.