### PR TITLE
Fix mention pills display when coming back to a room with an unsent message

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -161,11 +161,6 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
 @property (nonatomic, readonly) NSInteger serverSyncEventCount;
 
 /**
- The current text message partially typed in text input (use nil to reset it).
- */
-@property (nonatomic) NSString *partialTextMessage;
-
-/**
  The current attributed text message partially typed in text input (use nil to reset it).
  */
 @property (nonatomic) NSAttributedString *partialAttributedTextMessage;

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -919,16 +919,6 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     return attachments;
 }
 
-- (NSString *)partialTextMessage
-{
-    return _room.partialTextMessage;
-}
-
-- (void)setPartialTextMessage:(NSString *)partialTextMessage
-{
-    _room.partialTextMessage = partialTextMessage;
-}
-
 - (NSAttributedString *)partialAttributedTextMessage
 {
     return _room.partialAttributedTextMessage;

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -358,7 +358,7 @@
     {
         // Retrieve the potential message partially typed during last room display.
         // Note: We have to wait for viewDidAppear before updating growingTextView (viewWillAppear is too early)
-        inputToolbarView.textMessage = roomDataSource.partialTextMessage;
+        inputToolbarView.attributedTextMessage = roomDataSource.partialAttributedTextMessage;
     }
     
     if (!hasAppearedOnce)
@@ -3351,7 +3351,7 @@
     if (_saveProgressTextInput && roomDataSource)
     {
         // Store the potential message partially typed in text input
-        roomDataSource.partialTextMessage = inputToolbarView.textMessage;
+        roomDataSource.partialAttributedTextMessage = inputToolbarView.attributedTextMessage;
     }
     
     [self handleTypingState:typing];

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5669,7 +5669,7 @@ static CGSize kThreadListBarButtonItemImageSize;
             if (self.saveProgressTextInput)
             {
                 // Restore the potential message partially typed before jump to last unread messages.
-                self.inputToolbarView.textMessage = roomDataSource.partialTextMessage;
+                self.inputToolbarView.attributedTextMessage = roomDataSource.partialAttributedTextMessage;
             }
         };
 

--- a/changelog.d/6670.bugfix
+++ b/changelog.d/6670.bugfix
@@ -1,0 +1,1 @@
+Fix mention pills display when coming back to a room with an unsent message


### PR DESCRIPTION
Fixes #6670 

Remove partialTextMessage on Matrix SDK: https://github.com/matrix-org/matrix-ios-sdk/pull/1571