### PR TITLE
Fix navigation bars inside of VectorHostingController.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Fix crash when scrolling chat list ([#6749](https://github.com/vector-im/element-ios/issues/6749))
 - App Layout: Unable to send message after filtering for room ([#6755](https://github.com/vector-im/element-ios/issues/6755))
 - Fix code block background colour ([#6778](https://github.com/vector-im/element-ios/issues/6778))
+- Fix navigation bars visibility on iOS 16. ([#6799](https://github.com/vector-im/element-ios/pull/6799))
 
 🧱 Build
 

--- a/Riot/Modules/Common/SwiftUI/VectorHostingController.swift
+++ b/Riot/Modules/Common/SwiftUI/VectorHostingController.swift
@@ -73,14 +73,6 @@ class VectorHostingController: UIHostingController<AnyView> {
         bottomSheetPreferences?.setup(viewController: self)
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        if isNavigationBarHidden {
-            self.navigationController?.isNavigationBarHidden = true
-        }
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -90,6 +82,14 @@ class VectorHostingController: UIHostingController<AnyView> {
         
         if navigationController?.isNavigationBarHidden ?? false {
             navigationController?.interactivePopGestureRecognizer?.delegate = nil
+        }
+    }
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        
+        if let navigationController = navigationController, navigationController.isNavigationBarHidden != isNavigationBarHidden {
+            navigationController.isNavigationBarHidden = isNavigationBarHidden
         }
     }
     

--- a/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
+++ b/RiotSwiftUI/Modules/AnalyticsPrompt/Coordinator/AnalyticsPromptCoordinator.swift
@@ -27,7 +27,7 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
     // MARK: Private
     
     private let parameters: AnalyticsPromptCoordinatorParameters
-    private let analyticsPromptHostingController: UIViewController
+    private let analyticsPromptHostingController: VectorHostingController
     private var _analyticsPromptViewModel: Any?
     
     fileprivate var analyticsPromptViewModel: AnalyticsPromptViewModel {
@@ -59,6 +59,7 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
         let view = AnalyticsPrompt(viewModel: viewModel.context)
         _analyticsPromptViewModel = viewModel
         analyticsPromptHostingController = VectorHostingController(rootView: view)
+        analyticsPromptHostingController.isNavigationBarHidden = true
     }
     
     // MARK: - Public

--- a/RiotSwiftUI/Modules/Onboarding/Celebration/Coordinator/OnboardingCelebrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Celebration/Coordinator/OnboardingCelebrationCoordinator.swift
@@ -45,6 +45,7 @@ final class OnboardingCelebrationCoordinator: Coordinator, Presentable {
         onboardingCelebrationViewModel = viewModel
         onboardingCelebrationHostingController = VectorHostingController(rootView: view)
         onboardingCelebrationHostingController.enableNavigationBarScrollEdgeAppearance = true
+        onboardingCelebrationHostingController.isNavigationBarHidden = true
     }
     
     // MARK: - Public

--- a/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/Congratulations/Coordinator/OnboardingCongratulationsCoordinator.swift
@@ -58,6 +58,7 @@ final class OnboardingCongratulationsCoordinator: Coordinator, Presentable {
         onboardingCongratulationsViewModel = viewModel
         onboardingCongratulationsHostingController = VectorHostingController(rootView: view)
         onboardingCongratulationsHostingController.statusBarStyle = .lightContent
+        onboardingCongratulationsHostingController.isNavigationBarHidden = true
     }
     
     // MARK: - Public

--- a/RiotSwiftUI/Modules/Onboarding/SplashScreen/Coordinator/OnboardingSplashScreenCoordinator.swift
+++ b/RiotSwiftUI/Modules/Onboarding/SplashScreen/Coordinator/OnboardingSplashScreenCoordinator.swift
@@ -46,6 +46,7 @@ final class OnboardingSplashScreenCoordinator: OnboardingSplashScreenCoordinator
         onboardingSplashScreenViewModel = viewModel
         onboardingSplashScreenHostingController = VectorHostingController(rootView: view)
         onboardingSplashScreenHostingController.vc_removeBackTitle()
+        onboardingSplashScreenHostingController.isNavigationBarHidden = true
         
         indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: onboardingSplashScreenHostingController)
     }


### PR DESCRIPTION
When building with Xcode 13, Element iOS running on iOS 16 has had some issues with the navigation bars not behaving as expected from SwiftUI. This appears to be twofold:

1. The `.navigationBarHidden(true)` modifier doesn't appear to work inside of `VectorHostingController` on presentation (it does however work when popping back to a screen with the modifier.
2. Using `viewWillAppear` to update the navigation controller with the custom  `isNavigationBarHidden` appears to now occur before the hosting controller has been added to the navigation controller.

This PR sets the `isNavigationBarHidden` on screens that weren't using it and uses this property in `viewWillLayoutSubviews`.

The changelog is included in CHANGES.md ready for the release branch. Fixes #6738

| Splash Screen Before | Splash Screen After | Congratulations Before | Congratulations After | Create Space Before | Create Space After |
| - | - | - | - | - | - |
| ![IMG_5C6ED1C8BA41-1](https://user-images.githubusercontent.com/6060466/193854977-ecd6dfaf-31ae-42e6-a128-1efd2e29e285.jpeg) | ![IMG_0474](https://user-images.githubusercontent.com/6060466/193854673-e1ed9a81-deec-44a7-8d04-13d2e6c8d234.PNG)| ![IMG_0472](https://user-images.githubusercontent.com/6060466/193854715-38633a24-3999-4d6b-8134-6fd8c65c68f9.PNG) | ![IMG_0475](https://user-images.githubusercontent.com/6060466/193854736-a43bb937-b978-4ddb-bff0-d4ee66715a2c.PNG) | ![IMG_0009](https://user-images.githubusercontent.com/6060466/193855113-37697b53-0c05-4b48-9f6e-b76a95f661ce.PNG) | ![IMG_0476](https://user-images.githubusercontent.com/6060466/193854755-fa14d853-660e-4995-bcbf-cbd348738daa.PNG) |