### PR TITLE
Add Notification Centre to in-app notification delivery options.

### DIFF
--- a/Riot/Managers/PushNotification/PushNotificationService.m
+++ b/Riot/Managers/PushNotification/PushNotificationService.m
@@ -347,7 +347,8 @@ Matrix session observer used to detect new opened sessions.
         {
             completionHandler(UNNotificationPresentationOptionBadge
                               | UNNotificationPresentationOptionSound
-                              | UNNotificationPresentationOptionBanner);
+                              | UNNotificationPresentationOptionBanner
+                              | UNNotificationPresentationOptionList);
         }
     }
     else

--- a/changelog.d/6503.change
+++ b/changelog.d/6503.change
@@ -1,0 +1,1 @@
+In-app notifications will now also be delivered to Notification Centre.


### PR DESCRIPTION
This PR fixes #6503 by included in-app notifications in Notification Centre. They're handled just like regular notifications and get dismissed in the same way.