### PR TITLE
Session Manager: Single session logout

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -897,6 +897,7 @@ Tap the + to start adding people.";
 "manage_session_trusted" = "Trusted by you";
 "manage_session_not_trusted" = "Not trusted";
 "manage_session_sign_out" = "Sign out of this session";
+"manage_session_rename" = "Rename session";
 
 // User sessions management
 "user_sessions_settings" = "Manage sessions";
@@ -1448,6 +1449,9 @@ Tap the + to start adding people.";
 "key_backup_recover_done_action" = "Done";
 
 // MARK: Sign out warning
+
+"sign_out" = "Sign out";
+"sign_out_confirmation_message" = "Are you sure you want to sign out?";
 
 "sign_out_existing_key_backup_alert_title" = "Are you sure you want to sign out?";
 "sign_out_existing_key_backup_alert_sign_out_action" = "Sign out";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3503,6 +3503,10 @@ public class VectorL10n: NSObject {
   public static var manageSessionNotTrusted: String { 
     return VectorL10n.tr("Vector", "manage_session_not_trusted") 
   }
+  /// Rename session
+  public static var manageSessionRename: String { 
+    return VectorL10n.tr("Vector", "manage_session_rename") 
+  }
   /// Sign out of this session
   public static var manageSessionSignOut: String { 
     return VectorL10n.tr("Vector", "manage_session_sign_out") 
@@ -7754,6 +7758,14 @@ public class VectorL10n: NSObject {
   /// Left panel
   public static var sideMenuRevealActionAccessibilityLabel: String { 
     return VectorL10n.tr("Vector", "side_menu_reveal_action_accessibility_label") 
+  }
+  /// Sign out
+  public static var signOut: String { 
+    return VectorL10n.tr("Vector", "sign_out") 
+  }
+  /// Are you sure you want to sign out?
+  public static var signOutConfirmationMessage: String { 
+    return VectorL10n.tr("Vector", "sign_out_confirmation_message") 
   }
   /// Sign out
   public static var signOutExistingKeyBackupAlertSignOutAction: String { 

--- a/Riot/Modules/UserInteractiveAuthentication/AuthenticatedEndpointRequest.swift
+++ b/Riot/Modules/UserInteractiveAuthentication/AuthenticatedEndpointRequest.swift
@@ -29,3 +29,14 @@ class AuthenticatedEndpointRequest: NSObject {
         super.init()
     }
 }
+
+// MARK: - Helper methods
+
+extension AuthenticatedEndpointRequest {
+    /// Create an authenticated request on `_matrix/client/r0/devices/{deviceID}`.
+    /// - Parameter deviceID: The device ID that is to be deleted.
+    static func deleteDevice(_ deviceID: String) -> AuthenticatedEndpointRequest {
+        let path = String(format: "%@/devices/%@", kMXAPIPrefixPathR0, MXTools.encodeURIComponent(deviceID))
+        return AuthenticatedEndpointRequest(path: path, httpMethod: "DELETE")
+    }
+}

--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
@@ -19,7 +19,7 @@ import Foundation
 
 struct UserSessionsFlowCoordinatorParameters {
     let session: MXSession
-    let router: NavigationRouterType?
+    let router: NavigationRouterType
 }
 
 final class UserSessionsFlowCoordinator: Coordinator, Presentable {
@@ -41,11 +41,9 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
     init(parameters: UserSessionsFlowCoordinatorParameters) {
         self.parameters = parameters
         
-        let navigationRouter = parameters.router ?? NavigationRouter(navigationController: RiotNavigationController())
-        self.navigationRouter = navigationRouter
-        
+        self.navigationRouter = parameters.router
         errorPresenter = MXKErrorAlertPresentation()
-        indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: navigationRouter.toPresentable())
+        indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: parameters.router.toPresentable())
     }
     
     // MARK: - Private
@@ -146,6 +144,7 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
             self?.showLogoutAuthentication(for: sessionInfo)
         })
         alert.addAction(UIAlertAction(title: VectorL10n.cancel, style: .cancel))
+        alert.popoverPresentationController?.sourceView = toPresentable().view
         
         navigationRouter.present(alert, animated: true)
     }
