### PR TITLE
Track all errors in Sentry

### DIFF
--- a/Riot/Categories/UIViewController.swift
+++ b/Riot/Categories/UIViewController.swift
@@ -142,7 +142,7 @@ extension UIViewController {
             // Even when .never, needs to be true otherwise animation will be broken on iOS11, 12, 13
             navigationController?.navigationBar.prefersLargeTitles = true
         @unknown default:
-            MXLog.failure("[UIViewController] setLargeTitleDisplayMode: Missing handler for \(largeTitleDisplayMode)")
+            MXLog.failure("[UIViewController] setLargeTitleDisplayMode: Missing handler", context: largeTitleDisplayMode)
         }
     }
 

--- a/Riot/Managers/Logging/MatrixSDKLogger.swift
+++ b/Riot/Managers/Logging/MatrixSDKLogger.swift
@@ -33,7 +33,7 @@ class MatrixSDKLogger: LoggerProtocol {
     static func warning(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         MXLog.warning(message(), file, function, line: line, context: context)
     }
-    static func error(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    static func error(_ message: @autoclosure () -> StaticString, _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         MXLog.error(message(), file, function, line: line, context: context)
     }
 }

--- a/Riot/Managers/URLPreviews/Core Data/URLPreviewStore.swift
+++ b/Riot/Managers/URLPreviews/Core Data/URLPreviewStore.swift
@@ -59,14 +59,14 @@ class URLPreviewStore {
         // Load the persistent stores into the container
         container.loadPersistentStores { storeDescription, error in
             if let error = error {
-                MXLog.error("[URLPreviewStore] Core Data container error: \(error.localizedDescription)")
+                MXLog.error("[URLPreviewStore] Core Data container", context: error)
             }
             
             if let url = storeDescription.url {
                 do {
                     try FileManager.default.excludeItemFromBackup(at: url)
                 } catch {
-                    MXLog.error("[URLPreviewStore] Cannot exclude Core Data from backup: \(error.localizedDescription)")
+                    MXLog.error("[URLPreviewStore] Cannot exclude Core Data from backup", context: error)
                 }
             }
         }
@@ -130,7 +130,7 @@ class URLPreviewStore {
         do {
             try context.execute(NSBatchDeleteRequest(fetchRequest: request))
         } catch {
-            MXLog.error("[URLPreviewStore] Error executing batch delete request: \(error.localizedDescription)")
+            MXLog.error("[URLPreviewStore] Error executing batch delete request", context: error)
         }
     }
     
@@ -140,7 +140,7 @@ class URLPreviewStore {
             _ = try context.execute(NSBatchDeleteRequest(fetchRequest: URLPreviewDataMO.fetchRequest()))
             _ = try context.execute(NSBatchDeleteRequest(fetchRequest: URLPreviewUserDataMO.fetchRequest()))
         } catch {
-            MXLog.error("[URLPreviewStore] Error executing batch delete request: \(error.localizedDescription)")
+            MXLog.error("[URLPreviewStore] Error executing batch delete request", context: error)
         }
     }
     
@@ -171,7 +171,7 @@ class URLPreviewStore {
         do {
             try context.save()
         } catch {
-            MXLog.error("[URLPreviewStore] Error saving changes: \(error.localizedDescription)")
+            MXLog.error("[URLPreviewStore] Error saving changes", context: error)
         }
     }
 }

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -384,7 +384,7 @@ extension Analytics: MXAnalyticsDelegate {
         capture(event: event)
     }
 
-    func trackNonFatalIssue(_ issue: String, details: [String : Any]?) {
+    func trackNonFatalIssue(_ issue: String, details: [String: Any]?) {
         monitoringClient.trackNonFatalIssue(issue, details: details)
     }
 }

--- a/Riot/Modules/Analytics/SentryMonitoringClient.swift
+++ b/Riot/Modules/Analytics/SentryMonitoringClient.swift
@@ -32,7 +32,9 @@ struct SentryMonitoringClient {
         MXLog.debug("[SentryMonitoringClient] Started")
         SentrySDK.start { options in
             options.dsn = Self.sentryDSN
-            options.tracesSampleRate = 1.0
+            
+            // Collecting only 10% of all events
+            options.tracesSampleRate = 0.1
             
             options.beforeSend = { event in
                 MXLog.debug("[SentryMonitoringClient] Issue detected: \(event)")

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -1400,7 +1400,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                                 event = eventFromServer;
                                 dispatch_group_leave(eventDispatchGroup);
                             } failure:^(NSError *error) {
-                                MXLogError(@"[LegacyAppDelegate] handleUniversalLinkWithParameters: event fetch failed: %@", error);
+                                MXLogErrorDetails(@"[LegacyAppDelegate] handleUniversalLinkWithParameters: event fetch failed", @{
+                                    @"error": error ?: @"unknown"
+                                });
                                 dispatch_group_leave(eventDispatchGroup);
                             }];
                         }

