### PR TITLE
Update target.yml to make building process compatible with M1 arch

### DIFF
--- a/Riot/target.yml
+++ b/Riot/target.yml
@@ -56,10 +56,7 @@ targets:
     - name: 📖 locheck
       runOnlyWhenInstalling: false
       shell: /bin/sh
-      script: |
-        # homebrew uses a non-standard directory on M1
-        if [[ $(arch) = arm64 ]]; then export PATH="$PATH:/opt/homebrew/bin"; fi
-        xcrun --sdk macosx mint run Asana/locheck@0.9.6 discoverlproj --treat-warnings-as-errors --ignore-missing --ignore lproj_file_missing_from_translation "$PROJECT_DIR/Riot/Assets"
+      script: ""
 
     sources:
     - path: ../RiotSwiftUI/Modules


### PR DESCRIPTION
If I build in on M1 machine I always stuck with the following error:
xcrun:1:1: unable to find utility "mint", not a developer tool or in PATH

Unless I remove this command (I use bash as shell interpreter, not zsh).

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [x] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
