### PR TITLE
Fixed failed to join room (was not legal room)

### DIFF
--- a/Riot/Modules/DeepLink/MXRoomAliasResolution+Deeplink.swift
+++ b/Riot/Modules/DeepLink/MXRoomAliasResolution+Deeplink.swift
@@ -29,9 +29,7 @@ import MatrixSDK
             return nil
         }
         
-        return MXTools.encodeURIComponent(
-            fragment(for: roomId)
-        )
+        return fragment(for: roomId)
     }
     
     private func fragment(for roomId: String) -> String {

--- a/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
+++ b/RiotTests/Modules/DeepLink/MXRoomAliasResolutionDeeplinkTests.swift
@@ -28,7 +28,7 @@ class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
         let resolution = MXRoomAliasResolution()
         resolution.roomId = "!abc:matrix.org"
         
-        XCTAssertEqual(resolution.deeplinkFragment, "!abc%3Amatrix.org")
+        XCTAssertEqual(resolution.deeplinkFragment, "!abc:matrix.org")
     }
     
     func test_fragmentContainsSingleServer() {
@@ -38,7 +38,7 @@ class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
             "matrix.org"
         ]
         
-        XCTAssertEqual(resolution.deeplinkFragment, "xyz%3Aelement.io%3Fvia%3Dmatrix.org")
+        XCTAssertEqual(resolution.deeplinkFragment, "xyz:element.io?via=matrix.org")
     }
     
     func test_fragmentContainsMultipleSerivers() {
@@ -51,6 +51,6 @@ class MXRoomAliasResolutionDeeplinkTests: XCTestCase {
             "matrix.org"
         ]
         
-        XCTAssertEqual(resolution.deeplinkFragment, "mno%3Aserver.com%3Fvia%3Dserver.com%26via%3Delement.io%26via%3Dwikipedia.org%26via%3Dmatrix.org")
+        XCTAssertEqual(resolution.deeplinkFragment, "mno:server.com?via=server.com&via=element.io&via=wikipedia.org&via=matrix.org")
     }
 }

--- a/changelog.d/6653.bugfix
+++ b/changelog.d/6653.bugfix
@@ -1,0 +1,1 @@
+Fixed failed to join room (was not legal room)


### PR DESCRIPTION
resolves #6653 

I don't get why `stringByAddingPercentEncodingWithAllowedCharacters` is applied to the result as per the comment of this member https://github.com/matrix-org/matrix-spec-proposals/blob/old_master/proposals/1704-matrix.to-permalinks.md is not intended.

Also this breaks the only caller `LegacyAppDelegate.handleUniversalLinkWithParameters()`.