### PR TITLE
Fix Crash when some opus files are added to a room

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/vector-im/swift-ogg",
       "state" : {
         "branch" : "main",
-        "revision" : "0ffad3f7b45a6a4760db090d503b00f094bbecc0"
+        "revision" : "e9a9e7601da662fd8b97d93781ff5c60b4becf88"
       }
     }
   ],

--- a/changelog.d/6584.bugfix
+++ b/changelog.d/6584.bugfix
@@ -1,0 +1,1 @@
+Fix crash when some opus audio files are added to a room.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/6584