--- a/Riot/Modules/Authentication/SessionVerificationListener.swift
+++ b/Riot/Modules/Authentication/SessionVerificationListener.swift
@@ -99,7 +99,7 @@ class SessionVerificationListener {
                                     MXLog.debug("[SessionVerificationListener] sessionStateDidChange: Bootstrap succeeded")
                                     self.completion?(.authenticationIsComplete)
                                 } failure: { error in
-                                    MXLog.error("[SessionVerificationListener] sessionStateDidChange: Bootstrap failed. Error: \(error)")
+                                    MXLog.error("[SessionVerificationListener] sessionStateDidChange: Bootstrap failed", context: error)
                                     crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                                     self.completion?(.authenticationIsComplete)
                                 }
@@ -128,7 +128,7 @@ class SessionVerificationListener {
                         self.completion?(.authenticationIsComplete)
                     }
                 } failure: { [weak self] error in
-                    MXLog.error("[SessionVerificationListener] sessionStateDidChange: Fail to refresh crypto state with error: \(error)")
+                    MXLog.error("[SessionVerificationListener] sessionStateDidChange: Fail to refresh crypto state", context: error)
                     crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                     self?.completion?(.authenticationIsComplete)
                 }

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -2046,7 +2046,11 @@ NSString *const RecentsViewControllerDataReadyNotification = @"RecentsViewContro
         }
         else if (section >= self.recentsTableView.numberOfSections)
         {
-            MXLogFailure(@"[RecentsViewController] Section %ld is invalid in a table view with only %ld sections", section, self.recentsTableView.numberOfSections);
+            NSDictionary *details = @{
+                @"section": @(section),
+                @"number_of_sections": @(self.recentsTableView.numberOfSections)
+            };
+            MXLogFailureDetails(@"[RecentsViewController] Section in a table view is invalid", details);
         }
     }
 }

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
@@ -219,7 +219,7 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         do {
             return try codeGenerator.generateCode(from: data, with: codeImageView.frame.size)
         } catch {
-            MXLog.error("[KeyVerificationVerifyByScanningViewController] qrCodeImage: cannot generate QR code - \(error)")
+            MXLog.error("[KeyVerificationVerifyByScanningViewController] qrCodeImage: cannot generate QR code", context: error)
             return nil
         }
     }

--- a/Riot/Modules/LocationSharing/LocationManager.swift
+++ b/Riot/Modules/LocationSharing/LocationManager.swift
@@ -214,6 +214,6 @@ extension LocationManager: CLLocationManagerDelegate {
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        MXLog.error("[LocationManager] Did failed with error :\(error)")
+        MXLog.error("[LocationManager] Did failed", context: error)
     }
 }

--- a/Riot/Modules/LocationSharing/UserLocationService.swift
+++ b/Riot/Modules/LocationSharing/UserLocationService.swift
@@ -217,7 +217,7 @@ class UserLocationService: UserLocationServiceProtocol {
             case .success:
                 break
             case .failure(let error):
-                MXLog.error("Fail to send location with error \(error)")
+                MXLog.error("Fail to send location", context: error)
             }
         }
     }

--- a/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m
+++ b/Riot/Modules/MatrixKit/Controllers/MXKAuthenticationViewController.m
@@ -1542,12 +1542,16 @@
         
         if (retry)
         {
-            MXLogError(@"[MXKAuthenticationViewController] attemptDeviceRehydration: device rehydration failed due to error: %@. Retrying", error);
+            MXLogErrorDetails(@"[MXKAuthenticationViewController] attemptDeviceRehydration: device rehydration failed due to error: Retrying", @{
+                @"error": error ?: @"unknown"
+            });
             [self attemptDeviceRehydrationWithKeyData:keyData credentials:credentials retry:NO];
             return;
         }
         
-        MXLogError(@"[MXKAuthenticationViewController] attemptDeviceRehydration: device rehydration failed due to error: %@", error);
+        MXLogErrorDetails(@"[MXKAuthenticationViewController] attemptDeviceRehydration: device rehydration failed due to error", @{
+            @"error": error ?: @"unknown"
+        });
         
         [self _createAccountWithCredentials:credentials];
     }];

--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -1618,11 +1618,15 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
         if (retry)
         {
             [self attemptDeviceDehydrationWithKeyData:keyData retry:NO success:success failure:failure];
-            MXLogError(@"[MXKAccount] attemptDeviceDehydrationWithRetry: device dehydration failed due to error: %@. Retrying.", error);
+            MXLogErrorDetails(@"[MXKAccount] attemptDeviceDehydrationWithRetry: device dehydration failed due to error: Retrying.", @{
+                @"error": error ?: @"unknown"
+            });
         }
         else
         {
-            MXLogError(@"[MXKAccount] attemptDeviceDehydrationWithRetry: device dehydration failed due to error: %@", error);
+            MXLogErrorDetails(@"[MXKAccount] attemptDeviceDehydrationWithRetry: device dehydration failed due to error", @{
+                @"error": error ?: @"unknown"
+            });
             
             if (failure)
             {
@@ -1772,7 +1776,9 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
                     
                     dispatch_group_leave(dispatchGroup);
                 } failure:^(NSError *error) {
-                    MXLogError(@"[MXKAccount] onDateTimeFormatUpdate: event fetch failed: %@", error);
+                    MXLogErrorDetails(@"[MXKAccount] onDateTimeFormatUpdate: event fetch failed", @{
+                        @"error": error ?: @"unknown"
+                    });
                     dispatch_group_leave(dispatchGroup);
                 }];
             }

