### PR TITLE
Fix verification check

### DIFF
--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewModel.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewModel.swift
@@ -172,8 +172,9 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
             
                 // Remove pending QR code transaction, as we are going to use SAS verification
                 self.removePendingQRCodeTransaction()
-            
-                if keyVerificationTransaction is MXSASTransaction == false || keyVerificationTransaction.isIncoming {
+
+                // Check due to legacy implementation of key verification which could pass incorrect type of transaction
+                if keyVerificationTransaction is MXIncomingSASTransaction {
                     MXLog.debug("[KeyVerificationVerifyByScanningViewModel] SAS transaction should be outgoing")
                     self.unregisterTransactionDidStateChangeNotification()
                     self.update(viewState: .error(KeyVerificationVerifyByScanningViewModelError.unknown))


### PR DESCRIPTION
A small fix for cross-signing that checks the type of key verification transaction. Crypto V1 has some legacy issue where this check is needed, whereas Crypto V2 does not, so changing the code to only apply to the legacy types