### PR TITLE
Update strings for unknown sessions.

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2430,13 +2430,14 @@ To enable access, tap Settings> Location and select Always";
 "user_session_learn_more" = "Learn more";
 "user_session_verified_additional_info" = "Your current session is ready for secure messaging.";
 "user_session_unverified_additional_info" = "Verify your current session for enhanced secure messaging.";
+"user_session_verification_unknown_additional_info" = "Verify your current session to reveal this session's verification status.";
 
 "user_session_push_notifications" = "Push notifications";
 "user_session_push_notifications_message" = "When turned on, this session will receive push notifications.";
 
 "user_other_session_security_recommendation_title" = "Security recommendation";
 "user_other_session_unverified_sessions_header_subtitle" = "Verify your sessions for enhanced secure messaging or sign out from those you don’t recognize or use anymore.";
-"user_other_session_unverified_current_session_details" =  "%@ · Your current session";
+"user_other_session_current_session_details" =  "Your current session";
 "user_other_session_verified_sessions_header_subtitle" = "For best security, sign out from any session that you don’t recognize or use anymore.";
 
 "user_other_session_filter" = "Filter";
@@ -2452,7 +2453,9 @@ To enable access, tap Settings> Location and select Always";
 // First item is client name and second item is session display name
 "user_session_name" = "%@: %@";
 