--- a/Riot/Modules/MatrixKit/Models/Room/MXKAttachment.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKAttachment.m
@@ -476,7 +476,9 @@ NSString *const kMXKAttachmentFileNameBase = @"attatchment";
         NSError *error;
         BOOL result = [NSFileManager.defaultManager removeItemAtPath:[temporaryDirectoryPath stringByAppendingPathComponent:filePath] error:&error];
         if (!result && error) {
-            MXLogError(@"[MXKAttachment] Failed deleting temporary file with error: %@", error);
+            MXLogErrorDetails(@"[MXKAttachment] Failed deleting temporary file with error", @{
+                @"error": error ?: @"unknown"
+            });
         }
     }
 }

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MarkdownToHTMLRenderer.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MarkdownToHTMLRenderer.swift
@@ -44,7 +44,7 @@ extension MarkdownToHTMLRenderer: MarkdownToHTMLRendererProtocol {
             ast.repairLinks()
             return try DownHTMLRenderer.astToHTML(ast, options: options)
         } catch {
-            MXLog.error("[MarkdownToHTMLRenderer] renderToHTML failed with string: \(markdown)")
+            MXLog.error("[MarkdownToHTMLRenderer] renderToHTML failed")
             return nil
         }
     }

--- a/Riot/Modules/MatrixKit/Utils/MXKVideoThumbnailGenerator.swift
+++ b/Riot/Modules/MatrixKit/Utils/MXKVideoThumbnailGenerator.swift
@@ -67,7 +67,7 @@ public class MXKVideoThumbnailGenerator: NSObject {
             let image = try assetImageGenerator.copyCGImage(at: .zero, actualTime: nil)
             thumbnailImage = UIImage(cgImage: image)
         } catch {
-            MXLog.error(error.localizedDescription)
+            MXLog.error("[MXKVideoThumbnailGenerator] generateThumbnail:", context: error)
             thumbnailImage = nil
         }
         

--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -1197,7 +1197,8 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
                         pasteboardImage = [UIImage imageWithData:[dict objectForKey:key]];
                     }
                     else {
-                        MXLogError(@"[MXKRoomInputToolbarView] Unsupported image format %@ for mimetype %@ pasted.", MIMEType, NSStringFromClass([[dict objectForKey:key] class]));
+                        NSString *message = [NSString stringWithFormat:@"[MXKRoomInputToolbarView] Unsupported image format %@ for mimetype %@ pasted.", MIMEType, NSStringFromClass([[dict objectForKey:key] class])];
+                        MXLogError(message);
                     }
                     
                     if (pasteboardImage)

--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -1365,7 +1365,9 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
 {
     if (event.eventType != MXEventTypeBeaconInfo)
     {
-        MXLogError(@"[RoomBubbleCellData] Try to update beacon info summary with wrong event type with event id %@", eventId);
+        MXLogErrorDetails(@"[RoomBubbleCellData] Try to update beacon info summary with wrong event type", @{
+            @"event_id": eventId ?: @"unknown"
+        });
         return;
     }
     
@@ -1378,7 +1380,9 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
         // A start beacon info event (isLive == true) should have an associated BeaconInfoSummary
         if (beaconInfo && beaconInfo.isLive)
         {
-            MXLogError(@"[RoomBubbleCellData] No beacon info summary found for beacon info start event with id %@", eventId);
+            MXLogErrorDetails(@"[RoomBubbleCellData] No beacon info summary found for beacon info start event", @{
+                @"event_id": eventId ?: @"unknown"
+            });
         }
     }
     

--- a/Riot/Modules/Room/ParticipantsInviteModal/ContactsPicker/ContactsPickerViewModel.swift
+++ b/Riot/Modules/Room/ParticipantsInviteModal/ContactsPicker/ContactsPickerViewModel.swift
@@ -224,7 +224,7 @@ extension ContactsPickerViewModel: ContactsTableViewControllerDelegate {
                 case .success:
                     self.coordinatorDelegate?.contactsPickerViewModelDidEndInvite(self)
                 case .failure:
-                    MXLog.error("[ContactsPickerViewModel] Failed to invite \(participantId) due to error; \(response.error ?? "nil")")
+                    MXLog.error("[ContactsPickerViewModel] Failed to invite participant", context: response.error)
                     self.coordinatorDelegate?.contactsPickerViewModel(self, inviteFailedWithError: response.error)
                 }
             }
