### PR TITLE
Fix an infinite loop when tapping an unjoined room alias.

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.h
+++ b/Riot/Modules/Application/LegacyAppDelegate.h
@@ -234,10 +234,10 @@ UINavigationControllerDelegate
  Process the fragment part of a vector.im link.
 
  @param fragment the fragment part of the universal link.
- @param universalLinkURL the unprocessed the universal link URL (optional).
+ @param universalLink the original universal link.
  @return YES in case of processing success.
  */
-- (BOOL)handleUniversalLinkFragment:(NSString*)fragment fromURL:(NSURL*)universalLinkURL;
+- (BOOL)handleUniversalLinkFragment:(NSString*)fragment fromLink:(UniversalLink*)universalLink;
 
 /**
  Process the URL of a vector.im link.

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1242,7 +1242,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                 // Continue the registration with the passed nextLink
                 MXLogDebug(@"[AppDelegate] handleUniversalLink. Complete registration with nextLink");
                 NSURL *nextLink = [NSURL URLWithString:queryParams[@"nextLink"]];
-                [self handleUniversalLinkFragment:nextLink.fragment fromURL:nextLink];
+                UniversalLink *link = [[UniversalLink alloc] initWithUrl:nextLink];
+                [self handleUniversalLinkFragment:nextLink.fragment fromLink:link];
             }
             else
             {
@@ -1704,8 +1705,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 {
     // iOS Patch: fix vector.im urls before using it
     NSURL *fixedURL = [Tools fixURLWithSeveralHashKeys:universalLinkURL];
+    UniversalLink *link = [[UniversalLink alloc] initWithUrl:universalLinkURL];
     
-    return [self handleUniversalLinkFragment:fixedURL.fragment fromURL:universalLinkURL];
+    return [self handleUniversalLinkFragment:fixedURL.fragment fromLink:link];
 }
 
 - (void)resetPendingUniversalLink

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1242,8 +1242,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                 // Continue the registration with the passed nextLink
                 MXLogDebug(@"[AppDelegate] handleUniversalLink. Complete registration with nextLink");
                 NSURL *nextLink = [NSURL URLWithString:queryParams[@"nextLink"]];
-                UniversalLink *link = [[UniversalLink alloc] initWithUrl:nextLink];
-                [self handleUniversalLinkFragment:nextLink.fragment fromLink:link];
+                [self handleUniversalLinkURL:nextLink];
             }
             else
             {

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1602,11 +1602,11 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         
         if (roomIdOrAlias.length)
         {
-            // Open the room or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:roomIdOrAlias]];
-            NSURL *url = [NSURL URLWithString:[MXTools permalinkToRoom:fragment]];
-            UniversalLink *link = [[UniversalLink alloc] initWithUrl:url];
-            [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromLink:link];
+            // Create a permalink to open or preview the room.
+            NSString *permalink = [MXTools permalinkToRoom:roomIdOrAlias];
+            NSURL *permalinkURL = [NSURL URLWithString:permalink];
+            UniversalLink *link = [[UniversalLink alloc] initWithUrl:permalinkURL];
+            [[AppDelegate theDelegate] handleUniversalLinkFragment:permalinkURL.fragment fromLink:link];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:NO];
     }

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1605,8 +1605,7 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
             // Create a permalink to open or preview the room.
             NSString *permalink = [MXTools permalinkToRoom:roomIdOrAlias];
             NSURL *permalinkURL = [NSURL URLWithString:permalink];
-            UniversalLink *link = [[UniversalLink alloc] initWithUrl:permalinkURL];
-            [[AppDelegate theDelegate] handleUniversalLinkFragment:permalinkURL.fragment fromLink:link];
+            [[AppDelegate theDelegate] handleUniversalLinkURL:permalinkURL];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:NO];
     }

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1605,7 +1605,8 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
             // Open the room or preview it
             NSString *fragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:roomIdOrAlias]];
             NSURL *url = [NSURL URLWithString:[MXTools permalinkToRoom:fragment]];
-            [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromURL:url];
+            UniversalLink *link = [[UniversalLink alloc] initWithUrl:url];
+            [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromLink:link];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:NO];
     }

--- a/Riot/Modules/Communities/Home/GroupHomeViewController.m
+++ b/Riot/Modules/Communities/Home/GroupHomeViewController.m
@@ -892,7 +892,8 @@
         // Open the group or preview it
         NSString *fragment = [NSString stringWithFormat:@"/group/%@",
                         [MXTools encodeURIComponent:absoluteURLString]];
-        [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromURL:URL];
+        UniversalLink *link = [[UniversalLink alloc] initWithUrl:URL];
+        [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment fromLink:link];
     }
     
     return shouldInteractWithURL;

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4279,10 +4279,11 @@ static CGSize kThreadListBarButtonItemImageSize;
             
             NSString *roomIdOrAlias = absoluteURLString;
             
-            // Open the room or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:roomIdOrAlias]];
+            // Create a permalink to open or preview the room.
+            NSString *permalink = [MXTools permalinkToRoom:roomIdOrAlias];
+            NSURL *permalinkURL = [NSURL URLWithString:permalink];
             
-            [self handleUniversalLinkFragment:fragment fromURL:url];
+            [self handleUniversalLinkFragment:permalinkURL.fragment fromURL:permalinkURL];
         }
         // Preview the clicked group
         else if ([MXTools isMatrixGroupIdentifier:absoluteURLString])

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4283,7 +4283,7 @@ static CGSize kThreadListBarButtonItemImageSize;
             NSString *permalink = [MXTools permalinkToRoom:roomIdOrAlias];
             NSURL *permalinkURL = [NSURL URLWithString:permalink];
             
-            [self handleUniversalLinkFragment:permalinkURL.fragment fromURL:permalinkURL];
+            [self handleUniversalLinkURL:permalinkURL];
         }
         // Preview the clicked group
         else if ([MXTools isMatrixGroupIdentifier:absoluteURLString])

--- a/Riot/Utils/UniversalLink.h
+++ b/Riot/Utils/UniversalLink.h
@@ -40,6 +40,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param url original url
 - (id)initWithUrl:(NSURL *)url;
 
+/// An Initializer that preserves the original URL, but parses the parameters from an updated fragment.
+/// @param url original url
+/// @param fragment the updated fragment to parse.
+- (id)initWithUrl:(NSURL *)url updatedFragment:(NSString *)fragment;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Riot/Utils/UniversalLink.m
+++ b/Riot/Utils/UniversalLink.m
@@ -27,7 +27,22 @@
         _url = url;
 
         // Extract required parameters from the link
-        [self parsePathAndQueryParams];
+        [self parsePathAndQueryParamsForURL:url];
+    }
+    return self;
+}
+
+- (id)initWithUrl:(NSURL *)url updatedFragment:(NSString *)fragment
+{
+    self = [super init];
+    if (self)
+    {
+        _url = url;
+
+        // Update the url with the fragment
+        NSURLComponents *components = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
+        components.fragment = fragment;
+        [self parsePathAndQueryParamsForURL:components.URL];
     }
     return self;
 }
@@ -38,12 +53,12 @@
  The fragment can contain a '?'. So there are two kinds of parameters: path params and query params.
  It is in the form of /[pathParam1]/[pathParam2]?[queryParam1Key]=[queryParam1Value]&[queryParam2Key]=[queryParam2Value]
  */
