### PR TITLE
Refactor verification manager, request, transactions

### DIFF
--- a/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinator.swift
@@ -240,7 +240,7 @@ final class KeyVerificationCoordinator: KeyVerificationCoordinatorType {
         }
     }
 
-    private func showIncoming(otherUser: MXUser, transaction: MXIncomingSASTransaction) {
+    private func showIncoming(otherUser: MXUser, transaction: MXSASTransaction) {
         let coordinator = DeviceVerificationIncomingCoordinator(session: self.session, otherUser: otherUser, transaction: transaction)
         coordinator.delegate = self
         coordinator.start()
@@ -429,7 +429,7 @@ extension KeyVerificationCoordinator: KeyVerificationSelfVerifyWaitCoordinatorDe
         self.showVerifyByScanning(keyVerificationRequest: keyVerificationRequest, animated: true)
     }
     
-    func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, didAcceptIncomingSASTransaction incomingSASTransaction: MXIncomingSASTransaction) {
+    func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, didAcceptIncomingSASTransaction incomingSASTransaction: MXSASTransaction) {
         self.showVerifyBySAS(transaction: incomingSASTransaction, animated: true)                
     }
     

--- a/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinatorBridgePresenter.swift
@@ -74,7 +74,7 @@ final class KeyVerificationCoordinatorBridgePresenter: NSObject {
         self.present(coordinator: keyVerificationCoordinator, from: viewController, animated: animated)
     }
 
-    func present(from viewController: UIViewController, incomingTransaction: MXIncomingSASTransaction, animated: Bool) {
+    func present(from viewController: UIViewController, incomingTransaction: MXSASTransaction, animated: Bool) {
         
         MXLog.debug("[KeyVerificationCoordinatorBridgePresenter] Present incoming verification from \(viewController)")
         

--- a/Riot/Modules/KeyVerification/Common/KeyVerificationFlow.swift
+++ b/Riot/Modules/KeyVerification/Common/KeyVerificationFlow.swift
@@ -28,5 +28,5 @@ enum KeyVerificationFlow {
     case verifyDevice(userId: String, deviceId: String)
     case completeSecurity(_ isNewSignIn: Bool)
     case incomingRequest(_ request: MXKeyVerificationRequest)
-    case incomingSASTransaction(_ transaction: MXIncomingSASTransaction)
+    case incomingSASTransaction(_ transaction: MXSASTransaction)
 }

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewModel.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewModel.swift
@@ -102,7 +102,7 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
         
         self.update(viewState: .loaded(viewData: viewData))
         
-        self.registerTransactionDidStateChangeNotification()
+        self.registerDidStateChangeNotification()
     }
     
     private func canShowScanAction(from verificationMethods: [String]) -> Bool {
@@ -112,7 +112,7 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
     private func cancel() {
         self.cancelQRCodeTransaction()
         self.keyVerificationRequest.cancel(with: MXTransactionCancelCode.user(), success: nil, failure: nil)
-        self.unregisterTransactionDidStateChangeNotification()
+        self.unregisterDidStateChangeNotification()
         self.coordinatorDelegate?.keyVerificationVerifyByScanningViewModelDidCancel(self)
     }
     
@@ -148,7 +148,7 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
             return
         }
         
-        self.unregisterTransactionDidStateChangeNotification()
+        self.unregisterDidStateChangeNotification()
         self.coordinatorDelegate?.keyVerificationVerifyByScanningViewModel(self, didScanOtherQRCodeData: scannedQRCodeData, withTransaction: qrCodeTransaction)
     }    
     
@@ -176,7 +176,7 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
                 // Check due to legacy implementation of key verification which could pass incorrect type of transaction
                 if keyVerificationTransaction is MXIncomingSASTransaction {
                     MXLog.debug("[KeyVerificationVerifyByScanningViewModel] SAS transaction should be outgoing")
-                    self.unregisterTransactionDidStateChangeNotification()
+                    self.unregisterDidStateChangeNotification()
                     self.update(viewState: .error(KeyVerificationVerifyByScanningViewModelError.unknown))
                 }
             
