### PR TITLE
Self-verification flow in Crypto V2

### DIFF
--- a/changelog.d/6589.feature
+++ b/changelog.d/6589.feature
@@ -1,0 +1,1 @@
+CryptoV2: Self-verification flow


### PR DESCRIPTION
Resolves #6589 

[SDK changes](https://github.com/matrix-org/matrix-ios-sdk/pull/1565)

App delegate is relying on concrete implementations of verification requests. We need to change this to protocols instead for it to work with v2 requests sa well