### PR TITLE
Revert maximum voice message recording length back to 2m (PSG-662)

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
@@ -26,7 +26,7 @@ import DSWaveformImage
 public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, VoiceMessageAudioRecorderDelegate, VoiceMessageAudioPlayerDelegate {
     
     private enum Constants {
-        static let maximumAudioRecordingDuration: TimeInterval = 900.0
+        static let maximumAudioRecordingDuration: TimeInterval = 120.0
         static let maximumAudioRecordingLengthReachedThreshold: TimeInterval = 10.0
         static let elapsedTimeFormat = "m:ss"
         static let fileNameDateFormat = "MM.dd.yyyy HH.mm.ss"

--- a/changelog.d/6529.change
+++ b/changelog.d/6529.change
@@ -1,1 +1,0 @@
-Increase max length of voice messages to 15m (PSG-662)


### PR DESCRIPTION
This reverts commit f92bda4e8822bb9cceeda293120c01f5ba0f569e, reversing
changes made to b7713043b15b26606b2d11fb183379881d7ad498.

This undoes the changes from #6529. Testing with longer voice messages and on real devices has revealed that the absence of a loading state both for sending and receiving voice messages can make the feature very hard to use on longer voice messages. The issue still persists on 2m voice messages, too, but is at least less apparent.

Relates to #5415