### PR TITLE
Include app name in default session display name

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2392,6 +2392,9 @@ To enable access, tap Settings> Location and select Always";
 
 // MARK: User sessions management
 
+// Parameter is the application display name (e.g. "Element")
+"user_sessions_default_session_display_name" = "%@ iOS";
+
 "user_sessions_overview_title" = "Sessions";
 
 "user_sessions_overview_security_recommendations_section_title" = "Security recommendations";

--- a/Riot/Categories/UIDevice.swift
+++ b/Riot/Categories/UIDevice.swift
@@ -35,7 +35,7 @@ import UIKit
     }
     
     var initialDisplayName: String {
-        isPhone ? VectorL10n.loginMobileDevice : VectorL10n.loginTabletDevice
+        VectorL10n.userSessionsDefaultSessionDisplayName(AppInfo.current.displayName)
     }
     
 }

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -8743,6 +8743,10 @@ public class VectorL10n: NSObject {
   public static var userSessionViewDetails: String { 
     return VectorL10n.tr("Vector", "user_session_view_details") 
   }
+  /// %@ iOS
+  public static func userSessionsDefaultSessionDisplayName(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "user_sessions_default_session_display_name", p1)
+  }
   /// Current session
   public static var userSessionsOverviewCurrentSessionSectionTitle: String { 
     return VectorL10n.tr("Vector", "user_sessions_overview_current_session_section_title") 

--- a/changelog.d/6828.change
+++ b/changelog.d/6828.change
@@ -1,0 +1,1 @@
+ Include app name in default session display name


### PR DESCRIPTION
The current default session display name is "Mobile" or "Tablet" which isn't very descriptive as it doesn't disclose what actual client this session belongs to. This PR changes the default session name to "%@ iOS" where current application name (e.g. "Element") is inserted into the placeholder. This harmonizes the default name with Element Android which uses the same pattern.

There is an argument to be made about including the device type (phone vs. tablet) in the name. However, since we have the concrete device model available via the new device manager, I think this is better solved via the UI.