### PR TITLE
Use regular titles for sub-screens of Settings.

### DIFF
--- a/Riot/Modules/Settings/Discovery/ThreePidDetails/SettingsDiscoveryThreePidDetailsViewController.swift
+++ b/Riot/Modules/Settings/Discovery/ThreePidDetails/SettingsDiscoveryThreePidDetailsViewController.swift
@@ -59,6 +59,7 @@ final class SettingsDiscoveryThreePidDetailsViewController: UIViewController {
         
         // Do any additional setup after loading the view.
         
+        vc_setLargeTitleDisplayMode(.never)
         self.setupViews()
         self.keyboardAvoider = KeyboardAvoider(scrollViewContainerView: self.view, scrollView: self.scrollView)
         self.activityPresenter = ActivityIndicatorPresenter()

--- a/Riot/Modules/Settings/IdentityServer/SettingsIdentityServerViewController.swift
+++ b/Riot/Modules/Settings/IdentityServer/SettingsIdentityServerViewController.swift
@@ -72,6 +72,7 @@ final class SettingsIdentityServerViewController: UIViewController {
         // Do any additional setup after loading the view.
         
         self.title = VectorL10n.identityServerSettingsTitle
+        vc_setLargeTitleDisplayMode(.never)
         
         self.setupViews()
         self.keyboardAvoider = KeyboardAvoider(scrollViewContainerView: self.view, scrollView: self.scrollView)

--- a/Riot/Modules/Settings/Language/LanguagePickerViewController.m
+++ b/Riot/Modules/Settings/Language/LanguagePickerViewController.m
@@ -48,6 +48,8 @@
 {
     [super viewDidLoad];
 
+    [self vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
+    
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
     

--- a/Riot/Modules/Settings/PhoneCountry/CountryPickerViewController.m
+++ b/Riot/Modules/Settings/PhoneCountry/CountryPickerViewController.m
@@ -50,6 +50,7 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
+    [self vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
     
     // Add a top view which will be displayed in case of vertical bounce.
     CGFloat height = self.tableView.frame.size.height;

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -156,6 +156,7 @@ TableViewSectionsDelegate>
     // Do any additional setup after loading the view, typically from a nib.
     
     self.navigationItem.title = [VectorL10n securitySettingsTitle];
+    [self vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
     [self vc_removeBackTitle];
 
     [self.tableView registerClass:MXKTableViewCellWithLabelAndSwitch.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndSwitch defaultReuseIdentifier]];

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -2840,6 +2840,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
                 WebViewViewController *webViewViewController = [[WebViewViewController alloc] initWithURL:BuildSettings.applicationCopyrightUrlString];
                 
                 webViewViewController.title = [VectorL10n settingsCopyright];
+                [webViewViewController vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
                 
                 [self pushViewController:webViewViewController];
             }
@@ -2848,6 +2849,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
                 WebViewViewController *webViewViewController = [[WebViewViewController alloc] initWithURL:BuildSettings.applicationTermsConditionsUrlString];
                 
                 webViewViewController.title = [VectorL10n settingsTermConditions];
+                [webViewViewController vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
                 
                 [self pushViewController:webViewViewController];
             }
@@ -2856,6 +2858,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
                 WebViewViewController *webViewViewController = [[WebViewViewController alloc] initWithURL:BuildSettings.applicationPrivacyPolicyUrlString];
                 
                 webViewViewController.title = [VectorL10n settingsPrivacyPolicy];
+                [webViewViewController vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
                 
                 [self pushViewController:webViewViewController];
             }
@@ -2866,6 +2869,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
                 WebViewViewController *webViewViewController = [[WebViewViewController alloc] initWithLocalHTMLFile:htmlFile];
                 
                 webViewViewController.title = [VectorL10n settingsThirdPartyNotices];
+                [webViewViewController vc_setLargeTitleDisplayMode:UINavigationItemLargeTitleDisplayModeNever];
                 
                 [self pushViewController:webViewViewController];
             }

--- a/RiotSwiftUI/Modules/Settings/Notifications/Coordinator/NotificationSettingsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Coordinator/NotificationSettingsCoordinator.swift
@@ -50,6 +50,7 @@ final class NotificationSettingsCoordinator: NotificationSettingsCoordinatorType
         }
         notificationSettingsViewModel = viewModel
         notificationSettingsViewController = viewController
+        notificationSettingsViewController.vc_setLargeTitleDisplayMode(.never)
     }
     
     // MARK: - Public methods

--- a/changelog.d/6804.bugfix
+++ b/changelog.d/6804.bugfix
@@ -1,0 +1,1 @@
+Settings: Use regular titles for all of the sub-screens.


### PR DESCRIPTION
Fixes #6804 

Some screenshots below:
| Terms | Identity | Discovery | Notifications |
| - | - | - | - |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-10-05 at 15 15 56](https://user-images.githubusercontent.com/6060466/194083295-006edbb7-140f-44af-9a25-72e0676dcbd6.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-10-05 at 15 16 01](https://user-images.githubusercontent.com/6060466/194083323-975812f7-e452-44aa-8f73-cce327e5bac8.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-10-05 at 15 16 11](https://user-images.githubusercontent.com/6060466/194083462-fb3a27c7-3d53-4ef0-9af7-f0d2063a8b7e.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-10-05 at 15 16 17](https://user-images.githubusercontent.com/6060466/194083484-c0cf92ec-b296-4c9c-89cb-b0dc8c455e53.png) |