### PR TITLE
Dismiss the launching screen when clearing cache.

### DIFF
--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -208,7 +208,22 @@ class AllChatsViewController: HomeViewController {
     
     override func addMatrixSession(_ mxSession: MXSession!) {
         super.addMatrixSession(mxSession)
-        initDataSource()
+        
+        if let dataSource = dataSource, !dataSource.mxSessions.contains(where: { $0 as? MXSession == mxSession }) {
+            dataSource.addMatrixSession(mxSession)
+            // Setting the delegate is required to send a RecentsViewControllerDataReadyNotification.
+            // Without this, when clearing the cache we end up with an infinite green spinner.
+            (dataSource as? RecentsDataSource)?.setDelegate(self, andRecentsDataSourceMode: recentsDataSourceMode)
+        } else {
+            initDataSource()
+        }
+    }
+    
+    override func removeMatrixSession(_ mxSession: MXSession!) {
+        super.removeMatrixSession(mxSession)
+        
+        guard let dataSource = dataSource else { return }
+        dataSource.removeMatrixSession(mxSession)
     }
     
     private func initDataSource() {

--- a/changelog.d/6709.bugfix
+++ b/changelog.d/6709.bugfix
@@ -1,0 +1,1 @@
+New App Layout: Make sure the green loading spinner is dismissed after clearing the cache.


### PR DESCRIPTION
When clearing the cache with the new app layout, the launch screen spinner was never hidden. `addMatrixSession`/`removeMatrixSession` had some extra logic in the master tab bar controller that was no longer being called. This PR adds it back.

It's not possible to set the `dataSource` to `nil` when no sessions are present as [done in the tab bar](https://github.com/vector-im/element-ios/blob/a12ef0118d5968e60e15214a69ac98bb17e7f03a/Riot/Modules/TabBar/MasterTabBarController.m#L437-L438), but this doesn't seem to cause an issue here.

<del>I wonder if this could be related to #6705 as well.</del> Nope I just read that one properly 🤦‍♂️

Fixes #6709 