@@ -154,9 +153,7 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
     private func showLogoutAuthentication(for sessionInfo: UserSessionInfo) {
         startLoading()
         
-        let path = String(format: "%@/devices/%@", kMXAPIPrefixPathR0, MXTools.encodeURIComponent(sessionInfo.id))
-        let deleteDeviceRequest = AuthenticatedEndpointRequest(path: path, httpMethod: "DELETE")
-
+        let deleteDeviceRequest = AuthenticatedEndpointRequest.deleteDevice(sessionInfo.id)
         let coordinatorParameters = ReauthenticationCoordinatorParameters(session: parameters.session,
                                                                           presenter: navigationRouter.toPresentable(),
                                                                           title: VectorL10n.deviceDetailsDeletePromptTitle,

--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
@@ -15,6 +15,7 @@
 //
 
 import CommonKit
+import Foundation
 
 struct UserSessionsFlowCoordinatorParameters {
     let session: MXSession
@@ -23,7 +24,15 @@ struct UserSessionsFlowCoordinatorParameters {
 
 final class UserSessionsFlowCoordinator: Coordinator, Presentable {
     private let parameters: UserSessionsFlowCoordinatorParameters
+    
     private let navigationRouter: NavigationRouterType
+    private var reauthenticationPresenter: ReauthenticationCoordinatorBridgePresenter?
+    private var errorPresenter: MXKErrorPresentation
+    private var indicatorPresenter: UserIndicatorTypePresenterProtocol
+    private var loadingIndicator: UserIndicator?
+    
+    /// The root coordinator for user session management.
+    private weak var sessionsOverviewCoordinator: UserSessionsOverviewCoordinator?
     
     // Must be used only internally
     var childCoordinators: [Coordinator] = []
@@ -31,7 +40,12 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
     
     init(parameters: UserSessionsFlowCoordinatorParameters) {
         self.parameters = parameters
-        navigationRouter = parameters.router ?? NavigationRouter(navigationController: RiotNavigationController())
+        
+        let navigationRouter = parameters.router ?? NavigationRouter(navigationController: RiotNavigationController())
+        self.navigationRouter = navigationRouter
+        
+        errorPresenter = MXKErrorAlertPresentation()
+        indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: navigationRouter.toPresentable())
     }
     
     // MARK: - Private
@@ -53,6 +67,10 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
         coordinator.completion = { [weak self] result in
             guard let self = self else { return }
             switch result {
+            case let .renameSession(sessionInfo):
+                break
+            case let .logoutOfSession(sessionInfo):
+                self.showLogoutConfirmation(for: sessionInfo)
             case let .openSessionOverview(sessionInfo: sessionInfo):
                 self.openSessionOverview(sessionInfo: sessionInfo)
             case let .openOtherSessions(sessionsInfo: sessionsInfo, filter: filter):
@@ -81,6 +99,10 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
             switch result {
             case let .openSessionDetails(sessionInfo: sessionInfo):
                 self.openSessionDetails(sessionInfo: sessionInfo)
+            case let .renameSession(sessionInfo):
+                break
+            case let .logoutOfSession(sessionInfo):
+                self.showLogoutConfirmation(for: sessionInfo)
             }
         }
         pushScreen(with: coordinator)
@@ -115,6 +137,90 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
         return UserOtherSessionsCoordinator(parameters: parameters)
     }
     
+    
+    /// Shows a confirmation dialog to the user to sign out of a session.
+    private func showLogoutConfirmation(for sessionInfo: UserSessionInfo) {
+        // Use a UIAlertController as we don't have confirmationDialog in SwiftUI on iOS 14.
+        let alert = UIAlertController(title: VectorL10n.signOutConfirmationMessage, message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: VectorL10n.signOut, style: .destructive) { [weak self] _ in
+            self?.showLogoutAuthentication(for: sessionInfo)
+        })
+        alert.addAction(UIAlertAction(title: VectorL10n.cancel, style: .cancel))
+        
+        navigationRouter.present(alert, animated: true)
+    }
+    
+    /// Prompts the user to authenticate (if necessary) in order to log out of a specific session.
+    private func showLogoutAuthentication(for sessionInfo: UserSessionInfo) {
+        startLoading()
+        
+        let path = String(format: "%@/devices/%@", kMXAPIPrefixPathR0, MXTools.encodeURIComponent(sessionInfo.id))
+        let deleteDeviceRequest = AuthenticatedEndpointRequest(path: path, httpMethod: "DELETE")
+
+        let coordinatorParameters = ReauthenticationCoordinatorParameters(session: parameters.session,
+                                                                          presenter: navigationRouter.toPresentable(),
+                                                                          title: VectorL10n.deviceDetailsDeletePromptTitle,
+                                                                          message: VectorL10n.deviceDetailsDeletePromptMessage,
+                                                                          authenticatedEndpointRequest: deleteDeviceRequest)
+        let presenter = ReauthenticationCoordinatorBridgePresenter()
+        presenter.present(with: coordinatorParameters, animated: true) { [weak self] authenticationParameters in
+            self?.finalizeLogout(of: sessionInfo, with: authenticationParameters)
+            self?.reauthenticationPresenter = nil
+        } cancel: { [weak self] in
+            self?.stopLoading()
+            self?.reauthenticationPresenter = nil
+        } failure: { [weak self] error in
+            guard let self = self else { return }
+            self.stopLoading()
+            self.errorPresenter.presentError(from: self.toPresentable(), forError: error, animated: true, handler: { })
+            self.reauthenticationPresenter = nil
+        }
+
+        reauthenticationPresenter = presenter
+    }
+    
+    /// Finishes the logout process by deleting the device from the user's account.
+    /// - Parameters:
+    ///   - sessionInfo: The `UserSessionInfo` for the session to be removed.
+    ///   - authenticationParameters: The parameters from performing interactive authentication on the `devices` endpoint.
+    private func finalizeLogout(of sessionInfo: UserSessionInfo, with authenticationParameters: [String: Any]?) {
+        parameters.session.matrixRestClient.deleteDevice(sessionInfo.id,
+                                                         authParameters: authenticationParameters ?? [:]) { [weak self] response in
+            guard let self = self else { return }
+            
+            self.stopLoading()
+
+            guard response.isSuccess else {
+                MXLog.debug("[LogoutDeviceService] Delete device (\(sessionInfo.id) failed")
+                if let error = response.error {
+                    self.errorPresenter.presentError(from: self.toPresentable(), forError: error, animated: true, handler: { })
+                } else {
+                    self.errorPresenter.presentGenericError(from: self.toPresentable(), animated: true, handler: { })
+                }
+                
+                return
+            }
+
+            self.popToSessionsOverview()
+        }
+    }
+    
+    /// Pops back to the root coordinator in the session management flow.
+    private func popToSessionsOverview() {
+        guard let sessionsOverviewCoordinator = sessionsOverviewCoordinator else { return }
+        navigationRouter.popToModule(sessionsOverviewCoordinator, animated: true)
+    }
+    
+    /// Show an activity indicator whilst loading.
+    private func startLoading() {
+        loadingIndicator = indicatorPresenter.present(.loading(label: VectorL10n.loading, isInteractionBlocking: true))
+    }
+
+    /// Hide the currently displayed activity indicator.
+    private func stopLoading() {
+        loadingIndicator = nil
+    }
+    
     // MARK: - Public
     
     func start() {
@@ -136,6 +242,8 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
                 self?.completion?()
             }
         }
+        
+        sessionsOverviewCoordinator = rootCoordinator
     }
     
     func toPresentable() -> UIViewController {

--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinatorBridgePresenter.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinatorBridgePresenter.swift
@@ -42,12 +42,8 @@ final class UserSessionsFlowCoordinatorBridgePresenter: NSObject {
     
     // MARK: - Private
     
-    private func startUserSessionsFlow(mxSession: MXSession, navigationController: UINavigationController?) {
-        var navigationRouter: NavigationRouterType?
-        
-        if let navigationController = navigationController {
-            navigationRouter = NavigationRouterStore.shared.navigationRouter(for: navigationController)
-        }
+    private func startUserSessionsFlow(mxSession: MXSession, navigationController: UINavigationController) {
+        let navigationRouter = NavigationRouterStore.shared.navigationRouter(for: navigationController)
         
         let parameters = UserSessionsFlowCoordinatorParameters(session: mxSession, router: navigationRouter)
         let coordinator = UserSessionsFlowCoordinator(parameters: parameters)

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/Coordinator/UserSessionOverviewCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/Coordinator/UserSessionOverviewCoordinator.swift
@@ -45,6 +45,8 @@ final class UserSessionOverviewCoordinator: Coordinator, Presentable {
         viewModel = UserSessionOverviewViewModel(sessionInfo: parameters.sessionInfo, service: service)
         
         hostingController = VectorHostingController(rootView: UserSessionOverview(viewModel: viewModel.context))
+        hostingController.vc_setLargeTitleDisplayMode(.never)
+        hostingController.vc_removeBackTitle()
         
         indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: hostingController)
     }
@@ -55,12 +57,17 @@ final class UserSessionOverviewCoordinator: Coordinator, Presentable {
         MXLog.debug("[UserSessionOverviewCoordinator] did start.")
         viewModel.completion = { [weak self] result in
             guard let self = self else { return }
+            
             MXLog.debug("[UserSessionOverviewCoordinator] UserSessionOverviewViewModel did complete with result: \(result).")
             switch result {
             case .verifyCurrentSession:
                 break // TODO:
             case let .showSessionDetails(sessionInfo: sessionInfo):
                 self.completion?(.openSessionDetails(sessionInfo: sessionInfo))
+            case let .renameSession(sessionInfo):
+                self.completion?(.renameSession(sessionInfo))
+            case let .logoutOfSession(sessionInfo):
+                self.completion?(.logoutOfSession(sessionInfo))
             }
         }
     }

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/UserSessionOverviewModels.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/UserSessionOverviewModels.swift
@@ -20,6 +20,8 @@ import Foundation
 
 enum UserSessionOverviewCoordinatorResult {
     case openSessionDetails(sessionInfo: UserSessionInfo)
+    case renameSession(UserSessionInfo)
+    case logoutOfSession(UserSessionInfo)
 }
 
 // MARK: View model
@@ -27,6 +29,8 @@ enum UserSessionOverviewCoordinatorResult {
 enum UserSessionOverviewViewModelResult: Equatable {
     case showSessionDetails(sessionInfo: UserSessionInfo)
     case verifyCurrentSession
+    case renameSession(UserSessionInfo)
+    case logoutOfSession(UserSessionInfo)
 }
 
 // MARK: View
@@ -43,4 +47,6 @@ enum UserSessionOverviewViewAction {
     case verifyCurrentSession
     case viewSessionDetails
     case togglePushNotifications
+    case renameSession
+    case logoutOfSession
 }

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/UserSessionOverviewViewModel.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/UserSessionOverviewViewModel.swift
@@ -69,6 +69,10 @@ class UserSessionOverviewViewModel: UserSessionOverviewViewModelType, UserSessio
         case .togglePushNotifications:
             self.state.showLoadingIndicator = true
             service.togglePushNotifications()
+        case .renameSession:
+            completion?(.renameSession(sessionInfo))
+        case .logoutOfSession:
+            completion?(.logoutOfSession(sessionInfo))
         }
     }
 }

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/View/UserSessionOverview.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/View/UserSessionOverview.swift
@@ -31,15 +31,24 @@ struct UserSessionOverview: View {
             })
             .padding(16)
             SwiftUI.Section {
-                UserSessionOverviewDisclosureCell(title: VectorL10n.userSessionOverviewSessionDetailsButtonTitle, onBackgroundTap: {
+                UserSessionOverviewItem(title: VectorL10n.userSessionOverviewSessionDetailsButtonTitle,
+                                        showsChevron: true) {
                     viewModel.send(viewAction: .viewSessionDetails)
-                })
+                }
+                
                 if let enabled = viewModel.viewState.isPusherEnabled {
                     UserSessionOverviewToggleCell(title: VectorL10n.userSessionPushNotifications,
                                                   message: VectorL10n.userSessionPushNotificationsMessage,
                                                   isOn: enabled, isEnabled: viewModel.viewState.remotelyTogglingPushersAvailable) {
                         viewModel.send(viewAction: .togglePushNotifications)
                     }
+                }
+            }
+            
+            SwiftUI.Section {
+                UserSessionOverviewItem(title: VectorL10n.manageSessionSignOut,
+                                        isDestructive: true) {
+                    viewModel.send(viewAction: .logoutOfSession)
                 }
             }
         }
