### PR TITLE
Fix timeline items text height calculation

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -534,7 +534,7 @@
     CGFloat horizontalInset = measurementTextView.textContainer.lineFragmentPadding * 2;
     
     CGSize size = [attributedText boundingRectWithSize:CGSizeMake(_maxTextViewWidth - horizontalInset, CGFLOAT_MAX)
-                                               options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
+                                               options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading | NSStringDrawingUsesDeviceMetrics
                                                context:nil].size;
     
     //In iOS 7 and later, this method returns fractional sizes (in the size component of the returned rectangle);

--- a/changelog.d/pr-6702.bugfix
+++ b/changelog.d/pr-6702.bugfix
@@ -1,0 +1,1 @@
+Fix timeline items text height calculation


### PR DESCRIPTION
![0A4CC072-FB26-4232-B927-62C67FA30B91](https://user-images.githubusercontent.com/637564/189511838-64545833-65e2-43dc-a8f4-0ab184931712.jpeg)

vs.

![734D3764-7D99-4AD8-83F3-439CF86BF3DE](https://user-images.githubusercontent.com/637564/189511840-5c7775fd-279e-42dd-97d6-61e5e6c17481.jpeg)
