### PR TITLE
Measure performance in Sentry

### DIFF
--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -338,6 +338,10 @@ extension Analytics: MXAnalyticsDelegate {
         capture(event: event)
     }
     
+    func startDurationTracking(forName name: String, operation: String) -> StopDurationTracking {
+        return monitoringClient.startPerformanceTracking(name: name, operation: operation)
+    }
+    
     func trackCallStarted(withVideo isVideo: Bool, numberOfParticipants: Int, incoming isIncoming: Bool) {
         let event = AnalyticsEvent.CallStarted(isVideo: isVideo, numParticipants: numberOfParticipants, placed: !isIncoming)
         capture(event: event)

--- a/Riot/Modules/Analytics/SentryMonitoringClient.swift
+++ b/Riot/Modules/Analytics/SentryMonitoringClient.swift
@@ -34,6 +34,7 @@ struct SentryMonitoringClient {
             options.dsn = Self.sentryDSN
             
             // Collecting only 10% of all events
+            options.sampleRate = 0.1
             options.tracesSampleRate = 0.1
             
             options.beforeSend = { event in
@@ -65,5 +66,12 @@ struct SentryMonitoringClient {
         event.message = .init(formatted: issue)
         event.extra = details
         SentrySDK.capture(event: event)
+    }
+    
+    func startPerformanceTracking(name: String, operation: String) -> StopDurationTracking {
+        let transaction = SentrySDK.startTransaction(name: name, operation: operation)
+        return {
+            transaction.finish()
+        }
     }
 }

--- a/changelog.d/pr-6647.change
+++ b/changelog.d/pr-6647.change
@@ -1,0 +1,1 @@
+Analytics: Measure performance in Sentry


### PR DESCRIPTION
Implement `startDurationTracking` of `MAnalyticsDelegate` and send performance events to Sentry