### PR TITLE
Manual device verification with Crypto V2

### DIFF
--- a/Riot/Modules/KeyVerification/User/UserVerificationCoordinator.swift
+++ b/Riot/Modules/KeyVerification/User/UserVerificationCoordinator.swift
@@ -209,6 +209,7 @@ extension UserVerificationCoordinator: KeyVerificationManuallyVerifyCoordinatorD
         self.presenter.toPresentable().dismiss(animated: true) {
             self.remove(childCoordinator: coordinator)
         }
+        delegate?.userVerificationCoordinatorDidComplete(self)
     }
     
     func keyVerificationManuallyVerifyCoordinatorDidCancel(_ coordinator: KeyVerificationManuallyVerifyCoordinatorType) {

--- a/Riot/Modules/KeyVerification/User/UserVerificationCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/KeyVerification/User/UserVerificationCoordinatorBridgePresenter.swift
@@ -77,8 +77,14 @@ final class UserVerificationCoordinatorBridgePresenter: NSObject {
         } else {
             userVerificationCoordinator = UserVerificationCoordinator(presenter: self.presenter, session: self.session, userId: self.userId, userDisplayName: self.userDisplayName)
         }
-        
+        userVerificationCoordinator.delegate = self
         userVerificationCoordinator.start()
         self.coordinator = userVerificationCoordinator
+    }
+}
+
+extension UserVerificationCoordinatorBridgePresenter: UserVerificationCoordinatorDelegate {
+    func userVerificationCoordinatorDidComplete(_ coordinator: UserVerificationCoordinatorType) {
+        delegate?.userVerificationCoordinatorBridgePresenterDelegateDidComplete(self)
     }
 }

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -32,7 +32,7 @@
 #define TABLEVIEW_ROW_CELL_HEIGHT         46
 #define TABLEVIEW_SECTION_HEADER_HEIGHT   28
 
-@interface RoomMemberDetailsViewController () <UIGestureRecognizerDelegate, DeviceTableViewCellDelegate, RoomMemberTitleViewDelegate, KeyVerificationCoordinatorBridgePresenterDelegate>
+@interface RoomMemberDetailsViewController () <UIGestureRecognizerDelegate, DeviceTableViewCellDelegate, RoomMemberTitleViewDelegate, KeyVerificationCoordinatorBridgePresenterDelegate, UserVerificationCoordinatorBridgePresenterDelegate>
 {
     RoomMemberTitleView* memberTitleView;
     
@@ -449,6 +449,7 @@
                                                                                                                                                            session:self.mxRoom.mxSession
                                                                                                                                                             userId:self.mxRoomMember.userId
                                                                                                                                                    userDisplayName:self.mxRoomMember.displayname];
+    userVerificationCoordinatorBridgePresenter.delegate = self;
     [userVerificationCoordinatorBridgePresenter start];
     self.userVerificationCoordinatorBridgePresenter = userVerificationCoordinatorBridgePresenter;
 }
@@ -1343,6 +1344,13 @@
 {
     [keyVerificationCoordinatorBridgePresenter dismissWithAnimated:YES completion:nil];
     keyVerificationCoordinatorBridgePresenter = nil;
+}
+
+#pragma mark - UserVerificationCoordinatorBridgePresenterDelegate
+
+- (void)userVerificationCoordinatorBridgePresenterDelegateDidComplete:(UserVerificationCoordinatorBridgePresenter *)coordinatorBridgePresenter
+{
+    [self refreshUserEncryptionTrustLevel];
 }
 
 @end

--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -45,7 +45,7 @@ enum {
 };
 
 
-@interface ManageSessionViewController ()
+@interface ManageSessionViewController () <UserVerificationCoordinatorBridgePresenterDelegate>
 {
     // The device to display
     MXDevice *device;
@@ -649,6 +649,7 @@ enum {
                                                                                                                                                             userId:self.mainSession.myUser.userId
                                                                                                                                                    userDisplayName:nil
                                                                                                                                                           deviceId:device.deviceId];
+    userVerificationCoordinatorBridgePresenter.delegate = self;
     [userVerificationCoordinatorBridgePresenter start];
     self.userVerificationCoordinatorBridgePresenter = userVerificationCoordinatorBridgePresenter;
 }
@@ -699,6 +700,13 @@ enum {
     }];
     
     self.reauthenticationCoordinatorBridgePresenter = reauthenticationPresenter;
+}
+
+#pragma mark - UserVerificationCoordinatorBridgePresenterDelegate
+
+- (void)userVerificationCoordinatorBridgePresenterDelegateDidComplete:(UserVerificationCoordinatorBridgePresenter *)coordinatorBridgePresenter
+{
+    [self reloadDeviceWithCompletion:^{}];
 }
 
 @end

--- a/changelog.d/6781.change
+++ b/changelog.d/6781.change
@@ -1,0 +1,1 @@
+CryptoV2: Manual device verification


### PR DESCRIPTION
Relates to https://github.com/vector-im/element-ios/issues/6781

Small changes to refresh a view controller when manual device verification is complete. The relevant delegate methods existed previously but delegates were never set and called.