### PR TITLE
Move the attachment navigation bar into a container.

### DIFF
--- a/Riot/Modules/Room/Attachements/AttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/AttachmentsViewController.m
@@ -58,7 +58,12 @@
 
 - (void)userInterfaceThemeDidChange
 {
-    [ThemeService.shared.theme applyStyleOnNavigationBar:self.navigationController.navigationBar];
+    [ThemeService.shared.theme applyStyleOnNavigationBar:self.navigationBar];
+    
+    // Remove the background effect as that won't match the container.
+    self.navigationBar.standardAppearance.backgroundEffect = nil;
+    self.navigationBar.standardAppearance.backgroundColor = ThemeService.shared.theme.colors.system;
+    self.navigationBarContainer.backgroundColor = ThemeService.shared.theme.colors.system;
 
     self.view.backgroundColor = ThemeService.shared.theme.backgroundColor;
     self.activityIndicator.backgroundColor = ThemeService.shared.theme.overlayBackgroundColor;

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.h
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.h
@@ -29,6 +29,7 @@ limitations under the License.
 @interface MXKAttachmentsViewController : MXKViewController <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UIDocumentInteractionControllerDelegate, MXKDestinationAttachmentAnimatorDelegate>
 
 @property (nonatomic) IBOutlet UICollectionView *attachmentsCollection;
+@property (nonatomic) IBOutlet UIView *navigationBarContainer;
 @property (nonatomic) IBOutlet UINavigationBar *navigationBar;
 @property (unsafe_unretained, nonatomic) IBOutlet UIBarButtonItem *backButton;
 

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -463,7 +463,7 @@
 
 - (IBAction)hideNavigationBar
 {
-    self.navigationBar.hidden = YES;
+    self.navigationBarContainer.hidden = YES;
     
     [navigationBarDisplayTimer invalidate];
     navigationBarDisplayTimer = nil;
@@ -953,10 +953,10 @@
                     }
                     
                     // Apply the same display to the navigation bar
-                    self.navigationBar.hidden = !controlsVisible;
+                    self.navigationBarContainer.hidden = !controlsVisible;
                     
                     navigationBarDisplayHandled = YES;
-                    if (!self.navigationBar.hidden)
+                    if (!self.navigationBarContainer.hidden)
                     {
                         // Automaticaly hide the nav bar after 5s. This is the same timer value that
                         // MPMoviePlayerController uses for its controls bar
@@ -1032,7 +1032,7 @@
                         [pieChartView removeFromSuperview];
                         
                         // Display the navigation bar so that the user can leave this screen
-                        self.navigationBar.hidden = NO;
+                        self.navigationBarContainer.hidden = NO;
                         
                         // Notify MatrixKit user
                         [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
@@ -1049,9 +1049,9 @@
     // Animate navigation bar if it is has not been handled
     if (!navigationBarDisplayHandled)
     {
-        if (self.navigationBar.hidden)
+        if (self.navigationBarContainer.hidden)
         {
-            self.navigationBar.hidden = NO;
+            self.navigationBarContainer.hidden = NO;
             [navigationBarDisplayTimer invalidate];
             navigationBarDisplayTimer = [NSTimer scheduledTimerWithTimeInterval:3 target:self selector:@selector(hideNavigationBar) userInfo:self repeats:NO];
         }
@@ -1141,7 +1141,7 @@
         MXLogDebug(@"[MXKAttachmentsVC] Playback failed with error description: %@", [mediaPlayerError localizedDescription]);
 
         // Display the navigation bar so that the user can leave this screen
-        self.navigationBar.hidden = NO;
+        self.navigationBarContainer.hidden = NO;
 
         // Notify MatrixKit user
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:mediaPlayerError];

--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.xib
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,16 +14,17 @@
                 <outlet property="attachmentsCollection" destination="LOp-cf-Sji" id="4Zx-KZ-fkh"/>
                 <outlet property="backButton" destination="VjO-K2-a0w" id="VlD-Iw-NT5"/>
                 <outlet property="navigationBar" destination="orb-yb-k6g" id="ILw-DO-IH2"/>
+                <outlet property="navigationBarContainer" destination="40U-Si-EHJ" id="ub0-0l-lga"/>
                 <outlet property="view" destination="iN0-l3-epB" id="ieV-u7-rXU"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" alwaysBounceHorizontal="YES" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="LOp-cf-Sji">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                     <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="RrA-v8-THJ">
                         <size key="itemSize" width="600" height="600"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -36,34 +36,50 @@
                         <outlet property="delegate" destination="-1" id="z1d-ep-n4n"/>
                     </connections>
                 </collectionView>
-                <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="orb-yb-k6g">
-                    <rect key="frame" x="0.0" y="20" width="375" height="44"/>
-                    <items>
-                        <navigationItem id="lP4-eZ-AQ8">
-                            <barButtonItem key="leftBarButtonItem" image="back_icon.png" style="plain" id="VjO-K2-a0w">
-                                <connections>
-                                    <action selector="onButtonPressed:" destination="-1" id="PEa-WB-Up1"/>
-                                </connections>
-                            </barButtonItem>
-                        </navigationItem>
-                    </items>
-                </navigationBar>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="40U-Si-EHJ" userLabel="Navigation Bar Container">
+                    <rect key="frame" x="0.0" y="0.0" width="390" height="88"/>
+                    <subviews>
+                        <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="orb-yb-k6g">
+                            <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                            <items>
+                                <navigationItem id="lP4-eZ-AQ8">
+                                    <barButtonItem key="leftBarButtonItem" image="back_icon.png" style="plain" id="VjO-K2-a0w">
+                                        <connections>
+                                            <action selector="onButtonPressed:" destination="-1" id="PEa-WB-Up1"/>
+                                        </connections>
+                                    </barButtonItem>
+                                </navigationItem>
+                            </items>
+                        </navigationBar>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="orb-yb-k6g" secondAttribute="trailing" id="XxB-m0-ll4"/>
+                        <constraint firstItem="orb-yb-k6g" firstAttribute="leading" secondItem="40U-Si-EHJ" secondAttribute="leading" id="vCT-fM-dmm"/>
+                        <constraint firstAttribute="bottom" secondItem="orb-yb-k6g" secondAttribute="bottom" id="xgn-qV-XWo"/>
+                    </constraints>
+                </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="kHK-qN-rPN"/>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="orb-yb-k6g" firstAttribute="top" secondItem="kHK-qN-rPN" secondAttribute="top" id="GGy-ix-LRO"/>
+                <constraint firstItem="40U-Si-EHJ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Ezg-Aa-OV8"/>
+                <constraint firstItem="40U-Si-EHJ" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="F5v-ws-OVn"/>
                 <constraint firstItem="LOp-cf-Sji" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="RQT-el-TH0"/>
+                <constraint firstItem="orb-yb-k6g" firstAttribute="top" secondItem="kHK-qN-rPN" secondAttribute="top" id="UxQ-JU-t2b"/>
                 <constraint firstAttribute="trailing" secondItem="LOp-cf-Sji" secondAttribute="trailing" id="Vgl-Wc-CI1"/>
-                <constraint firstAttribute="trailing" secondItem="orb-yb-k6g" secondAttribute="trailing" id="bFh-tc-Lub"/>
                 <constraint firstAttribute="bottom" secondItem="LOp-cf-Sji" secondAttribute="bottom" id="d22-2K-BEZ"/>
                 <constraint firstItem="LOp-cf-Sji" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="jEc-aG-zZn"/>
-                <constraint firstItem="orb-yb-k6g" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="toe-s8-clE"/>
+                <constraint firstAttribute="trailing" secondItem="40U-Si-EHJ" secondAttribute="trailing" id="kBi-Gh-1Oq"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
-            <viewLayoutGuide key="safeArea" id="kHK-qN-rPN"/>
+            <point key="canvasLocation" x="135" y="95"/>
         </view>
     </objects>
     <resources>
-        <image name="back_icon.png" width="13.5" height="23"/>
+        <image name="back_icon.png" width="13.666666984558105" height="23"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/changelog.d/6486.bugfix
+++ b/changelog.d/6486.bugfix
@@ -1,0 +1,1 @@
+Media: Fix a bug where the navigation bar shown when viewing an image wasn't taking the safe area into account.


### PR DESCRIPTION
The navigation bar wasn't using the safe area correctly, so it is now inside of a container that ignores the safe area and the top of the bar is aligned to the top of the safe area.

Realistically this view should use a Navigation Controller but this interferes animations so I've themed the container to match the nav bar. One down side of this is that it won't gain the system material when we enable the new app layout 😕

Fixes #6486.

| Light Mode | Dark Mode | iPhone SE |
| - | - | - |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-08-03 at 14 27 22](https://user-images.githubusercontent.com/6060466/182624173-6bd38342-e601-474d-b6f6-0ed17e9da36c.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-08-03 at 14 27 29](https://user-images.githubusercontent.com/6060466/182624199-e18c07f8-e1b5-4b25-aa55-962d29cddc3f.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-03 at 14 44 15](https://user-images.githubusercontent.com/6060466/182624223-93d8d61e-adca-463e-9803-1c8c3bc09a5b.png) |