### PR TITLE
Fixes #6569 - Provide SSO backup for homeservers that don't return an identity providers list

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginModels.swift
@@ -52,7 +52,9 @@ enum LoginMode {
     var ssoIdentityProviders: [SSOIdentityProvider]? {
         switch self {
         case .sso(let ssoIdentityProviders), .ssoAndPassword(let ssoIdentityProviders):
-            return ssoIdentityProviders
+            // Provide a backup for homeservers that support SSO but don't offer any identity providers
+            // https://spec.matrix.org/latest/client-server-api/#client-login-via-sso
+            return ssoIdentityProviders.count > 0 ? ssoIdentityProviders : [SSOIdentityProvider(id: "", name: "SSO", brand: nil, iconURL: nil)]
         default:
             return nil
         }

--- a/changelog.d/6569.bugfix
+++ b/changelog.d/6569.bugfix
@@ -1,0 +1,1 @@
+Add a login and signup fallback SSO option for homeservers that don't offer a list of identity providers.


### PR DESCRIPTION
The identity providers list is optional in the spec and can be missing on homeservers that **do** support SSO.
The solution is to provide a nameless fallback identity provider that would make a generic button be shown on the login screen and use the base path as the sso redirect path here https://github.com/vector-im/element-ios/blob/develop/Riot/Modules/Authentication/SSO/SSOAuthenticationService.swift#L53