@@ -255,7 +255,7 @@ extension ContactsPickerViewModel: ContactsTableViewControllerDelegate {
                     case .success:
                         self.coordinatorDelegate?.contactsPickerViewModelDidEndInvite(self)
                     case .failure:
-                        MXLog.error("[ContactsPickerViewModel] Failed to invite \(participantId) by email due to error; \(response.error ?? "nil")")
+                        MXLog.error("[ContactsPickerViewModel] Failed to invite participant by email", context: response.error)
                         
                         if let error = response.error as NSError?, error.domain == kMXRestClientErrorDomain, error.code == MXRestClientErrorMissingIdentityServer {
                             self.coordinatorDelegate?.contactsPickerViewModel(self, inviteFailedWithError: nil)
@@ -273,7 +273,7 @@ extension ContactsPickerViewModel: ContactsTableViewControllerDelegate {
                     case .success:
                         self.coordinatorDelegate?.contactsPickerViewModelDidEndInvite(self)
                     case .failure:
-                        MXLog.error("[ContactsPickerViewModel] Failed to invite \(participantId) due to error; \(response.error ?? "nil")")
+                        MXLog.error("[ContactsPickerViewModel] Failed to invite participant", context: response.error)
                         self.coordinatorDelegate?.contactsPickerViewModel(self, inviteFailedWithError: response.error)
                     }
                 }

--- a/Riot/Modules/Room/RoomCoordinator.swift
+++ b/Riot/Modules/Room/RoomCoordinator.swift
@@ -598,7 +598,9 @@ extension RoomCoordinator: RoomViewControllerDelegate {
     
     func threadsCoordinator(for roomViewController: RoomViewController, threadId: String?) -> ThreadsCoordinatorBridgePresenter? {
         guard let session = mxSession, let roomId = roomId else {
-            MXLog.error("[RoomCoordinator] Cannot create threads coordinator for room \(roomId ?? "")")
+            MXLog.error("[RoomCoordinator] Cannot create threads coordinator for room", context: [
+                "room_id": roomId
+            ])
             return nil
         }
         

--- a/Riot/Modules/Room/RoomViewController.swift
+++ b/Riot/Modules/Room/RoomViewController.swift
@@ -67,7 +67,9 @@ extension RoomViewController {
                     case .success:
                         break
                     case .failure:
-                        MXLog.error("[RoomViewController] sendAttributedTextMessage failed while updating event: \(eventModified.eventId ?? "N/A")")
+                        MXLog.error("[RoomViewController] sendAttributedTextMessage failed while updating event", context: [
+                            "event_id": eventModified.eventId
+                        ])
                     }
                 }
             } else if self.inputToolbar?.sendMode == .edit, let eventModified = eventModified {
@@ -78,7 +80,9 @@ extension RoomViewController {
                         //
                     },
                     failure: { _ in
-                        MXLog.error("[RoomViewController] sendAttributedTextMessage failed while updating event: \(eventModified.eventId ?? "N/A")")
+                        MXLog.error("[RoomViewController] sendAttributedTextMessage failed while updating event", context: [
+                            "event_id": eventModified.eventId
+                        ])
                 })
             } else {
                 roomDataSource.sendAttributedTextMessage(attributedTextMsg) { response in

--- a/Riot/Modules/Room/TimelineCells/LocationView/RoomTimelineLocationView.swift
+++ b/Riot/Modules/Room/TimelineCells/LocationView/RoomTimelineLocationView.swift
@@ -396,7 +396,7 @@ class RoomTimelineLocationView: UIView, NibLoadable, Themable, MGLMapViewDelegat
     
     func mapViewDidFailLoadingMap(_ mapView: MGLMapView, withError error: Error) {
         
-        MXLog.error("[RoomTimelineLocationView] Failed to load map with error: \(error)")
+        MXLog.error("[RoomTimelineLocationView] Failed to load map", context: error)
         
         self.isMapViewLoadingFailed = true
     }

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift
@@ -107,7 +107,7 @@ class VoiceMessageAttachmentCacheManager {
             try setupTemporaryFilesFolder()
         } catch {
             completion(Result.failure(VoiceMessageAttachmentCacheManagerError.preparationError(error)))
-            MXLog.error("[VoiceMessageAttachmentCacheManager] Failed creating temporary files folder with error: \(error)")
+            MXLog.error("[VoiceMessageAttachmentCacheManager] Failed creating temporary files folder", context: error)
             return
         }
         
@@ -140,7 +140,7 @@ class VoiceMessageAttachmentCacheManager {
         do {
             try FileManager.default.removeItem(at: temporaryFilesFolderURL)
         } catch {
-            MXLog.error("[VoiceMessageAttachmentCacheManager] Failed clearing cached disk files with error: \(error)")
+            MXLog.error("[VoiceMessageAttachmentCacheManager] Failed clearing cached disk files", context: error)
         }
     }
     
@@ -176,7 +176,7 @@ class VoiceMessageAttachmentCacheManager {
                 }, failure: { error in
                     // A nil error in this case is a cancellation on the MXMediaLoader
                     if let error = error {
-                        MXLog.error("[VoiceMessageAttachmentCacheManager] Failed decrypting attachment with error: \(String(describing: error))")
+                        MXLog.error("[VoiceMessageAttachmentCacheManager] Failed decrypting attachment", context: error)
                         self.invokeFailureCallbacksForIdentifier(identifier, requiredNumberOfSamples: numberOfSamples, error: VoiceMessageAttachmentCacheManagerError.decryptionError(error))
                     }
                     semaphore.signal()
@@ -189,7 +189,7 @@ class VoiceMessageAttachmentCacheManager {
                 }, failure: { error in
                     // A nil error in this case is a cancellation on the MXMediaLoader
                     if let error = error {
-                        MXLog.error("[VoiceMessageAttachmentCacheManager] Failed preparing attachment with error: \(String(describing: error))")
+                        MXLog.error("[VoiceMessageAttachmentCacheManager] Failed preparing attachment", context: error)
                         self.invokeFailureCallbacksForIdentifier(identifier, requiredNumberOfSamples: numberOfSamples, error: VoiceMessageAttachmentCacheManagerError.preparationError(error))
                     }
                     semaphore.signal()
@@ -232,14 +232,14 @@ class VoiceMessageAttachmentCacheManager {
                                     semaphore.signal()
                                 }
                             case .failure(let error):
-                                MXLog.error("[VoiceMessageAttachmentCacheManager] Failed retrieving audio duration with error: \(error)")
+                                MXLog.error("[VoiceMessageAttachmentCacheManager] Failed retrieving audio duration", context: error)
                                 self.invokeFailureCallbacksForIdentifier(identifier, requiredNumberOfSamples: numberOfSamples, error: VoiceMessageAttachmentCacheManagerError.durationError(error))
                                 semaphore.signal()
                             }
                         }
                     }
                 case .failure(let error):
-                    MXLog.error("[VoiceMessageAttachmentCacheManager] Failed converting voice message with error: \(error)")
+                    MXLog.error("[VoiceMessageAttachmentCacheManager] Failed converting voice message", context: error)
                     self.invokeFailureCallbacksForIdentifier(identifier, requiredNumberOfSamples: numberOfSamples, error: VoiceMessageAttachmentCacheManagerError.conversionError(error))
                     semaphore.signal()
                 }

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
@@ -308,7 +308,7 @@ public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, 
                     MXLog.error("[VoiceMessageController] Failed retrieving media duration")
                 }
             case .failure(let error):
