### PR TITLE
Fix render of links with both characters requiring percent encoding and markdown-like syntax

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MarkdownToHTMLRenderer.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MarkdownToHTMLRenderer.swift
@@ -166,10 +166,11 @@ private extension CMarkNode {
 private extension String {
     /// Returns array of URLs detected inside the String.
     var containedUrls: [NSTextCheckingResult] {
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue),
+              let percentEncoded = self.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
             return []
         }
 
-        return detector.matches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count))
+        return detector.matches(in: percentEncoded, options: [], range: NSRange(location: 0, length: percentEncoded.utf16.count))
     }
 }

--- a/RiotTests/MarkdownToHTMLRendererTests.swift
+++ b/RiotTests/MarkdownToHTMLRendererTests.swift
@@ -112,6 +112,20 @@ final class MarkdownToHTMLRendererTests: XCTestCase {
         testRenderHTML(input: input, expectedOutput: expectedOutput)
     }
 
+    func testRenderRepairedLinksWithCharactersRequiringPercentEncoding() {
+        let input = "Some link with special characters: "
+        + "https://matrix.to/#/#_oftc_#matrix-dev:matrix.org"
+        + " "
+        + "https://matrix.to/#/#?=+-_#_"
+        + "\n"
+        let expectedOutput = "<p>Some link with special characters: "
+        + "https://matrix.to/#/#_oftc_#matrix-dev:matrix.org"
+        + " "
+        + "https://matrix.to/#/#?=+-_#_</p>"
+        + "\n"
+        testRenderHTML(input: input, expectedOutput: expectedOutput)
+    }
+
     /// Test links inside codeblocks.
     func testRenderLinksInCodeblock() {
         let input = "```"

--- a/changelog.d/6748.bugfix
+++ b/changelog.d/6748.bugfix
@@ -1,0 +1,1 @@
+Fix render of links with both characters requiring percent encoding and markdown-like syntax


### PR DESCRIPTION
Fixes #6748 