### PR TITLE
Symmetric backup

### DIFF
--- a/Riot/Modules/KeyBackup/Recover/KeyBackupRecoverCoordinator.swift
+++ b/Riot/Modules/KeyBackup/Recover/KeyBackupRecoverCoordinator.swift
@@ -84,7 +84,7 @@ final class KeyBackupRecoverCoordinator: KeyBackupRecoverCoordinatorType {
         let coordinator: Coordinator & Presentable
         
         // Check if a passphrase has been set for given backup
-        if let megolmBackupAuthData = MXMegolmBackupAuthData(fromJSON: self.keyBackupVersion.authData), megolmBackupAuthData.privateKeySalt != nil {
+        if self.keyBackupVersion.authData["private_key_salt"] != nil {
             coordinator = self.createRecoverFromPassphraseCoordinator()
         } else {
             coordinator = self.createRecoverFromRecoveryKeyCoordinator()

--- a/Riot/Modules/KeyBackup/Setup/KeyBackupSetupCoordinator.swift
+++ b/Riot/Modules/KeyBackup/Setup/KeyBackupSetupCoordinator.swift
@@ -134,7 +134,7 @@ final class KeyBackupSetupCoordinator: KeyBackupSetupCoordinatorType {
             return
         }
         
-        keyBackup.prepareKeyBackupVersion(withPassword: nil, success: { megolmBackupCreationInfo in
+        keyBackup.prepareKeyBackupVersion(withPassword: nil, algorithm: nil, success: { megolmBackupCreationInfo in
             keyBackup.createKeyBackupVersion(megolmBackupCreationInfo, success: { _ in
                 recoveryService.updateRecovery(forSecrets: [MXSecretId.keyBackup.takeUnretainedValue() as String], withPrivateKey: privateKey) {
                     completion(.success(Void()))

--- a/Riot/Modules/KeyBackup/Setup/Passphrase/KeyBackupSetupPassphraseViewModel.swift
+++ b/Riot/Modules/KeyBackup/Setup/Passphrase/KeyBackupSetupPassphraseViewModel.swift
@@ -96,7 +96,7 @@ final class KeyBackupSetupPassphraseViewModel: KeyBackupSetupPassphraseViewModel
         
         self.update(viewState: .loading)
         
-        self.keyBackup.prepareKeyBackupVersion(withPassword: passphrase, success: { [weak self] (megolmBackupCreationInfo) in
+        self.keyBackup.prepareKeyBackupVersion(withPassword: passphrase, algorithm: nil, success: { [weak self] (megolmBackupCreationInfo) in
             guard let sself = self else {
                 return
             }
@@ -122,7 +122,7 @@ final class KeyBackupSetupPassphraseViewModel: KeyBackupSetupPassphraseViewModel
     private func setupRecoveryKey() {
         self.update(viewState: .loading)
         
-        self.keyBackup.prepareKeyBackupVersion(withPassword: nil, success: { [weak self] (megolmBackupCreationInfo) in
+        self.keyBackup.prepareKeyBackupVersion(withPassword: nil, algorithm: nil, success: { [weak self] (megolmBackupCreationInfo) in
             guard let sself = self else {
                 return
             }

--- a/Riot/Modules/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/Riot/Modules/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -192,6 +192,7 @@ static NSAttributedString *verticalWhitespace = nil;
         NSString *claimedKey = _mxEvent.keysClaimed[@"ed25519"];
         NSString *algorithm = _mxEvent.wireContent[@"algorithm"];
         NSString *sessionId = _mxEvent.wireContent[@"session_id"];
+        NSString *untrusted = _mxEvent.isUntrusted ? [VectorL10n userVerificationSessionsListSessionUntrusted] : [VectorL10n userVerificationSessionsListSessionTrusted];
         
         NSString *decryptionError;
         if (_mxEvent.decryptionError)
@@ -274,6 +275,16 @@ static NSAttributedString *verticalWhitespace = nil;
                                                                      NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
         [eventInformationString appendAttributedString:[[NSMutableAttributedString alloc]
                                                         initWithString:sessionId
+                                                        attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
+                                                                     NSFontAttributeName: [UIFont systemFontOfSize:14]}]];
+        [eventInformationString appendAttributedString:[MXKEncryptionInfoView verticalWhitespace]];
+
+        [eventInformationString appendAttributedString:[[NSMutableAttributedString alloc]
+                                                        initWithString:[NSString stringWithFormat:@"%@\n", [VectorL10n sslTrust]]
+                                                        attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
+                                                                     NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
+        [eventInformationString appendAttributedString:[[NSMutableAttributedString alloc]
+                                                        initWithString:untrusted
                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
                                                                      NSFontAttributeName: [UIFont systemFontOfSize:14]}]];
         [eventInformationString appendAttributedString:[MXKEncryptionInfoView verticalWhitespace]];

--- a/changelog.d/pr-6555.change
+++ b/changelog.d/pr-6555.change
@@ -1,0 +1,1 @@
+KeyBackup: Adapt changes from sdk, add an entry into encryption info view of a message.


### PR DESCRIPTION
Adapt to changes in https://github.com/matrix-org/matrix-ios-sdk/pull/1542.

Adds an entry into the encryption info view for `MXEvent.isUntrusted`. It's for debugging purposes, will be updated later.