-                MXLog.error("[VoiceMessageController] Failed getting audio duration with: \(error)")
+                MXLog.error("[VoiceMessageController] Failed getting audio duration", context: error)
             }
             
             dispatchGroup.leave()
@@ -336,7 +336,7 @@ public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, 
             case .success:
                 finalURL = destinationURL
             case .failure(let error):
-                MXLog.error("Failed failed encoding audio message with: \(error)")
+                MXLog.error("Failed failed encoding audio message", context: error)
             }
             
             dispatchGroup.leave()
@@ -371,7 +371,7 @@ public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, 
         do {
             try FileManager.default.removeItem(at: url)
         } catch {
-            MXLog.error(error)
+            MXLog.error("[VoiceMessageController] deleteRecordingAtURL:", context: error)
         }
     }
     

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessagePlaybackController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessagePlaybackController.swift
@@ -137,7 +137,7 @@ class VoiceMessagePlaybackController: VoiceMessageAudioPlayerDelegate, VoiceMess
     
     func audioPlayer(_ audioPlayer: VoiceMessageAudioPlayer, didFailWithError error: Error) {
         state = .error
-        MXLog.error("Failed playing voice message with error: \(error)")
+        MXLog.error("Failed playing voice message", context: error)
     }
     
     func audioPlayerDidFinishPlaying(_ audioPlayer: VoiceMessageAudioPlayer) {

--- a/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinator.swift
+++ b/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinator.swift
@@ -96,8 +96,7 @@ final class ServiceTermsModalCoordinator: NSObject, ServiceTermsModalCoordinator
         // Disable IS feature on user's account
         session.setIdentityServer(nil, andAccessToken: nil)
         session.setAccountDataIdentityServer(nil, success: nil) { error in
-            guard let errorDescription = error?.localizedDescription else { return }
-            MXLog.error("[ServiceTermsModalCoordinator] IS Terms: Error: \(errorDescription)")
+            MXLog.error("[ServiceTermsModalCoordinator] IS Terms", context: error)
         }
     }
 }

