### PR TITLE
Fix login crash on Xcode 14 builds

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
@@ -51,7 +51,7 @@ class LoginWizard {
     ///   - deviceID: The device ID, optional. If not provided or nil, the server will generate one.
     ///   - removeOtherAccounts: If set to true, existing accounts with different user identifiers will be removed.
     /// - Returns: An `MXSession` if the login is successful.
-    @MainActor func login(login: String,
+    func login(login: String,
                password: String,
                initialDeviceName: String,
                deviceID: String? = nil,
@@ -78,9 +78,9 @@ class LoginWizard {
         }
         
         let credentials = try await client.login(parameters: parameters)
-        return sessionCreator.createSession(credentials: credentials,
-                                            client: client,
-                                            removeOtherAccounts: removeOtherAccounts)
+        return await sessionCreator.createSession(credentials: credentials,
+                                                  client: client,
+                                                  removeOtherAccounts: removeOtherAccounts)
     }
 
     /// Exchange a login token to an access token.
@@ -91,9 +91,9 @@ class LoginWizard {
     func login(with token: String, removeOtherAccounts: Bool = false) async throws -> MXSession {
         let parameters = LoginTokenParameters(token: token)
         let credentials = try await client.login(parameters: parameters)
-        return sessionCreator.createSession(credentials: credentials,
-                                            client: client,
-                                            removeOtherAccounts: removeOtherAccounts)
+        return await sessionCreator.createSession(credentials: credentials,
+                                                  client: client,
+                                                  removeOtherAccounts: removeOtherAccounts)
     }
 
     /// Ask the homeserver to reset the user password. The password will not be

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginWizard.swift
@@ -51,7 +51,7 @@ class LoginWizard {
     ///   - deviceID: The device ID, optional. If not provided or nil, the server will generate one.
     ///   - removeOtherAccounts: If set to true, existing accounts with different user identifiers will be removed.
     /// - Returns: An `MXSession` if the login is successful.
-    func login(login: String,
+    @MainActor func login(login: String,
                password: String,
                initialDeviceName: String,
                deviceID: String? = nil,

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/RegistrationWizard.swift
@@ -255,7 +255,7 @@ class RegistrationWizard {
         do {
             let response = try await client.register(parameters: parameters)
             let credentials = MXCredentials(loginResponse: response, andDefaultCredentials: client.credentials)
-            return .success(sessionCreator.createSession(credentials: credentials, client: client, removeOtherAccounts: false))
+            return await .success(sessionCreator.createSession(credentials: credentials, client: client, removeOtherAccounts: false))
         } catch {
             let nsError = error as NSError
             

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/SessionCreator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/SessionCreator.swift
@@ -23,6 +23,7 @@ protocol SessionCreatorProtocol {
     ///   - client: The client that completed the authentication.
     ///   - removeOtherAccounts: Flag to remove other accounts than the account specified with the `credentials.userId`.
     /// - Returns: A new `MXSession` for the account.
+    @MainActor
     func createSession(credentials: MXCredentials, client: AuthenticationRestClient, removeOtherAccounts: Bool) -> MXSession
 }
 
@@ -35,6 +36,7 @@ struct SessionCreator: SessionCreatorProtocol {
         self.accountManager = accountManager
     }
 
+    @MainActor
     func createSession(credentials: MXCredentials, client: AuthenticationRestClient, removeOtherAccounts: Bool) -> MXSession {
         // Use identity server provided in the client
         if credentials.identityServer == nil {

--- a/RiotTests/Modules/Authentication/Mocks/MockSessionCreator.swift
+++ b/RiotTests/Modules/Authentication/Mocks/MockSessionCreator.swift
@@ -20,6 +20,7 @@ import Foundation
 
 struct MockSessionCreator: SessionCreatorProtocol {
     /// Returns a basic session created from the supplied credentials. This prevents the app from setting up the account during tests.
+    @MainActor
     func createSession(credentials: MXCredentials, client: AuthenticationRestClient, removeOtherAccounts: Bool) -> MXSession {
         let client = MXRestClient(credentials: credentials,
                                   unauthenticatedHandler: { _,_,_,_ in }) // The handler is expected if credentials are set.

--- a/RiotTests/SessionCreatorTests.swift
+++ b/RiotTests/SessionCreatorTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 class SessionCreatorTests: XCTestCase {
 
-    func testIdentityServer() throws {
+    func testIdentityServer() async throws {
         let sessionCreator = SessionCreator(withAccountManager: .mock)
 
         let mockIS = "mock_identity_server"
@@ -29,7 +29,7 @@ class SessionCreatorTests: XCTestCase {
                                         accessToken: "mock_access_token")
         let client = MXRestClient(credentials: credentials)
         client.identityServer = mockIS
-        let session = sessionCreator.createSession(credentials: credentials, client: client, removeOtherAccounts: false)
+        let session = await sessionCreator.createSession(credentials: credentials, client: client, removeOtherAccounts: false)
         
         XCTAssertEqual(credentials.identityServer, mockIS)
         XCTAssertEqual(session.credentials.identityServer, mockIS)

--- a/changelog.d/6722.bugfix
+++ b/changelog.d/6722.bugfix
@@ -1,0 +1,1 @@
+Fix login crash on Xcode 14 builds


### PR DESCRIPTION
Fixes #6722

To be honest, I'm not sure if this is a Swift bug or not but the additional `@MainActor` appears to force the `await`ed call onto the main thread which prevents the assertion.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
