### PR TITLE
Fix potential crash when dismissing an image.

### DIFF
--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -1383,13 +1383,19 @@
 
 - (BOOL)prepareSubviewsForTransition:(BOOL)isStartInteraction
 {
-    MXKMediaCollectionViewCell *cell = (MXKMediaCollectionViewCell *)[self.attachmentsCollection.visibleCells firstObject];
+    // Sanity check
+    if (currentVisibleItemIndex >= attachments.count)
+    {
+        return NO;
+    }
+    
     MXKAttachment *attachment = attachments[currentVisibleItemIndex];
     NSString *mimeType = attachment.contentInfo[@"mimetype"];
 
     // Check attachment type for GIFs - this is required because of the extra WKWebView
     if (attachment.type == MXKAttachmentTypeImage && attachment.contentURL && [mimeType isEqualToString:@"image/gif"])
     {
+        MXKMediaCollectionViewCell *cell = (MXKMediaCollectionViewCell *)[self.attachmentsCollection.visibleCells firstObject];
         UIView *customView = cell.customView;
         for (UIView *v in customView.subviews)
         {

--- a/changelog.d/6548.bugfix
+++ b/changelog.d/6548.bugfix
@@ -1,0 +1,1 @@
+Media: Fix a potential crash when dismissing an image.


### PR DESCRIPTION
Adds a small sanity check following a few crashes reported in the RC.

Fixes #6548.