-"user_session_item_details" = "%@ · Last activity %@";
+/* %1$@ will be the verification state and %2$@ will be user_session_item_details_verification_unknown or user_other_session_unverified_current_session_details */
+"user_session_item_details" = "%1$@ · %2$@";
+"user_session_item_details_last_activity" = "Last activity %@";
 "user_inactive_session_item" = "Inactive for 90+ days";
 "user_inactive_session_item_with_date" = "Inactive for 90+ days (%@)";
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -8639,6 +8639,10 @@ public class VectorL10n: NSObject {
   public static var userOtherSessionClearFilter: String { 
     return VectorL10n.tr("Vector", "user_other_session_clear_filter") 
   }
+  /// Your current session
+  public static var userOtherSessionCurrentSessionDetails: String { 
+    return VectorL10n.tr("Vector", "user_other_session_current_session_details") 
+  }
   /// Filter
   public static var userOtherSessionFilter: String { 
     return VectorL10n.tr("Vector", "user_other_session_filter") 
@@ -8674,10 +8678,6 @@ public class VectorL10n: NSObject {
   /// Security recommendation
   public static var userOtherSessionSecurityRecommendationTitle: String { 
     return VectorL10n.tr("Vector", "user_other_session_security_recommendation_title") 
-  }
-  /// %@ · Your current session
-  public static func userOtherSessionUnverifiedCurrentSessionDetails(_ p1: String) -> String {
-    return VectorL10n.tr("Vector", "user_other_session_unverified_current_session_details", p1)
   }
   /// Verify your sessions for enhanced secure messaging or sign out from those you don’t recognize or use anymore.
   public static var userOtherSessionUnverifiedSessionsHeaderSubtitle: String { 
@@ -8747,9 +8747,13 @@ public class VectorL10n: NSObject {
   public static var userSessionDetailsTitle: String { 
     return VectorL10n.tr("Vector", "user_session_details_title") 
   }
-  /// %@ · Last activity %@
+  /// %1$@ · %2$@
   public static func userSessionItemDetails(_ p1: String, _ p2: String) -> String {
     return VectorL10n.tr("Vector", "user_session_item_details", p1, p2)
+  }
+  /// Last activity %@
+  public static func userSessionItemDetailsLastActivity(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "user_session_item_details_last_activity", p1)
   }
   /// Learn more
   public static var userSessionLearnMore: String { 
@@ -8794,6 +8798,10 @@ public class VectorL10n: NSObject {
   /// Unknown verification status
   public static var userSessionVerificationUnknown: String { 
     return VectorL10n.tr("Vector", "user_session_verification_unknown") 
+  }
+  /// Verify your current session to reveal this session's verification status.
+  public static var userSessionVerificationUnknownAdditionalInfo: String { 
+    return VectorL10n.tr("Vector", "user_session_verification_unknown_additional_info") 
   }
   /// Unknown
   public static var userSessionVerificationUnknownShort: String { 

--- a/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastService.swift
+++ b/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastService.swift
@@ -16,15 +16,6 @@
 
 import Foundation
 
-/// Voice Broadcast settings.
-@objcMembers
-final class VoiceBroadcastSettings: NSObject {
-    static let eventType = "io.element.voice_broadcast_info"
-    
-    static let voiceBroadcastContentKeyState = "state"
-    static let voiceBroadcastContentKeyChunkLength = "chunk_length"
-}
-
 /// VoiceBroadcastService handles voice broadcast.
 /// Note: Cannot use a protocol because of Objective-C compatibility
 @objcMembers

--- a/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastSettings.swift
+++ b/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastSettings.swift
@@ -1,0 +1,26 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Voice Broadcast settings.
+@objcMembers
+final class VoiceBroadcastSettings: NSObject {
+    static let eventType = "io.element.voice_broadcast_info"
+    
+    static let voiceBroadcastContentKeyState = "state"
+    static let voiceBroadcastContentKeyChunkLength = "chunk_length"
+}

--- a/RiotSwiftUI/Modules/UserSessions/Common/UserSessionInfo.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Common/UserSessionInfo.swift
@@ -93,13 +93,15 @@ extension UserSessionInfo: Equatable {
 // MARK: - Mocks
 
 extension UserSessionInfo {
-    static var mockPhone: UserSessionInfo {
+    static func mockPhone(verificationState: VerificationState = .verified,
+                          hasTimestamp: Bool = true,
+                          isCurrent: Bool = false) -> UserSessionInfo {
         UserSessionInfo(id: "1",
                         name: "Element Mobile: iOS",
                         deviceType: .mobile,
-                        verificationState: .verified,
+                        verificationState: verificationState,
                         lastSeenIP: "1.0.0.1",
-                        lastSeenTimestamp: Date().timeIntervalSince1970 - 130_000,
+                        lastSeenTimestamp: hasTimestamp ? Date().timeIntervalSince1970 : nil,
                         applicationName: "Element iOS",
                         applicationVersion: "1.9.8",
                         applicationURL: nil,
@@ -108,45 +110,7 @@ extension UserSessionInfo {
                         lastSeenIPLocation: nil,
                         clientName: nil,
                         clientVersion: nil,
-                        isActive: false,
-                        isCurrent: false)
-    }
-    
-    static var mockPhoneUnverified: UserSessionInfo {
-        UserSessionInfo(id: "1",
-                        name: "Element Mobile: iOS",
-                        deviceType: .mobile,
-                        verificationState: .unverified,
-                        lastSeenIP: "1.0.0.1",
-                        lastSeenTimestamp: Date().timeIntervalSince1970 - 130_000,
-                        applicationName: "Element iOS",
-                        applicationVersion: "1.9.8",
-                        applicationURL: nil,
-                        deviceModel: nil,
-                        deviceOS: "iOS 16.0.2",
-                        lastSeenIPLocation: nil,
-                        clientName: nil,
-                        clientVersion: nil,
-                        isActive: false,
-                        isCurrent: false)
-    }
-    
-    static var mockPhoneUnknownVerification: UserSessionInfo {
-        UserSessionInfo(id: "1",
-                        name: "Element Mobile: iOS",
-                        deviceType: .mobile,
-                        verificationState: .unknown,
-                        lastSeenIP: "1.0.0.1",
-                        lastSeenTimestamp: Date().timeIntervalSince1970 - 130_000,
-                        applicationName: "Element iOS",
-                        applicationVersion: "1.9.8",
-                        applicationURL: nil,
-                        deviceModel: nil,
-                        deviceOS: "iOS 16.0.2",
-                        lastSeenIPLocation: nil,
-                        clientName: nil,
-                        clientVersion: nil,
-                        isActive: false,
-                        isCurrent: false)
+                        isActive: true,
+                        isCurrent: isCurrent)
     }
 }

--- a/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardViewData.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardViewData.swift
@@ -83,7 +83,7 @@ struct UserSessionCardViewData {
         case .unverified:
             return VectorL10n.userSessionUnverifiedAdditionalInfo
         case .unknown:
-            return VectorL10n.userSessionUnverifiedAdditionalInfo
+            return VectorL10n.userSessionVerificationUnknownAdditionalInfo
         }
     }
     

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionName/MockUserSessionNameScreenState.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionName/MockUserSessionNameScreenState.swift
@@ -37,12 +37,12 @@ enum MockUserSessionNameScreenState: MockScreenState, CaseIterable {
         let viewModel: UserSessionNameViewModel
         switch self {
         case .initialName:
-            viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone)
+            viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone())
         case .empty:
-            viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone)
+            viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone())
             viewModel.state.bindings.sessionName = ""
         case .changedName:
-            viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone)
+            viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone())
             viewModel.state.bindings.sessionName = "iPhone SE"
         }
         

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionName/Test/Unit/UserSessionNameViewModelTests.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionName/Test/Unit/UserSessionNameViewModelTests.swift
@@ -23,7 +23,7 @@ class UserSessionNameViewModelTests: XCTestCase {
     var context: UserSessionNameViewModelType.Context!
     
     override func setUpWithError() throws {
-        viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone)
+        viewModel = UserSessionNameViewModel(sessionInfo: .mockPhone())
         context = viewModel.context
     }
 

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Service/MatrixSDK/UserSessionsOverviewService.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Service/MatrixSDK/UserSessionsOverviewService.swift
@@ -117,7 +117,7 @@ class UserSessionsOverviewService: UserSessionsOverviewServiceProtocol {
     private func sessionsOverviewData(from allSessions: [UserSessionInfo],
                                       linkDeviceEnabled: Bool) -> UserSessionsOverviewData {
         UserSessionsOverviewData(currentSession: allSessions.filter(\.isCurrent).first,
-                                 unverifiedSessions: allSessions.filter { $0.verificationState != .verified },
+                                 unverifiedSessions: allSessions.filter { $0.verificationState == .unverified && !$0.isCurrent },
                                  inactiveSessions: allSessions.filter { !$0.isActive },
                                  otherSessions: allSessions.filter { !$0.isCurrent },
                                  linkDeviceEnabled: linkDeviceEnabled)

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Test/Unit/UserSessionListItemViewDataFactoryTests.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Test/Unit/UserSessionListItemViewDataFactoryTests.swift
@@ -1,0 +1,114 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+import XCTest
+
+@testable import RiotSwiftUI
+
+class UserSessionListItemViewDataFactoryTests: XCTestCase {
+    let factory = UserSessionListItemViewDataFactory()
+    
+    func testSessionDetailsWithTimestamp() {
+        // Given other devices in each of the verification states.
+        let sessionInfoVerified = UserSessionInfo.mockPhone(verificationState: .verified)
+        let sessionInfoUnverified = UserSessionInfo.mockPhone(verificationState: .unverified)
+        let sessionInfoUnknown = UserSessionInfo.mockPhone(verificationState: .unknown)
+        
+        // When getting session details for each of them.
+        let sessionDetailsVerified = factory.create(from: sessionInfoVerified).sessionDetails
+        let sessionDetailsUnverified = factory.create(from: sessionInfoUnverified).sessionDetails
+        let sessionDetailsUnknown = factory.create(from: sessionInfoUnknown).sessionDetails
+        
+        // Then the details should be formatted correctly.
+        let lastActivityString = UserSessionLastActivityFormatter.lastActivityDateString(from: sessionInfoVerified.lastSeenTimestamp!)
+        XCTAssertEqual(sessionDetailsVerified,
+                       VectorL10n.userSessionItemDetails(VectorL10n.userSessionVerifiedShort, VectorL10n.userSessionItemDetailsLastActivity(lastActivityString)),
+                       "The details should show as verified with a last activity string when verified.")
+        XCTAssertEqual(sessionDetailsUnverified,
+                       VectorL10n.userSessionItemDetails(VectorL10n.userSessionUnverifiedShort, VectorL10n.userSessionItemDetailsLastActivity(lastActivityString)),
+                       "The details should show as unverified with a last activity string when unverified.")
+        XCTAssertEqual(sessionDetailsUnknown,
+                       VectorL10n.userSessionItemDetailsLastActivity(lastActivityString),
+                       "The details should only show the last activity string when verification is unknown.")
+    }
+    
+    func testSessionDetailsVerifiedWithoutTimestamp() {
+        // Given a verified other device
+        let sessionInfoVerified = UserSessionInfo.mockPhone(hasTimestamp: false)
+        let sessionInfoUnverified = UserSessionInfo.mockPhone(verificationState: .unverified, hasTimestamp: false)
+        let sessionInfoUnknown = UserSessionInfo.mockPhone(verificationState: .unknown, hasTimestamp: false)
+        
+        // When getting session details
+        let sessionDetailsVerified = factory.create(from: sessionInfoVerified).sessionDetails
+        let sessionDetailsUnverified = factory.create(from: sessionInfoUnverified).sessionDetails
+        let sessionDetailsUnknown = factory.create(from: sessionInfoUnknown).sessionDetails
+        
+        // Then the details should contain the verification state and a last seen date.
+        XCTAssertEqual(sessionDetailsVerified, VectorL10n.userSessionVerifiedShort,
+                       "The details should only show the verification state when no timestamp exists.")
+        XCTAssertEqual(sessionDetailsUnverified, VectorL10n.userSessionUnverifiedShort,
+                       "The details should only show the verification state when no timestamp exists.")
+        XCTAssertEqual(sessionDetailsUnknown, VectorL10n.userSessionVerificationUnknownShort,
+                       "The details should only show the verification state when no timestamp exists.")
+    }
+    
+    func testCurrentSessionDetailsWithTimestamp() {
+        // Given other devices in each of the verification states.
+        let sessionInfoVerified = UserSessionInfo.mockPhone(verificationState: .verified, isCurrent: true)
+        let sessionInfoUnverified = UserSessionInfo.mockPhone(verificationState: .unverified, isCurrent: true)
+        let sessionInfoUnknown = UserSessionInfo.mockPhone(verificationState: .unknown, isCurrent: true)
+        
+        // When getting session details for each of them.
+        let sessionDetailsVerified = factory.create(from: sessionInfoVerified).sessionDetails
+        let sessionDetailsUnverified = factory.create(from: sessionInfoUnverified).sessionDetails
+        let sessionDetailsUnknown = factory.create(from: sessionInfoUnknown).sessionDetails
+        
+        // Then the details should be formatted correctly.
+        XCTAssertEqual(sessionDetailsVerified,
+                       VectorL10n.userSessionItemDetails(VectorL10n.userSessionVerifiedShort, VectorL10n.userOtherSessionCurrentSessionDetails),
+                       "The details should show as verified with a current session string when verified.")
+        XCTAssertEqual(sessionDetailsUnverified,
+                       VectorL10n.userSessionItemDetails(VectorL10n.userSessionUnverifiedShort, VectorL10n.userOtherSessionCurrentSessionDetails),
+                       "The details should show as unverified with a current session string when unverified.")
+        XCTAssertEqual(sessionDetailsUnknown,
+                       VectorL10n.userOtherSessionCurrentSessionDetails,
+                       "The details should only show the current session string when verification is unknown.")
+    }
+    
+    func testCurrentSessionDetailsVerifiedWithoutTimestamp() {
+        // Given a verified other device
+        let sessionInfoVerified = UserSessionInfo.mockPhone(hasTimestamp: false, isCurrent: true)
+        let sessionInfoUnverified = UserSessionInfo.mockPhone(verificationState: .unverified, hasTimestamp: false, isCurrent: true)
+        let sessionInfoUnknown = UserSessionInfo.mockPhone(verificationState: .unknown, hasTimestamp: false, isCurrent: true)
+        
+        // When getting session details
+        let sessionDetailsVerified = factory.create(from: sessionInfoVerified).sessionDetails
+        let sessionDetailsUnverified = factory.create(from: sessionInfoUnverified).sessionDetails
+        let sessionDetailsUnknown = factory.create(from: sessionInfoUnknown).sessionDetails
+        
+        // Then the details should contain the verification state and a last seen date.
+        XCTAssertEqual(sessionDetailsVerified,
+                       VectorL10n.userSessionItemDetails(VectorL10n.userSessionVerifiedShort, VectorL10n.userOtherSessionCurrentSessionDetails),
+                       "The details should show as verified with a current session string when verified.")
+        XCTAssertEqual(sessionDetailsUnverified,
+                       VectorL10n.userSessionItemDetails(VectorL10n.userSessionUnverifiedShort, VectorL10n.userOtherSessionCurrentSessionDetails),
+                       "The details should show as unverified with a current session string when unverified.")
+        XCTAssertEqual(sessionDetailsUnknown,
+                       VectorL10n.userOtherSessionCurrentSessionDetails,
+                       "The details should only show the current session string when verification is unknown.")
+    }
+}

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionListItemViewDataFactory.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionListItemViewDataFactory.swift
@@ -48,32 +48,41 @@ struct UserSessionListItemViewDataFactory {
     }
     
     private func activeSessionDetails(sessionInfo: UserSessionInfo) -> String {
-        let sessionDetailsString: String
+        // Start by creating the main part of the details string.
+        var sessionDetailsString = ""
         
-        let sessionStatusText: String
+        var lastActivityDateString: String?
+        if let lastActivityDate = sessionInfo.lastSeenTimestamp {
+            lastActivityDateString = UserSessionLastActivityFormatter.lastActivityDateString(from: lastActivityDate)
+        }
+        
+        if sessionInfo.isCurrent {
+            sessionDetailsString = VectorL10n.userOtherSessionCurrentSessionDetails
+        } else if let lastActivityDateString = lastActivityDateString, lastActivityDateString.isEmpty == false {
+            sessionDetailsString = VectorL10n.userSessionItemDetailsLastActivity(lastActivityDateString)
+        }
+        
+        // Prepend the verification state if one is known.
+        let sessionStatusText: String?
         switch sessionInfo.verificationState {
         case .verified:
             sessionStatusText = VectorL10n.userSessionVerifiedShort
         case .unverified:
             sessionStatusText = VectorL10n.userSessionUnverifiedShort
         case .unknown:
-            sessionStatusText = VectorL10n.userSessionVerificationUnknownShort
+            sessionStatusText = nil
         }
         
-        var lastActivityDateString: String?
-        
-        if let lastActivityDate = sessionInfo.lastSeenTimestamp {
-            lastActivityDateString = UserSessionLastActivityFormatter.lastActivityDateString(from: lastActivityDate)
+        if let sessionStatusText = sessionStatusText {
+            if sessionDetailsString.isEmpty {
+                sessionDetailsString = sessionStatusText
+            } else {
+                sessionDetailsString = VectorL10n.userSessionItemDetails(sessionStatusText, sessionDetailsString)
+            }
+        } else if sessionDetailsString.isEmpty {
+            sessionDetailsString = VectorL10n.userSessionVerificationUnknownShort
         }
-        
-        if sessionInfo.isCurrent {
-            sessionDetailsString = VectorL10n.userOtherSessionUnverifiedCurrentSessionDetails(sessionStatusText)
-        } else if let lastActivityDateString = lastActivityDateString, lastActivityDateString.isEmpty == false {
-            sessionDetailsString = VectorL10n.userSessionItemDetails(sessionStatusText, lastActivityDateString)
-        } else {
-            sessionDetailsString = sessionStatusText
-        }
-        
+            
         return sessionDetailsString
     }
     

--- a/RiotTests/target.yml
+++ b/RiotTests/target.yml
@@ -72,3 +72,4 @@ targets:
     - path: ../Riot/Modules/Room/TimelineCells/Styles/RoomTimelineStyleIdentifier.swift
     - path: ../Riot/Modules/Room/EventMenu/EventMenuBuilder.swift
     - path: ../Riot/Modules/Room/EventMenu/EventMenuItemType.swift
+    - path: ../Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastSettings.swift


### PR DESCRIPTION
This PR updates the strings for #6832.

It also makes sure that unverified sessions card is hidden when the current session is unverified.

No changelog as it already exists from the previous PR.

| Sessions | Unknown Session |
| - | - |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-10-12 at 12 10 23](https://user-images.githubusercontent.com/6060466/195328035-a0bf8188-418c-4c46-8204-9f16dbbb734c.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-10-12 at 12 10 32](https://user-images.githubusercontent.com/6060466/195328053-be2f545a-19bd-422a-8254-0a774a9789a4.png) |
