### PR TITLE
Reset registration.

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -131,8 +131,8 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
 
         let flow: AuthenticationFlow = initialScreen == .login ? .login : .register
         do {
-            let homeserverAddress = authenticationService.state.homeserver.addressFromUser ?? authenticationService.state.homeserver.address
-            try await authenticationService.startFlow(flow, for: homeserverAddress)
+            // Start the flow using the default server (or a provisioning link if set).
+            try await authenticationService.startFlow(flow)
         } catch {
             MXLog.error("[AuthenticationCoordinator] start: Failed to start")
             displayError(message: error.localizedDescription)

--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -134,8 +134,8 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
             // Start the flow using the default server (or a provisioning link if set).
             try await authenticationService.startFlow(flow)
         } catch {
-            MXLog.error("[AuthenticationCoordinator] start: Failed to start")
-            displayError(message: error.localizedDescription)
+            MXLog.error("[AuthenticationCoordinator] start: Failed to start, showing server selection.")
+            showServerSelectionScreen(for: flow)
             return
         }
 
@@ -152,6 +152,42 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
             } else {
                 showLoginScreen()
             }
+        }
+    }
+    
+    /// Pushes the server selection screen into the flow (other screens may also present it modally later).
+    @MainActor private func showServerSelectionScreen(for flow: AuthenticationFlow) {
+        MXLog.debug("[AuthenticationCoordinator] showServerSelectionScreen")
+        let parameters = AuthenticationServerSelectionCoordinatorParameters(authenticationService: authenticationService,
+                                                                            flow: flow,
+                                                                            hasModalPresentation: false)
+        let coordinator = AuthenticationServerSelectionCoordinator(parameters: parameters)
+        coordinator.callback = { [weak self, weak coordinator] result in
+            guard let self = self, let coordinator = coordinator else { return }
+            self.serverSelectionCoordinator(coordinator, didCompleteWith: result, for: flow)
+        }
+        
+        coordinator.start()
+        add(childCoordinator: coordinator)
+        
+        navigationRouter.push(coordinator, animated: true) { [weak self] in
+            self?.remove(childCoordinator: coordinator)
+        }
+    }
+    
+    /// Shows the next screen in the flow after the server selection screen.
+    @MainActor private func serverSelectionCoordinator(_ coordinator: AuthenticationServerSelectionCoordinator,
+                                                       didCompleteWith result: AuthenticationServerSelectionCoordinatorResult,
+                                                       for flow: AuthenticationFlow) {
+        switch result {
+        case .updated:
+            if flow == .register {
+                showRegistrationScreen()
+            } else {
+                showLoginScreen()
+            }
+        case .dismiss:
+            MXLog.failure("[AuthenticationCoordinator] AuthenticationServerSelectionScreen is requesting dismiss when part of a stack.")
         }
     }
     
@@ -306,48 +342,6 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     }
     
     // MARK: - Registration
-    
-    #warning("Unused.")
-    /// Pushes the server selection screen into the flow (other screens may also present it modally later).
-    @MainActor private func showServerSelectionScreen() {
-        MXLog.debug("[AuthenticationCoordinator] showServerSelectionScreen")
-        let parameters = AuthenticationServerSelectionCoordinatorParameters(authenticationService: authenticationService,
-                                                                            flow: .register,
-                                                                            hasModalPresentation: false)
-        let coordinator = AuthenticationServerSelectionCoordinator(parameters: parameters)
-        coordinator.callback = { [weak self, weak coordinator] result in
-            guard let self = self, let coordinator = coordinator else { return }
-            self.serverSelectionCoordinator(coordinator, didCompleteWith: result)
-        }
-        
-        coordinator.start()
-        add(childCoordinator: coordinator)
-        
-        if navigationRouter.modules.isEmpty {
-            navigationRouter.setRootModule(coordinator) { [weak self] in
-                self?.remove(childCoordinator: coordinator)
-            }
-        } else {
-            navigationRouter.push(coordinator, animated: true) { [weak self] in
-                self?.remove(childCoordinator: coordinator)
-            }
-        }
-    }
-    
-    /// Shows the next screen in the flow after the server selection screen.
-    @MainActor private func serverSelectionCoordinator(_ coordinator: AuthenticationServerSelectionCoordinator,
-                                                       didCompleteWith result: AuthenticationServerSelectionCoordinatorResult) {
-        switch result {
-        case .updated:
-            if authenticationService.state.homeserver.needsRegistrationFallback {
-                showFallback(for: .register)
-            } else {
-                showRegistrationScreen()
-            }
-        case .dismiss:
-            MXLog.failure("[AuthenticationCoordinator] AuthenticationServerSelectionScreen is requesting dismiss when part of a stack.")
-        }
-    }
     
     /// Shows the registration screen.
     @MainActor private func showRegistrationScreen() {

--- a/changelog.d/6489.bugfix
+++ b/changelog.d/6489.bugfix
@@ -1,0 +1,1 @@
+Authentication: Always start a new authentication flow with the default homeserver (or the provisioning link if set).


### PR DESCRIPTION
This PR makes 2 changes to the authentication.
- Always load the default homeserver (or provisioned one) when starting a new auth flow
- If an error occurs when starting a new auth flow, show the server selection screen instead of an error (so the user can potentially choose a different server to fix the error).

Fixes #6489.