--- a/Riot/Modules/SideMenu/SideMenuCoordinator.swift
+++ b/Riot/Modules/SideMenu/SideMenuCoordinator.swift
@@ -320,7 +320,9 @@ final class SideMenuCoordinator: NSObject, SideMenuCoordinatorType {
     
     func showSpaceInvite(spaceId: String, session: MXSession) {
         guard let space = session.spaceService.getSpace(withId: spaceId), let spaceRoom = space.room else {
-            MXLog.error("[SideMenuCoordinator] showSpaceInvite: failed to find space with id \(spaceId)")
+            MXLog.error("[SideMenuCoordinator] showSpaceInvite: failed to find space", context: [
+                "space_id": spaceId
+            ])
             return
         }
         

--- a/Riot/Modules/Spaces/SpaceMembers/SpaceMembersCoordinator.swift
+++ b/Riot/Modules/Spaces/SpaceMembers/SpaceMembersCoordinator.swift
@@ -156,7 +156,9 @@ extension SpaceMembersCoordinator: SpaceMemberListCoordinatorDelegate {
     
     func spaceMemberListCoordinatorShowInvite(_ coordinator: SpaceMemberListCoordinatorType) {
         guard let space = parameters.session.spaceService.getSpace(withId: parameters.spaceId), let spaceRoom = space.room else {
-            MXLog.error("[SpaceMembersCoordinator] spaceMemberListCoordinatorShowInvite: failed to find space with id \(parameters.spaceId)")
+            MXLog.error("[SpaceMembersCoordinator] spaceMemberListCoordinatorShowInvite: failed to find space", context: [
+                "space_id": parameters.spaceId
+            ])
             return
         }
         

--- a/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
+++ b/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
@@ -148,7 +148,9 @@ extension SpaceMenuPresenter: SpaceMenuModelViewModelCoordinatorDelegate {
         case .leaveSpaceAndChooseRooms:
             self.showLeaveSpace()
         default:
-            MXLog.error("[SpaceMenuPresenter] spaceListViewModel didSelectItem: invalid action \(action)")
+            MXLog.error("[SpaceMenuPresenter] spaceListViewModel didSelectItem: invalid action", context: [
+                "action": action
+            ])
         }
     }
 }

--- a/Riot/Modules/Threads/ThreadList/ThreadListViewModel.swift
+++ b/Riot/Modules/Threads/ThreadList/ThreadListViewModel.swift
@@ -253,7 +253,7 @@ final class ThreadListViewModel: ThreadListViewModelProtocol {
                 self.threads = threads
                 self.threadsLoaded()
             case .failure(let error):
-                MXLog.error("[ThreadListViewModel] loadData: error: \(error)")
+                MXLog.error("[ThreadListViewModel] loadData", context: error)
                 self.viewState = .error(error)
             }
         }

--- a/Riot/Utils/DictionaryEncodable.swift
+++ b/Riot/Utils/DictionaryEncodable.swift
@@ -31,7 +31,9 @@ extension DictionaryEncodable {
         let object = try JSONSerialization.jsonObject(with: jsonData)
         
         guard let dictionary = object as? [String: Any] else {
-            MXLog.error("[DictionaryEncodable] Unexpected type decoded \(type(of: object)). Expected a Dictionary.")
+            MXLog.error("[DictionaryEncodable] Unexpected type decoded, expected a Dictionary.", context: [
+                "type": type(of: object)
+            ])
             throw DictionaryEncodableError.typeError
         }
         

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -105,7 +105,9 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
         // If we cannot create attributed string, but the message is nevertheless meant for display, show generic error
         // instead of a missing message on a timeline.
         if ([self shouldDisplayEvent:event]) {
-            MXLogError(@"[EventFormatter]: Missing attributed string for message event: %@", event.eventId);
+            MXLogErrorDetails(@"[EventFormatter]: Missing attributed string for message event", @{
+                @"event_id": event.eventId ?: @"unknown"
+            });
             string = [[NSAttributedString alloc] initWithString:[VectorL10n noticeErrorUnformattableEvent] attributes:@{
                 NSFontAttributeName: [self encryptedMessagesTextFont]
             }];

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -241,7 +241,7 @@ class NotificationService: UNNotificationServiceExtension {
                 MXLog.debug("[NotificationService] fetchAndProcessEvent: Event fetched successfully")
                 self?.checkPlaybackAndContinueProcessing(event, roomId: roomId)
             case .failure(let error):
-                MXLog.error("[NotificationService] fetchAndProcessEvent: Failed fetching notification event with error: \(error)")
+                MXLog.error("[NotificationService] fetchAndProcessEvent: Failed fetching notification event", context: error)
                 self?.fallbackToBestAttemptContent(forEventId: eventId)
             }
         }
@@ -265,7 +265,7 @@ class NotificationService: UNNotificationServiceExtension {
                 }
                 
             case .failure(let error):
-                MXLog.error("[NotificationService] checkPlaybackAndContinueProcessing: Failed fetching read marker event with error: \(error)")
+                MXLog.error("[NotificationService] checkPlaybackAndContinueProcessing: Failed fetching read marker event", context: error)
                 self?.processEvent(notificationEvent)
             }
         }
@@ -849,7 +849,7 @@ class NotificationService: UNNotificationServiceExtension {
             if response.isSuccess {
                 MXLog.debug("[NotificationService] sendReadReceipt: Read receipt send successfully.")
             } else if let error = response.error {
-                MXLog.error("[NotificationService] sendReadReceipt: Read receipt send failed with error \(error).")
+                MXLog.error("[NotificationService] sendReadReceipt: Read receipt send failed", context: error)
             }
         }
     }

--- a/RiotShareExtension/Sources/ShareItemSender.m
+++ b/RiotShareExtension/Sources/ShareItemSender.m
@@ -528,7 +528,9 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
         [room sendTextMessage:text threadId:nil success:^(NSString *eventId) {
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError *innerError) {
-            MXLogError(@"[ShareItemSender] sendTextMessage failed with error %@", error);
+            MXLogErrorDetails(@"[ShareItemSender] sendTextMessage failed with error", @{
+                @"error": error ?: @"unknown"
+            });
             error = innerError;
             dispatch_group_leave(dispatchGroup);
         }];
@@ -568,7 +570,9 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
         [room sendFile:fileUrl mimeType:mimeType threadId:nil localEcho:nil success:^(NSString *eventId) {
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError *innerError) {
-            MXLogError(@"[ShareItemSender] sendFile failed with error %@", innerError);
+            MXLogErrorDetails(@"[ShareItemSender] sendFile failed with error", @{
+                @"error": innerError ?: @"unknown"
+            });
             error = innerError;
             dispatch_group_leave(dispatchGroup);
         } keepActualFilename:YES];
