### PR TITLE
Only disable the composer if the room is yet to be created.

### DIFF
--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -187,7 +187,7 @@ public class VectorL10n: NSObject {
   public static var allChatsEmptySpaceInformation: String { 
     return VectorL10n.tr("Vector", "all_chats_empty_space_information") 
   }
-  /// This is where you're unread messages will show up, when you have some.
+  /// This is where your unread messages will show up, when you have some.
   public static var allChatsEmptyUnreadsPlaceholderMessage: String { 
     return VectorL10n.tr("Vector", "all_chats_empty_unreads_placeholder_message") 
   }

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1544,10 +1544,6 @@ static CGSize kThreadListBarButtonItemImageSize;
  */
 - (void)createDiscussionIfNeeded:(void (^)(BOOL readyToSend))onComplete
 {
-    // Disable the input tool bar during this operation. This prevents us from creating several discussions, or
-    // trying to send several invites.
-    self.inputToolbarView.userInteractionEnabled = false;
-    
     void(^completion)(BOOL) = ^(BOOL readyToSend) {
         self.inputToolbarView.userInteractionEnabled = true;
         if (onComplete) {
@@ -1557,6 +1553,10 @@ static CGSize kThreadListBarButtonItemImageSize;
     
     if (self.directChatTargetUser)
     {
+        // Disable the input tool bar during this operation. This prevents us from creating several discussions, or
+        // trying to send several invites.
+        self.inputToolbarView.userInteractionEnabled = false;
+        
         [self createDiscussionWithUser:self.directChatTargetUser completion:completion];
     }
     else

--- a/changelog.d/6708.bugfix
+++ b/changelog.d/6708.bugfix
@@ -1,0 +1,1 @@
+Message Composer: Stop the keyboard jumping after sending a message on certain devices.


### PR DESCRIPTION
Fixes #6708 as the composer was being disabled and then immediately re-enabled. Didn't figure out why this was only visible on some devices, but the fix was to not disable the composer in an existing room.

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/6060466/190711837-e4825143-f3c9-4afa-92ed-be9367344308.gif) | ![After](https://user-images.githubusercontent.com/6060466/190711839-202f8cf7-2b4e-4eaa-b530-5c1952b97763.gif) |
