### PR TITLE
Fix status bar style when using a custom theme.

### DIFF
--- a/Riot/Modules/Home/VersionCheck/HomeViewControllerWithBannerWrapperViewController.swift
+++ b/Riot/Modules/Home/VersionCheck/HomeViewControllerWithBannerWrapperViewController.swift
@@ -22,6 +22,10 @@ class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKVi
     private var bannerContainerView: UIView!
     private var stackView: UIStackView!
     
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        homeViewController.preferredStatusBarStyle
+    }
+    
     init(viewController: HomeViewController) {
         self.homeViewController = viewController
         

--- a/changelog.d/6487.bugfix
+++ b/changelog.d/6487.bugfix
@@ -1,0 +1,1 @@
+Home: Use the correct status bar colour when using the dark theme with dark mode disabled.


### PR DESCRIPTION
This PR fixes reproducible issues of #6487 where the home tab shows with an incorrect status bar colour.

Since adding the wrapper view, the system hasn't been calling preferredStatusBarStyle directly on `HomeViewController` so has left it as the default style.

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-08-01 at 17 39 39](https://user-images.githubusercontent.com/6060466/182201632-c5d06290-1008-4a69-a141-13fddc8f35df.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-08-01 at 17 38 36](https://user-images.githubusercontent.com/6060466/182201643-c8b1d8ff-bc00-40ef-9f09-6bc3b574e3ab.png) |