-- (void)parsePathAndQueryParams
+- (void)parsePathAndQueryParamsForURL:(NSURL *)url
 {
     NSArray<NSString*> *pathParams;
     NSMutableDictionary *queryParams = [NSMutableDictionary dictionary];
 
-    NSArray<NSString*> *fragments = [_url.fragment componentsSeparatedByString:@"?"];
+    NSArray<NSString*> *fragments = [url.fragment componentsSeparatedByString:@"?"];
 
     // Extract path params
     pathParams = [[fragments[0] stringByRemovingPercentEncoding] componentsSeparatedByString:@"/"];
@@ -57,7 +72,7 @@
     }];
     
     // Extract query params
-    NSURLComponents *components = [NSURLComponents componentsWithURL:_url resolvingAgainstBaseURL:NO];
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
     for (NSURLQueryItem *item in components.queryItems)
     {
         if (item.value)

--- a/changelog.d/6492.bugfix
+++ b/changelog.d/6492.bugfix
@@ -1,0 +1,1 @@
+Universal Links: Fix an infinite loop when handling a universal link for an unjoined room (or in some cases a crash).


### PR DESCRIPTION
When tapping on an unjoined room alias, the app delegate would look up the room ID for it, but as the link wasn't updated when it attempted to handle the new fragment the look up was made again.

Fixes #6492.