@@ -619,7 +623,9 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
             [room sendVideoAsset:videoAsset withThumbnail:videoThumbnail threadId:nil localEcho:nil success:^(NSString *eventId) {
                 dispatch_group_leave(dispatchGroup);
             } failure:^(NSError *innerError) {
-                MXLogError(@"[ShareManager] Failed sending video with error %@", innerError);
+                MXLogErrorDetails(@"[ShareManager] Failed sending video with error", @{
+                    @"error": innerError ?: @"unknown"
+                });
                 error = innerError;
                 dispatch_group_leave(dispatchGroup);
             }];
@@ -705,7 +711,9 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
         [room sendVoiceMessage:fileUrl mimeType:nil duration:0.0 samples:nil threadId:nil localEcho:nil success:^(NSString *eventId) {
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError *innerError) {
-            MXLogError(@"[ShareItemSender] sendVoiceMessage failed with error %@", error);
+            MXLogErrorDetails(@"[ShareItemSender] sendVoiceMessage failed with error", @{
+                @"error": error ?: @"unknown"
+            });
             error = innerError;
             dispatch_group_leave(dispatchGroup);
         } keepActualFilename:YES];
@@ -870,7 +878,9 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
         [room sendImage:finalImageData withImageSize:imageSize mimeType:mimeType andThumbnail:thumbnail threadId:nil localEcho:nil success:^(NSString *eventId) {
             dispatch_group_leave(dispatchGroup);
         } failure:^(NSError *innerError) {
-            MXLogError(@"[ShareManager] sendImage failed with error %@", error);
+            MXLogErrorDetails(@"[ShareManager] sendImage failed with error", @{
+                @"error": error ?: @"unknown"
+            });
             error = innerError;
             dispatch_group_leave(dispatchGroup);
         }];