@@ -49,6 +58,19 @@ struct UserSessionOverview: View {
         .navigationTitle(viewModel.viewState.isCurrentSession ?
             VectorL10n.userSessionOverviewCurrentSessionTitle :
             VectorL10n.userSessionOverviewSessionTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    Button { viewModel.send(viewAction: .renameSession) } label: {
+                        Label(VectorL10n.manageSessionRename, systemImage: "pencil")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+        .accentColor(theme.colors.accent)
     }
 }
 

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/View/UserSessionOverviewItem.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/View/UserSessionOverviewItem.swift
@@ -16,10 +16,12 @@
 
 import SwiftUI
 
-struct UserSessionOverviewDisclosureCell: View {
+struct UserSessionOverviewItem: View {
     @Environment(\.theme) private var theme: ThemeSwiftUI
     
     let title: String
+    var showsChevron = false
+    var isDestructive = false
     var onBackgroundTap: (() -> Void)?
     
     var body: some View {
@@ -29,9 +31,12 @@ struct UserSessionOverviewDisclosureCell: View {
                 HStack {
                     Text(title)
                         .font(theme.fonts.body)
-                        .foregroundColor(theme.colors.primaryContent)
+                        .foregroundColor(textColor)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Image(Asset.Images.chevron.name)
+                    
+                    if showsChevron {
+                        Image(Asset.Images.chevron.name)
+                    }
                 }
                 .padding(.vertical, 15)
                 .padding(.horizontal, 16)
@@ -40,17 +45,27 @@ struct UserSessionOverviewDisclosureCell: View {
             .background(theme.colors.background)
         }
     }
+    
+    var textColor: Color {
+        isDestructive ? theme.colors.alert : theme.colors.primaryContent
+    }
 }
 
-struct UserSessionOverviewDisclosureCell_Previews: PreviewProvider {
+struct UserSessionOverviewButtonCell_Previews: PreviewProvider {
+    static var buttons: some View {
+        NavigationView {
+            ScrollView {
+                UserSessionOverviewItem(title: "Nav item", showsChevron: true)
+                UserSessionOverviewItem(title: "Button")
+                UserSessionOverviewItem(title: "Button", isDestructive: true)
+            }
+        }
+    }
+    
     static var previews: some View {
         Group {
-            UserSessionOverviewDisclosureCell(title: "Title")
-                .theme(.light)
-                .preferredColorScheme(.light)
-            UserSessionOverviewDisclosureCell(title: "Title")
-                .theme(.dark)
-                .preferredColorScheme(.dark)
+            buttons.theme(.light).preferredColorScheme(.light)
+            buttons.theme(.dark).preferredColorScheme(.dark)
         }
     }
 }

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/View/UserSessionOverviewItem.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionOverview/View/UserSessionOverviewItem.swift
@@ -51,7 +51,7 @@ struct UserSessionOverviewItem: View {
     }
 }
 
-struct UserSessionOverviewButtonCell_Previews: PreviewProvider {
+struct UserSessionOverviewItem_Previews: PreviewProvider {
     static var buttons: some View {
         NavigationView {
             ScrollView {

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Coordinator/UserSessionsOverviewCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Coordinator/UserSessionsOverviewCoordinator.swift
@@ -40,7 +40,11 @@ final class UserSessionsOverviewCoordinator: Coordinator, Presentable {
         let dataProvider = UserSessionsDataProvider(session: parameters.session)
         service = UserSessionsOverviewService(dataProvider: dataProvider)
         viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: service)
+        
         hostingViewController = VectorHostingController(rootView: UserSessionsOverview(viewModel: viewModel.context))
+        hostingViewController.vc_setLargeTitleDisplayMode(.never)
+        hostingViewController.vc_removeBackTitle()
+        
         indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: hostingViewController)
     }
     
@@ -57,6 +61,10 @@ final class UserSessionsOverviewCoordinator: Coordinator, Presentable {
                 self.showOtherSessions(sessionsInfo: sessionsInfo, filterBy: filter)
             case .verifyCurrentSession:
                 self.startVerifyCurrentSession()
+            case .renameSession(let sessionInfo):
+                self.completion?(.renameSession(sessionInfo))
+            case .logoutOfSession(let sessionInfo):
+                self.completion?(.logoutOfSession(sessionInfo))
             case let .showCurrentSessionOverview(sessionInfo):
                 self.showCurrentSessionOverview(sessionInfo: sessionInfo)
             case let .showUserSessionOverview(sessionInfo):

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewModels.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewModels.swift
@@ -19,6 +19,8 @@ import Foundation
 // MARK: - Coordinator
 
 enum UserSessionsOverviewCoordinatorResult {
+    case renameSession(UserSessionInfo)
+    case logoutOfSession(UserSessionInfo)
     case openSessionOverview(sessionInfo: UserSessionInfo)
     case openOtherSessions(sessionsInfo: [UserSessionInfo], filter: OtherUserSessionsFilter)
 }
@@ -28,6 +30,8 @@ enum UserSessionsOverviewCoordinatorResult {
 enum UserSessionsOverviewViewModelResult: Equatable {
     case showOtherSessions(sessionsInfo: [UserSessionInfo], filter: OtherUserSessionsFilter)
     case verifyCurrentSession
+    case renameSession(UserSessionInfo)
+    case logoutOfSession(UserSessionInfo)
     case showCurrentSessionOverview(sessionInfo: UserSessionInfo)
     case showUserSessionOverview(sessionInfo: UserSessionInfo)
 }
@@ -49,6 +53,8 @@ struct UserSessionsOverviewViewState: BindableState {
 enum UserSessionsOverviewViewAction {
     case viewAppeared
     case verifyCurrentSession
+    case renameCurrentSession
+    case logoutOfCurrentSession
     case viewCurrentSessionDetails
     case viewAllUnverifiedSessions
     case viewAllInactiveSessions

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewViewModel.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewViewModel.swift
@@ -39,6 +39,18 @@ class UserSessionsOverviewViewModel: UserSessionsOverviewViewModelType, UserSess
             loadData()
         case .verifyCurrentSession:
             completion?(.verifyCurrentSession)
+        case .renameCurrentSession:
+            guard let currentSessionInfo = userSessionsOverviewService.overviewData.currentSession else {
+                assertionFailure("Missing current session")
+                return
+            }
+            completion?(.renameSession(currentSessionInfo))
+        case .logoutOfCurrentSession:
+            guard let currentSessionInfo = userSessionsOverviewService.overviewData.currentSession else {
+                assertionFailure("Missing current session")
+                return
+            }
+            completion?(.logoutOfSession(currentSessionInfo))
         case .viewCurrentSessionDetails:
             guard let currentSessionInfo = userSessionsOverviewService.overviewData.currentSession else {
                 assertionFailure("Missing current session")

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionsOverview.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionsOverview.swift
@@ -36,7 +36,9 @@ struct UserSessionsOverview: View {
         .background(theme.colors.system.ignoresSafeArea())
         .frame(maxHeight: .infinity)
         .navigationTitle(VectorL10n.userSessionsOverviewTitle)
+        .navigationBarTitleDisplayMode(.inline)
         .activityIndicator(show: viewModel.viewState.showLoadingIndicator)
+        .accentColor(theme.colors.accent)
         .onAppear {
             viewModel.send(viewAction: .viewAppeared)
         }
@@ -91,15 +93,39 @@ struct UserSessionsOverview: View {
                     viewModel.send(viewAction: .viewCurrentSessionDetails)
                 })
             } header: {
-                Text(VectorL10n.userSessionsOverviewCurrentSessionSectionTitle)
-                    .textCase(.uppercase)
-                    .font(theme.fonts.footnote)
-                    .foregroundColor(theme.colors.secondaryContent)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.bottom, 12.0)
-                    .padding(.top, 24.0)
+                HStack(alignment: .firstTextBaseline) {
+                    Text(VectorL10n.userSessionsOverviewCurrentSessionSectionTitle)
+                        .textCase(.uppercase)
+                        .font(theme.fonts.footnote)
+                        .foregroundColor(theme.colors.secondaryContent)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.bottom, 12.0)
+                        .padding(.top, 24.0)
+                    
+                    currentSessionMenu
+                }
             }
             .padding(.horizontal, 16)
+        }
+    }
+    
+    private var currentSessionMenu: some View {
+        Menu {
+            Button { viewModel.send(viewAction: .renameCurrentSession) } label: {
+                Label(VectorL10n.manageSessionRename, systemImage: "pencil")
+            }
+            
+            if #available(iOS 15, *) {
+                Button(role: .destructive) { viewModel.send(viewAction: .logoutOfCurrentSession) } label: {
+                    Label(VectorL10n.signOut, systemImage: "rectangle.portrait.and.arrow.right.fill")
+                }
+            } else {
+                Button { viewModel.send(viewAction: .logoutOfCurrentSession) } label: {
+                    Label(VectorL10n.signOut, systemImage: "rectangle.righthalf.inset.fill.arrow.right")
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
         }
     }
     

--- a/changelog.d/6802.wip
+++ b/changelog.d/6802.wip
@@ -1,0 +1,1 @@
+Device Manager: Add logout actions to UserSessionsOverview and UserSessionOverview


### PR DESCRIPTION
Adds the logout actions to both the current session section in the all sessions overview and to the single session overview screen as a button.

The UI for the rename action has been added but isn't hooked up to any logic yet.

Fixes #6802

| Light Mode | Dark Mode |
| - | - |
| ![Simulator Screen Recording - iPhone 13 mini - 2022-10-05 at 14 14 06](https://user-images.githubusercontent.com/6060466/194073234-515e79e3-436e-4e91-97db-451ecdda0de6.gif) | ![Simulator Screen Recording - iPhone 13 mini - 2022-10-05 at 14 14 59](https://user-images.githubusercontent.com/6060466/194073289-0ce9d128-7cb3-48af-8880-a5bdc9d5e555.gif) |


