### PR TITLE
Fix a race condition when sending multiple images.

### DIFF
--- a/RiotShareExtension/Sources/ShareExtensionShareItemProvider.swift
+++ b/RiotShareExtension/Sources/ShareExtensionShareItemProvider.swift
@@ -96,11 +96,13 @@ public class ShareExtensionShareItemProvider: NSObject	 {
         
         shareExtensionItem.loaded = false
         shareExtensionItem.itemProvider.loadItem(forTypeIdentifier: typeIdentifier, options: nil) { result, error in
-            if error == nil {
-                shareExtensionItem.loaded = true
-            }
-            
             DispatchQueue.main.async {
+                // Mark the item as loaded when back on the main queue to avoid
+                // a race condition where the share extension sends duplicates.
+                if error == nil {
+                    shareExtensionItem.loaded = true
+                }
+                
                 completion(result, error)
             }
         }

--- a/changelog.d/5922.bugfix
+++ b/changelog.d/5922.bugfix
@@ -1,0 +1,1 @@
+Share Extension: Fix a bug where sending multiple images sometimes resulted in additional duplicates being sent.


### PR DESCRIPTION
There was a race condition when sending multiple images in the share extension, where the `sendPendingImages` block could be called multiple times. This was because the items were marked as `loaded` on a different thread to the completion handler.

Fixes #5922.