### PR TITLE
Render the PIN entry screen correctly on landscape

### DIFF
--- a/Riot/Modules/SetPinCode/SetPinCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/SetPinCode/SetPinCoordinatorBridgePresenter.swift
@@ -95,13 +95,8 @@ final class SetPinCoordinatorBridgePresenter: NSObject {
         
         let setPinCoordinator = SetPinCoordinator(session: self.session, viewMode: self.viewMode, pinCodePreferences: .shared)
         setPinCoordinator.delegate = self
-        guard let view = setPinCoordinator.toPresentable().view else { return }
-        pinCoordinatorWindow.addSubview(view)
-        view.leadingAnchor.constraint(equalTo: pinCoordinatorWindow.leadingAnchor, constant: 0).isActive = true
-        view.trailingAnchor.constraint(equalTo: pinCoordinatorWindow.trailingAnchor, constant: 0).isActive = true
-        view.topAnchor.constraint(equalTo: pinCoordinatorWindow.topAnchor, constant: 0).isActive = true
-        view.bottomAnchor.constraint(equalTo: pinCoordinatorWindow.bottomAnchor, constant: 0).isActive = true
         
+        pinCoordinatorWindow.rootViewController = setPinCoordinator.toPresentable()        
         pinCoordinatorWindow.makeKeyAndVisible()
         
         setPinCoordinator.start()

--- a/changelog.d/pr-6629.bugfix
+++ b/changelog.d/pr-6629.bugfix
@@ -1,0 +1,1 @@
+Render the PIN entry screen correctly on landscape


### PR DESCRIPTION
This PR fixes the PIN entry screen layout if the app is used in landscape mode. It will still force it to be rendered in portrait as per original code.