### PR TITLE
Only update the nav bar from the top SwiftUI hosting controller.

### DIFF
--- a/Riot/Modules/Common/SwiftUI/VectorHostingController.swift
+++ b/Riot/Modules/Common/SwiftUI/VectorHostingController.swift
@@ -88,9 +88,13 @@ class VectorHostingController: UIHostingController<AnyView> {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
-        if let navigationController = navigationController, navigationController.isNavigationBarHidden != isNavigationBarHidden {
-            navigationController.isNavigationBarHidden = isNavigationBarHidden
-        }
+        guard
+            let navigationController = navigationController,
+            navigationController.topViewController == self,
+            navigationController.isNavigationBarHidden != isNavigationBarHidden
+        else { return }
+        
+        navigationController.isNavigationBarHidden = isNavigationBarHidden
     }
     
     override func viewDidLayoutSubviews() {

--- a/changelog.d/6833.bugfix
+++ b/changelog.d/6833.bugfix
@@ -1,0 +1,1 @@
+All Chats: Fix a header glitch when aborting a pop gesture.


### PR DESCRIPTION
Fixes #6833. The glitch was caused by my fix for #6738 not taking into account the embedded SwiftUI `UserSuggestions` module in `RoomViewController`, so it was modifying the navigation bar when it shouldn't have.

I've tested this change on iOS 15/16 with the auth flow and the navigation bar shows/hides as intended.