### PR TITLE
Pass country code into MSISDN requests

### DIFF
--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -3702,11 +3702,13 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         msisdn = [NSString stringWithFormat:@"+%@", [e164 substringFromIndex:2]];
     }
     
+    NSString *countryCode = newPhoneNumberCell.isoCountryCode;
+
     [self showAuthenticationIfNeededForAdding:kMX3PIDMediumMSISDN withSession:session completion:^(NSDictionary *authParams) {
         [self startActivityIndicator];
 
         __block MX3PidAddSession *new3Pid;
-        new3Pid = [session.threePidAddManager startAddPhoneNumberSessionWithPhoneNumber:msisdn countryCode:nil success:^{
+        new3Pid = [session.threePidAddManager startAddPhoneNumberSessionWithPhoneNumber:msisdn countryCode:countryCode success:^{
 
             [self showValidationMsisdnDialogWithMessage:[VectorL10n accountMsisdnValidationMessage] for3PidAddSession:new3Pid threePidAddManager:session.threePidAddManager authenticationParameters:authParams];
 

--- a/changelog.d/6723.bugfix
+++ b/changelog.d/6723.bugfix
@@ -1,0 +1,1 @@
+Pass country code into MSISDN requests


### PR DESCRIPTION
Fixes #6723

Unfortunately, this still leaves the user on what looks like a rate limiting error. Element Web has the same issue so this appears to be a separate problem.

![simulator_screenshot_E1C1C4E3-532E-46B5-A57A-498D44AB64ED](https://user-images.githubusercontent.com/1137962/190480933-fa5632c5-7349-4b2a-8307-b5dab04baec9.png)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