--- a/RiotSwiftUI/Modules/Common/Avatar/ViewModel/AvatarViewModel.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/ViewModel/AvatarViewModel.swift
@@ -54,7 +54,7 @@ class AvatarViewModel: InjectableObject, ObservableObject {
             avatarService.avatarImage(mxContentUri: mxContentUri, avatarSize: avatarSize)
             .sink { completion in
                 guard case let .failure(error) = completion else { return }
-                UILog.error("[AvatarService] Failed to retrieve avatar: \(error)")
+                UILog.error("[AvatarService] Failed to retrieve avatar", context: error)
             } receiveValue: { image in
                 self.viewState = .avatar(image)
             }

--- a/RiotSwiftUI/Modules/Common/Logging/LoggerProtocol.swift
+++ b/RiotSwiftUI/Modules/Common/Logging/LoggerProtocol.swift
@@ -22,5 +22,5 @@ protocol LoggerProtocol {
     static func debug(_ message: @autoclosure () -> Any, _ file: String, _ function: String, line: Int, context: Any?)
     static func info(_ message: @autoclosure () -> Any, _ file: String, _ function: String, line: Int, context: Any?)
     static func warning(_ message: @autoclosure () -> Any, _ file: String, _ function: String, line: Int, context: Any?)
-    static func error(_ message: @autoclosure () -> Any, _ file: String, _ function: String, line: Int, context: Any?)
+    static func error(_ message: @autoclosure () -> StaticString, _ file: String, _ function: String, line: Int, context: Any?)
 }

--- a/RiotSwiftUI/Modules/Common/Logging/PrintLogger.swift
+++ b/RiotSwiftUI/Modules/Common/Logging/PrintLogger.swift
@@ -32,7 +32,7 @@ class PrintLogger: LoggerProtocol {
     static func warning(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         print(message())
     }
-    static func error(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    static func error(_ message: @autoclosure () -> StaticString, _ file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
         print(message())
     }
 }

--- a/RiotSwiftUI/Modules/Common/Logging/UILog.swift
+++ b/RiotSwiftUI/Modules/Common/Logging/UILog.swift
@@ -63,7 +63,7 @@ class UILog: LoggerProtocol {
     }
     
     static func error(
-        _ message: @autoclosure () -> Any,
+        _ message: @autoclosure () -> StaticString,
         _ file: String = #file,
         _ function: String = #function,
         line: Int = #line,

--- a/RiotSwiftUI/Modules/LocationSharing/StartLocationSharing/Coordinator/LocationSharingCoordinator.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StartLocationSharing/Coordinator/LocationSharingCoordinator.swift
@@ -134,7 +134,7 @@ final class LocationSharingCoordinator: Coordinator, Presentable {
         } failure: { [weak self] error in
             guard let self = self else { return }
             
-            MXLog.error("[LocationSharingCoordinator] Failed sharing location with error: \(String(describing: error))")
+            MXLog.error("[LocationSharingCoordinator] Failed sharing location", context: error)
             self.locationSharingViewModel.stopLoading(error: .locationSharingError)
         }
     }
@@ -156,7 +156,7 @@ final class LocationSharingCoordinator: Coordinator, Presentable {
                     self.completion?()
                 }
             case .failure(let error):
-                MXLog.error("[LocationSharingCoordinator] Failed to start live location sharing with error: \(String(describing: error))")
+                MXLog.error("[LocationSharingCoordinator] Failed to start live location sharing", context: error)
                 
                 DispatchQueue.main.async {
                     self.locationSharingViewModel.stopLoading(error: .locationSharingError)

--- a/RiotSwiftUI/Modules/Room/PollEditForm/Coordinator/PollEditFormCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/PollEditForm/Coordinator/PollEditFormCoordinator.swift
@@ -83,7 +83,7 @@ final class PollEditFormCoordinator: Coordinator, Presentable {
                 } failure: { [weak self] error in
                     guard let self = self else { return }
                     
-                    MXLog.error("Failed creating poll with error: \(String(describing: error))")
+                    MXLog.error("Failed creating poll", context: error)
                     self.pollEditFormViewModel.stopLoading(errorAlertType: .failedCreatingPoll)
                 }
                 
@@ -111,7 +111,7 @@ final class PollEditFormCoordinator: Coordinator, Presentable {
                 } failure: { [weak self] error in
                     guard let self = self else { return }
                     
-                    MXLog.error("Failed updating poll with error: \(String(describing: error))")
+                    MXLog.error("Failed updating poll", context: error)
                     self.pollEditFormViewModel.stopLoading(errorAlertType: .failedUpdatingPoll)
                 }   
             }

--- a/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/MatrixSDK/RoomAccessTypeChooserService.swift
+++ b/RiotSwiftUI/Modules/Room/RoomAccess/RoomAccessTypeChooser/Service/MatrixSDK/RoomAccessTypeChooserService.swift
@@ -100,7 +100,9 @@ class RoomAccessTypeChooserService: RoomAccessTypeChooserServiceProtocol {
     
     func applySelection(completion: @escaping () -> Void) {
         guard let room = session.room(withRoomId: currentRoomId) else {
-            MXLog.error("[RoomAccessTypeChooserService] applySelection: room with ID \(currentRoomId) not found")
+            MXLog.error("[RoomAccessTypeChooserService] applySelection: room with ID not found", context: [
+                "room_id": currentRoomId
+            ])
             return
         }
         
@@ -164,7 +166,9 @@ class RoomAccessTypeChooserService: RoomAccessTypeChooserServiceProtocol {
     
     private func readRoomState() {
         guard let room = session.room(withRoomId: currentRoomId) else {
-            MXLog.error("[RoomAccessTypeChooserService] readRoomState: room with ID \(currentRoomId) not found")
+            MXLog.error("[RoomAccessTypeChooserService] readRoomState: room with ID not found", context: [
+                "room_id": currentRoomId
+            ])
             return
         }
         

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -72,7 +72,7 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
                                                       localEcho: nil, success: nil) { [weak self] error in
                     guard let self = self else { return }
                     
-                    MXLog.error("[TimelinePollCoordinator]] Failed submitting response with error \(String(describing: error))")
+                    MXLog.error("[TimelinePollCoordinator]] Failed submitting response", context: error)
                     
                     self.viewModel.showAnsweringFailure()
                 }

--- a/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/UserSuggestion/Coordinator/UserSuggestionCoordinator.swift
@@ -117,7 +117,7 @@ private class UserSuggestionCoordinatorRoomMemberProvider: RoomMembersProviderPr
             self.roomMembers = joinedMembers
             members(self.roomMembersToProviderMembers(joinedMembers))
         }, failure: { error in
-            MXLog.error("[UserSuggestionCoordinatorRoomMemberProvider] Failed loading room with error: \(String(describing: error))")
+            MXLog.error("[UserSuggestionCoordinatorRoomMemberProvider] Failed loading room", context: error)
         })
     }
     

--- a/RiotSwiftUI/Modules/Spaces/LeaveSpace/Service/MatrixSDK/LeaveSpaceItemsProcessor.swift
+++ b/RiotSwiftUI/Modules/Spaces/LeaveSpace/Service/MatrixSDK/LeaveSpaceItemsProcessor.swift
@@ -84,7 +84,7 @@ class LeaveSpaceItemsProcessor: MatrixItemChooserProcessorProtocol {
             case .success:
                 self.leaveAllRooms(from: roomIds, at: index+1, completion: completion)
             case .failure(let error):
-                MXLog.error("[LeaveSpaceItemsProcessor] failed to leave room with error: \(error)")
+                MXLog.error("[LeaveSpaceItemsProcessor] failed to leave room", context: error)
                 completion(.failure(error))
             }
         }
@@ -97,7 +97,7 @@ class LeaveSpaceItemsProcessor: MatrixItemChooserProcessorProtocol {
             case .success:
                 completion(.success(()))
             case .failure(let error):
-                MXLog.error("[LeaveSpaceItemsProcessor] failed to leave space with error: \(error)")
+                MXLog.error("[LeaveSpaceItemsProcessor] failed to leave space", context: error)
                 completion(.failure(error))
             }
         })

--- a/changelog.d/pr-6611.misc
+++ b/changelog.d/pr-6611.misc
@@ -1,0 +1,1 @@
+Analytics: Log all errors to analytics


### PR DESCRIPTION
Complement to https://github.com/matrix-org/matrix-ios-sdk/pull/1558

- track all `MXLogError` and `MXLogFailure` in Sentry
- reduce the sample rate of sentry from 100% to 10% as the volume is currently quite / sufficiently high