### PR TITLE
Don't show personalisation after registering with a generic SSO provider.

### DIFF
--- a/Riot/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Riot/Modules/Onboarding/OnboardingCoordinator.swift
@@ -306,8 +306,11 @@ final class OnboardingCoordinator: NSObject, OnboardingCoordinatorProtocol {
         if authenticationFlow == .register,
            let userId = session.credentials.userId,
            let userSession = UserSessionsService.shared.userSession(withUserId: userId) {
+            // Skip personalisation when a generic SSO provider was used in case it already included the same steps.
+            let shouldShowPersonalization = BuildSettings.onboardingShowAccountPersonalization && authenticationType.analyticsType != .SSO
+            
             // If personalisation is to be shown, check that the homeserver supports it otherwise show the congratulations screen
-            if BuildSettings.onboardingShowAccountPersonalization {
+            if shouldShowPersonalization {
                 checkHomeserverCapabilities(for: userSession)
                 return
             } else {

--- a/changelog.d/6530.change
+++ b/changelog.d/6530.change
@@ -1,0 +1,1 @@
+Authentication: Don't show personalisation steps after registering with a generic SSO provider.


### PR DESCRIPTION
Small change in logic that ignores the personalisation steps when registration occurred via a generic SSO provider (i.e. it wasn't a social login provider).

Fixes #6530 