### PR TITLE
Fix crash on logout when syncing is currently in progress

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2162,6 +2162,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 - (void)logoutSendingRequestServer:(BOOL)sendLogoutServerRequest
                         completion:(void (^)(BOOL isLoggedOut))completion
 {
+    MXSession *mainSession = self.mxSessions.firstObject;
+    [mainSession close];
+
     [self.pushNotificationService deregisterRemoteNotifications];
 
     // Clear cache
@@ -4360,8 +4363,14 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 {
     if (dueToTooManyErrors)
     {
-        [self showAlertWithTitle:nil message:[VectorL10n pinProtectionKickUserAlertMessage]];
-        [self logoutWithConfirmation:NO completion:nil];
+        [coordinatorBridgePresenter dismissWithMainAppWindow:self.window];
+        self.setPinCoordinatorBridgePresenter = nil;
+        [self logoutWithConfirmation:NO completion:^(BOOL isLoggedOut) {
+            if (isLoggedOut)
+            {
+                [self showAlertWithTitle:nil message:[VectorL10n pinProtectionKickUserAlertMessage]];
+            }
+        }];
     }
     else
     {

--- a/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
+++ b/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
@@ -638,6 +638,14 @@ public class RecentsListService: NSObject, RecentsListServiceProtocol {
         guard let session = session else {
             return
         }
+        guard session.state != .closed else {
+            MXLog.debug("[RecentsListService] createFetchers cancelled on closed session")
+            return
+        }
+        guard session.roomListDataManager != nil else {
+            MXLog.debug("[RecentsListService] createFetchers cancelled on race condition (session closing in progress)")
+            return
+        }
         guard session.isEventStreamInitialised else {
             return
         }

--- a/changelog.d/6705.bugfix
+++ b/changelog.d/6705.bugfix
@@ -1,0 +1,1 @@
+Fix crash on logout when syncing is currently in progress

--- a/changelog.d/6724.bugfix
+++ b/changelog.d/6724.bugfix
@@ -1,1 +1,0 @@
-Fix crash on logout from too much wrong pin codes

--- a/changelog.d/6724.bugfix
+++ b/changelog.d/6724.bugfix
@@ -1,0 +1,1 @@
+Fix crash on logout from too much wrong pin codes


### PR DESCRIPTION
Fixes #6705 #6724 

* Updates the tooManyErrors popup display that wasn't showing up over the pin code screen and was blocking the app from returning to the Onboarding/Login screen. It is now displayed right after the logout over the Onboarding/Login screen.
* Closes the session immediately when a logout is triggered.
* Updates the RecentsListService to avoid trying to setup fetchers when session is closed or currently closing (fix for the race condition is not optimal, perhaps a MXSessionStateClosing transition state would be better, but it probably would imply some impactful changes across MatrixSDK & the app).