### PR TITLE
Fix blank room screen

### DIFF
--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
@@ -205,7 +205,7 @@ typedef enum : NSUInteger
     UIView *messageComposerContainer;
     
 @protected
-    UIView *inputAccessoryView;
+    UIView *inputAccessoryViewForKeyboard;
 }
 
 /**
@@ -333,7 +333,7 @@ typedef enum : NSUInteger
  actually used to retrieve the keyboard view. Indeed the keyboard view is the superview of
  the accessory view when the message composer become the first responder.
  */
-@property (readonly) UIView *inputAccessoryView;
+@property (readonly) UIView *inputAccessoryViewForKeyboard;
 
 /**
  Display the keyboard.

--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -61,7 +61,7 @@
 @end
 
 @implementation MXKRoomInputToolbarView
-@synthesize messageComposerContainer, inputAccessoryView;
+@synthesize messageComposerContainer, inputAccessoryViewForKeyboard;
 
 + (UINib *)nib
 {
@@ -103,7 +103,7 @@
 
 - (void)dealloc
 {
-    inputAccessoryView = nil;
+    inputAccessoryViewForKeyboard = nil;
     
     [self destroy];
 }

--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithSimpleTextView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarViewWithSimpleTextView.m
@@ -30,8 +30,8 @@
     [super awakeFromNib];
     
     // Add an accessory view to the text view in order to retrieve keyboard view.
-    inputAccessoryView = [[UIView alloc] initWithFrame:CGRectZero];
-    self.messageComposerTextView.inputAccessoryView = self.inputAccessoryView;
+    inputAccessoryViewForKeyboard = [[UIView alloc] initWithFrame:CGRectZero];
+    self.messageComposerTextView.inputAccessoryView = inputAccessoryViewForKeyboard;
 }
 
 -(void)customizeViewRendering

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -308,7 +308,9 @@
     }
     
     // Finalize view controller appearance
-    [self updateViewControllerAppearanceOnRoomDataSourceState];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self updateViewControllerAppearanceOnRoomDataSourceState];
+    });
     
     // no need to reload the tableview at this stage
     // IOS is going to load it after calling this method

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -495,7 +495,7 @@
     if (!keyboardView)
     {
         // Check whether the first responder is the input tool bar text composer
-        keyboardView = inputToolbarView.inputAccessoryView.superview;
+        keyboardView = inputToolbarView.inputAccessoryViewForKeyboard.superview;
     }
     
     // Report the keyboard view in order to track keyboard frame changes

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4938,7 +4938,9 @@ static CGSize kThreadListBarButtonItemImageSize;
         {
             readMarkerTableViewCell = roomBubbleTableViewCell;
             
-            [self checkReadMarkerVisibility];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self checkReadMarkerVisibility];
+            });
         }
     }
 }

--- a/Riot/Modules/Room/RoomViewController.xib
+++ b/Riot/Modules/Room/RoomViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -41,25 +41,14 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3z2-8P-wlg">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="20.5"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hIS-uE-jlE">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="20.5"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <variation key="default">
-                        <mask key="subviews">
-                            <exclude reference="hIS-uE-jlE"/>
-                        </mask>
-                    </variation>
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3z2-8P-wlg" userLabel="Top Banners Stack View">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                    <constraints>
+                        <constraint firstAttribute="height" priority="250" id="Y9P-Ek-wjg"/>
+                    </constraints>
                 </stackView>
-                <tableView contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" keyboardDismissMode="interactive" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="BGD-sd-SQR">
-                    <rect key="frame" x="0.0" y="20.5" width="375" height="605.5"/>
+                <tableView contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="BGD-sd-SQR">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="626"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="RoomVCBubblesTableView"/>
@@ -160,8 +149,8 @@
                         <action selector="scrollToBottomAction:" destination="-1" eventType="touchUpInside" id="TOf-aY-J6a"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QHs-rM-UU8" userLabel="scroll badge" customClass="BadgeLabel" customModule="Riot" customModuleProvider="target">
-                    <rect key="frame" x="336.5" y="557.5" width="7.5" height="13.5"/>
+                <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QHs-rM-UU8" userLabel="scroll badge" customClass="BadgeLabel" customModule="Element" customModuleProvider="target">
+                    <rect key="frame" x="331.5" y="556" width="17.5" height="16.5"/>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="11"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -244,7 +233,7 @@
     </objects>
     <designables>
         <designable name="QHs-rM-UU8">
-            <size key="intrinsicContentSize" width="7.5" height="13.5"/>
+            <size key="intrinsicContentSize" width="17.5" height="16.5"/>
         </designable>
     </designables>
     <resources>

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -80,6 +80,9 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
     [self updateUIWithAttributedTextMessage:nil animated:NO];
     
     self.textView.toolbarDelegate = self;
+
+    inputAccessoryViewForKeyboard = [[UIView alloc] initWithFrame:CGRectZero];
+    self.textView.inputAccessoryView = inputAccessoryViewForKeyboard;
 }
 
 - (void)setVoiceMessageToolbarView:(UIView *)voiceMessageToolbarView

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -80,10 +80,6 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
     [self updateUIWithAttributedTextMessage:nil animated:NO];
     
     self.textView.toolbarDelegate = self;
-    
-    // Add an accessory view to the text view in order to retrieve keyboard view.
-    inputAccessoryView = [[UIView alloc] initWithFrame:CGRectZero];
-    self.textView.inputAccessoryView = inputAccessoryView;
 }
 
 - (void)setVoiceMessageToolbarView:(UIView *)voiceMessageToolbarView

--- a/changelog.d/5932.bugfix
+++ b/changelog.d/5932.bugfix
@@ -1,0 +1,1 @@
+RoomViewController: Wait for table view updates before checing read marker visibility.


### PR DESCRIPTION
I couldn't reproduce the issue by playing with network connection. I could see a blank screen but also a syncing spinner was there.

The issue seen on iPad was due to an unnecessary `inputAccessoryView` on message text view. Somehow the table view was insetted wrongly (so that all the content to be out of screen).
This PR also addresses some suspicious `UITableView` errors i saw in logs.
There may be other cases for the issue we're not aware of yet.

1. `Element[4045:46257] [Assert] Attempted to access the table view's visibleCells while they were in the process of being updated, which is not allowed. Make a symbolic breakpoint at UITableViewAlertForVisibleCellsAccessDuringUpdate to catch this in the debugger and see what caused this to occur. Perhaps you are trying to ask the table view for the visible cells from inside a table view callback about a specific row? Table view: <UITableView: 0x7fc1d0150000; frame = (0 0; 428 777); autoresize = RM+BM; gestureRecognizers = <NSArray: 0x6000010835a0>; layer = <CALayer: 0x600001d853c0>; contentOffset: {0, 0}; contentSize: {428, 1998.6666641235352}; adjustedContentInset: {0, 0, 34, 0}; dataSource: <RoomDataSource: 0x7fc1c72d13e0>>`

2. `Element[4288:55918] [TableView] Warning once only: UITableView was told to layout its visible cells and other contents without being in the view hierarchy (the table view or one of its superviews has not been added to a window). This may cause bugs by forcing views inside the table view to load and perform layout without accurate information (e.g. table view bounds, trait collection, layout margins, safe area insets, etc), and will also cause unnecessary performance overhead due to extra layout passes. Make a symbolic breakpoint at UITableViewAlertForLayoutOutsideViewHierarchy to catch this in the debugger and see what caused this to occur, so you can avoid this action altogether if possible, or defer it until the table view has been added to a window. Table view: <UITableView: 0x7fc927027a00; frame = (0 0; 428 868); hidden = YES; autoresize = RM+BM; gestureRecognizers = <NSArray: 0x6000018f4360>; layer = <CALayer: 0x6000016d5060>; contentOffset: {0, 0}; contentSize: {428, 0}; adjustedContentInset: {0, 0, 0, 0}; dataSource: (null)>`

3. iPad issue after orientation changes (reported at https://matrix.to/#/!NMoyFpQxIVYaQIfQHG:matrix.org/$Pf9_zjq5XrNPmWCI57DjdYnFcffH3NcS0iNHJKvx6rY?via=matrix.org&via=element.io&via=one.ems.host)

Fixes #5932 