@@ -191,12 +191,25 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
     
     // MARK: - MXKeyVerificationTransactionDidChange
     
-    private func registerTransactionDidStateChangeNotification() {
+    private func registerDidStateChangeNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(requestDidStateChange(notification:)), name: .MXKeyVerificationRequestDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
     
-    private func unregisterTransactionDidStateChangeNotification() {
+    private func unregisterDidStateChangeNotification() {
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationRequestDidChange, object: nil)
         NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
+    }
+    
+    @objc private func requestDidStateChange(notification: Notification) {
+        guard let request = notification.object as? MXKeyVerificationRequest else {
+            return
+        }
+        
+        if request.state == MXKeyVerificationRequestStateCancelled, let reason = request.reasonCancelCode {
+            self.unregisterDidStateChangeNotification()
+            self.update(viewState: .cancelled(cancelCode: reason, verificationKind: verificationKind))
+        }
     }
     
     @objc private func transactionDidStateChange(notification: Notification) {
@@ -219,19 +232,19 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
     private func sasTransactionDidStateChange(_ transaction: MXSASTransaction) {
         switch transaction.state {
         case MXSASTransactionStateShowSAS:
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.coordinatorDelegate?.keyVerificationVerifyByScanningViewModel(self, didStartSASVerificationWithTransaction: transaction)
         case MXSASTransactionStateCancelled:
             guard let reason = transaction.reasonCancelCode else {
                 return
             }
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.update(viewState: .cancelled(cancelCode: reason, verificationKind: verificationKind))
         case MXSASTransactionStateCancelledByMe:
             guard let reason = transaction.reasonCancelCode else {
                 return
             }
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.update(viewState: .cancelledByMe(reason))
         default:
             break
@@ -242,22 +255,22 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
         switch transaction.state {
         case .verified:
             // Should not happen
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.coordinatorDelegate?.keyVerificationVerifyByScanningViewModelDidCancel(self)
         case .qrScannedByOther:
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.coordinatorDelegate?.keyVerificationVerifyByScanningViewModel(self, qrCodeDidScannedByOtherWithTransaction: transaction)
         case .cancelled:
             guard let reason = transaction.reasonCancelCode else {
                 return
             }
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.update(viewState: .cancelled(cancelCode: reason, verificationKind: verificationKind))
         case .cancelledByMe:
             guard let reason = transaction.reasonCancelCode else {
                 return
             }
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterDidStateChangeNotification()
             self.update(viewState: .cancelledByMe(reason))
         default:
             break

--- a/Riot/Modules/KeyVerification/Device/Incoming/DeviceVerificationIncomingCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Device/Incoming/DeviceVerificationIncomingCoordinator.swift
@@ -38,7 +38,7 @@ final class DeviceVerificationIncomingCoordinator: DeviceVerificationIncomingCoo
     
     // MARK: - Setup
     
-    init(session: MXSession, otherUser: MXUser, transaction: MXIncomingSASTransaction) {
+    init(session: MXSession, otherUser: MXUser, transaction: MXSASTransaction) {
         self.session = session
         
         let deviceVerificationIncomingViewModel = DeviceVerificationIncomingViewModel(session: self.session, otherUser: otherUser, transaction: transaction)

--- a/Riot/Modules/KeyVerification/Device/Incoming/DeviceVerificationIncomingViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/Incoming/DeviceVerificationIncomingViewModel.swift
@@ -25,7 +25,7 @@ final class DeviceVerificationIncomingViewModel: DeviceVerificationIncomingViewM
     // MARK: Private
 
     private let session: MXSession
-    private let transaction: MXIncomingSASTransaction
+    private let transaction: MXSASTransaction
     
     // MARK: Public
 
@@ -41,7 +41,7 @@ final class DeviceVerificationIncomingViewModel: DeviceVerificationIncomingViewM
     
     // MARK: - Setup
     
-    init(session: MXSession, otherUser: MXUser, transaction: MXIncomingSASTransaction) {
+    init(session: MXSession, otherUser: MXUser, transaction: MXSASTransaction) {
         self.session = session
         self.transaction = transaction
         self.userId = otherUser.userId
@@ -83,7 +83,7 @@ final class DeviceVerificationIncomingViewModel: DeviceVerificationIncomingViewM
 
     // MARK: - MXKeyVerificationTransactionDidChange
 
-    private func registerTransactionDidStateChangeNotification(transaction: MXIncomingSASTransaction) {
+    private func registerTransactionDidStateChangeNotification(transaction: MXSASTransaction) {
         NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
     }
     
@@ -92,7 +92,7 @@ final class DeviceVerificationIncomingViewModel: DeviceVerificationIncomingViewM
     }
 
     @objc private func transactionDidStateChange(notification: Notification) {
-        guard let transaction = notification.object as? MXIncomingSASTransaction else {
+        guard let transaction = notification.object as? MXSASTransaction, transaction.isIncoming else {
             return
         }
 

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinator.swift
@@ -68,7 +68,7 @@ extension KeyVerificationSelfVerifyWaitCoordinator: KeyVerificationSelfVerifyWai
         self.delegate?.keyVerificationSelfVerifyWaitCoordinator(self, didAcceptKeyVerificationRequest: keyVerificationRequest)
     }
     
-    func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, didAcceptIncomingSASTransaction incomingSASTransaction: MXIncomingSASTransaction) {
+    func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, didAcceptIncomingSASTransaction incomingSASTransaction: MXSASTransaction) {
         self.delegate?.keyVerificationSelfVerifyWaitCoordinator(self, didAcceptIncomingSASTransaction: incomingSASTransaction)
     }
     

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinatorType.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinatorType.swift
@@ -20,7 +20,7 @@ import Foundation
 
 protocol KeyVerificationSelfVerifyWaitCoordinatorDelegate: AnyObject {
     func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, didAcceptKeyVerificationRequest keyVerificationRequest: MXKeyVerificationRequest)
-    func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, didAcceptIncomingSASTransaction incomingSASTransaction: MXIncomingSASTransaction)
+    func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, didAcceptIncomingSASTransaction incomingSASTransaction: MXSASTransaction)
     func keyVerificationSelfVerifyWaitCoordinatorDidCancel(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType)
     func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode)
 }

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
@@ -181,7 +181,7 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
     
     @objc private func keyVerificationManagerNewRequestNotification(notification: Notification) {
         
-        guard let userInfo = notification.userInfo, let keyVerificationRequest = userInfo[MXKeyVerificationManagerNotificationRequestKey] as? MXKeyVerificationByToDeviceRequest else {
+        guard let userInfo = notification.userInfo, let keyVerificationRequest = userInfo[MXKeyVerificationManagerNotificationRequestKey] as? MXKeyVerificationRequest, keyVerificationRequest.transport == .toDevice else {
             return
         }
         
@@ -242,14 +242,14 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
     }
 
     @objc private func transactionDidStateChange(notification: Notification) {
-        guard let sasTransaction = notification.object as? MXIncomingSASTransaction,
-            sasTransaction.otherUserId == self.session.myUserId else {
+        guard let sasTransaction = notification.object as? MXSASTransaction,
+            sasTransaction.isIncoming, sasTransaction.otherUserId == self.session.myUserId else {
             return
         }
         self.sasTransactionDidStateChange(sasTransaction)
     }
 
-    private func sasTransactionDidStateChange(_ transaction: MXIncomingSASTransaction) {
+    private func sasTransactionDidStateChange(_ transaction: MXSASTransaction) {
         switch transaction.state {
         case MXSASTransactionStateIncomingShowAccept:
             transaction.accept()

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModelType.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModelType.swift
@@ -24,7 +24,7 @@ protocol KeyVerificationSelfVerifyWaitViewModelViewDelegate: AnyObject {
 
 protocol KeyVerificationSelfVerifyWaitViewModelCoordinatorDelegate: AnyObject {
     func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, didAcceptKeyVerificationRequest keyVerificationRequest: MXKeyVerificationRequest)
-    func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, didAcceptIncomingSASTransaction incomingSASTransaction: MXIncomingSASTransaction)
+    func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, didAcceptIncomingSASTransaction incomingSASTransaction: MXSASTransaction)
     func keyVerificationSelfVerifyWaitViewModelDidCancel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType)
     func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode)
 }

--- a/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartViewModel.swift
@@ -72,7 +72,7 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
             guard let sself = self else {
                 return
             }
-            guard let sasTransaction: MXOutgoingSASTransaction = transaction as? MXOutgoingSASTransaction  else {
+            guard let sasTransaction = transaction as? MXSASTransaction, !sasTransaction.isIncoming  else {
                 return
             }
 
@@ -100,7 +100,7 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
 
     // MARK: - MXKeyVerificationTransactionDidChange
 
-    private func registerTransactionDidStateChangeNotification(transaction: MXOutgoingSASTransaction) {
+    private func registerTransactionDidStateChangeNotification(transaction: MXSASTransaction) {
         NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
     }
     
@@ -109,7 +109,7 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     }
 
     @objc private func transactionDidStateChange(notification: Notification) {
-        guard let transaction = notification.object as? MXOutgoingSASTransaction else {
+        guard let transaction = notification.object as? MXSASTransaction, !transaction.isIncoming else {
             return
         }
 

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -725,13 +725,13 @@ const CGFloat kTypingCellHeight = 24;
                                                                 {
                                                                     id notificationObject = notification.object;
                                                                     
-                                                                    if ([notificationObject isKindOfClass:MXKeyVerificationByDMRequest.class])
+                                                                    if ([notificationObject conformsToProtocol:@protocol(MXKeyVerificationRequest)])
                                                                     {
-                                                                        MXKeyVerificationByDMRequest *keyVerificationByDMRequest = (MXKeyVerificationByDMRequest*)notificationObject;
+                                                                        id<MXKeyVerificationRequest> keyVerificationRequest = (id<MXKeyVerificationRequest>)notificationObject;
                                                                         
-                                                                        if ([keyVerificationByDMRequest.roomId isEqualToString:self.roomId])
+                                                                        if (keyVerificationRequest.transport == MXKeyVerificationTransportDirectMessage && [keyVerificationRequest.roomId isEqualToString:self.roomId])
                                                                         {
-                                                                            RoomBubbleCellData *roomBubbleCellData = [self roomBubbleCellDataForEventId:keyVerificationByDMRequest.eventId];
+                                                                            RoomBubbleCellData *roomBubbleCellData = [self roomBubbleCellDataForEventId:keyVerificationRequest.requestId];
                                                                             
                                                                             roomBubbleCellData.isKeyVerificationOperationPending = NO;
                                                                             roomBubbleCellData.keyVerification = nil;

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -866,6 +866,7 @@ const CGFloat kTypingCellHeight = 24;
     }
     
     __block MXHTTPOperation *operation = [self.mxSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event
+                                                                                                                        roomId:self.roomId
                                                                                                                           success:^(MXKeyVerification * _Nonnull keyVerification)
                                           {
                                               BOOL shouldRefreshCells = bubbleCellData.isKeyVerificationOperationPending || bubbleCellData.keyVerification == nil;

--- a/changelog.d/6809.change
+++ b/changelog.d/6809.change
@@ -1,0 +1,1 @@
+CryptoV2: Incoming verification requests


### PR DESCRIPTION
Turn `MXKeyVerificationManager` into a protocol and rename all existing objective-c implementations to `MXLegacy...` variants. Additionally replace all references to concrete implementations of `...Request` and `...Transaction` to relevant protocols. This is to make Crypto V2 verification api safer.

Corresponding [API change](https://github.com/matrix-org/matrix-ios-sdk/pull/1599)