### PR TITLE
Slash command to manually discard outbound session

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKSlashCommands.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKSlashCommands.h
@@ -31,3 +31,4 @@ FOUNDATION_EXPORT NSString *const kMXKSlashCmdUnbanUser;
 FOUNDATION_EXPORT NSString *const kMXKSlashCmdSetUserPowerLevel;
 FOUNDATION_EXPORT NSString *const kMXKSlashCmdResetUserPowerLevel;
 FOUNDATION_EXPORT NSString *const kMXKSlashCmdChangeRoomTopic;
+FOUNDATION_EXPORT NSString *const kMXKSlashCmdDiscardSession;

--- a/Riot/Modules/MatrixKit/Models/Room/MXKSlashCommands.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKSlashCommands.m
@@ -27,3 +27,4 @@ NSString *const kMXKSlashCmdUnbanUser = @"/unban";
 NSString *const kMXKSlashCmdSetUserPowerLevel = @"/op";
 NSString *const kMXKSlashCmdResetUserPowerLevel = @"/deop";
 NSString *const kMXKSlashCmdChangeRoomTopic = @"/topic";
+NSString *const kMXKSlashCmdDiscardSession = @"/discardsession";

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -1438,6 +1438,12 @@
             cmdUsage = @"Usage: /topic <topic>";
         }
     }
+    else if ([string hasPrefix:kMXKSlashCmdDiscardSession])
+    {
+        [roomDataSource.mxSession.crypto discardOutboundGroupSessionForRoomWithRoomId:roomDataSource.roomId onComplete:^{
+            MXLogDebug(@"[MXKRoomVC] Manually discarded outbound group session");
+        }];
+    }
     else
     {
         // Retrieve userId

--- a/changelog.d/pr-6668.change
+++ b/changelog.d/pr-6668.change
@@ -1,0 +1,1 @@
+Crypto: Slash command to discard outbound session


### PR DESCRIPTION
This is equivalent to the `/discardsession` command used in the web client