### PR TITLE
E2EE support for Login with QR Code

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -427,9 +427,9 @@ final class BuildSettings: NSObject {
     static let newAppLayoutEnabled = true
 
     // MARK: - QR Login
-
+    
     /// Flag indicating whether the QR login enabled from login screen
-    static let qrLoginEnabledFromNotAuthenticated = false
+    static let qrLoginEnabledFromNotAuthenticated = true
     /// Flag indicating whether the QR login enabled from Device Manager screen
     static let qrLoginEnabledFromAuthenticated = false
     /// Flag indicating whether displaying QRs enabled for the QR login screens

--- a/RiotSwiftUI/Modules/Authentication/Login/Coordinator/AuthenticationLoginCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Login/Coordinator/AuthenticationLoginCoordinator.swift
@@ -31,7 +31,7 @@ enum AuthenticationLoginCoordinatorResult: CustomStringConvertible {
     /// Login was successful with the associated session created.
     case success(session: MXSession, password: String)
     /// Login was successful with the associated session created.
-    case loggedInWithQRCode(session: MXSession)
+    case loggedInWithQRCode(session: MXSession, securityCompleted: Bool)
     /// Login requested a fallback
     case fallback
     
@@ -301,8 +301,8 @@ final class AuthenticationLoginCoordinator: Coordinator, Presentable {
         coordinator.callback = { [weak self, weak coordinator] callback in
             guard let self = self, let coordinator = coordinator else { return }
             switch callback {
-            case .done(let session):
-                self.callback?(.loggedInWithQRCode(session: session))
+            case .done(let session, let securityCompleted):
+                self.callback?(.loggedInWithQRCode(session: session, securityCompleted: securityCompleted))
             }
             
             self.remove(childCoordinator: coordinator)

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Models/QRLoginCode.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Models/QRLoginCode.swift
@@ -84,6 +84,7 @@ struct QRLoginRendezvousPayload: Codable {
 
     enum Intent: String, Codable {
         case loginStart = "login.start"
+        case loginReciprocate = "login.reciprocate"
     }
     
     enum Outcome: String, Codable {

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Models/QRLoginCode.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Models/QRLoginCode.swift
@@ -43,7 +43,10 @@ struct QRLoginRendezvousPayload: Codable {
     var intent: Intent?
     var outcome: Outcome?
     
+    // swiftformat:disable:next redundantBackticks
     var protocols: [`Protocol`]?
+    
+    // swiftformat:disable:next redundantBackticks
     var `protocol`: `Protocol`?
     
     var homeserver: String?
@@ -84,10 +87,12 @@ struct QRLoginRendezvousPayload: Codable {
     }
     
     enum Outcome: String, Codable {
-        case success = "success"
-        case declined = "declined"
+        case success
+        case declined
+        case verified
     }
     
+    // swiftformat:disable:next redundantBackticks
     enum `Protocol`: String, Codable {
         case loginToken = "login_token"
     }

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/MatrixSDK/QRLoginService.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/MatrixSDK/QRLoginService.swift
@@ -283,24 +283,12 @@ class QRLoginService: NSObject, QRLoginServiceProtocol {
         
         MXLog.debug("[QRLoginService] Found verifying device info \(verifyingDeviceInfo)")
         
-        var securityCompleted = false
         if verifyingDeviceInfo.fingerprint == verifyingDeviceKey {
             MXLog.debug("[QRLoginService] Locally marking the existing device as verified \(verifyingDeviceInfo)")
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 session.crypto.setDeviceVerification(.verified, forDevice: verifiyingDeviceId, ofUser: session.myUserId) {
                     MXLog.debug("[QRLoginService] Marked the existing device as verified")
-                    
-                    MXLog.debug("[QRLoginService] Recovering secrets Through the existing device")
-                    session.crypto.crossSigning.requestPrivateKeys(toDeviceIds: [verifiyingDeviceId]) {
-                        MXLog.debug("[QRLoginService] Secrets recovered")
-                        securityCompleted = true
-                        continuation.resume(returning: ())
-                    } onPrivateKeysReceived: {
-                        // Do nothing
-                    } failure: { _ in
-                        MXLog.debug("[QRLoginService] Failed recovering secrets")
-                        continuation.resume(returning: ())
-                    }
+                    continuation.resume(returning: ())
                 } failure: { _ in
                     MXLog.debug("[QRLoginService] Failed marking the existing device as verified")
                     continuation.resume(returning: ())
@@ -309,7 +297,7 @@ class QRLoginService: NSObject, QRLoginServiceProtocol {
         }
         
         MXLog.debug("[QRLoginService] Login flow finished, returning session")
-        state = .completed(session: session, securityCompleted: securityCompleted)
+        state = .completed(session: session, securityCompleted: true)
     }
     
     private func declineRendezvous() async {

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/MatrixSDK/QRLoginService.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/MatrixSDK/QRLoginService.swift
@@ -169,7 +169,8 @@ class QRLoginService: NSObject, QRLoginServiceProtocol {
         MXLog.debug("[QRLoginService] processQRLoginCode: \(code)")
         state = .connectingToDevice
         
-        guard let uri = code.rendezvous.transport?.uri,
+        guard code.intent == QRLoginRendezvousPayload.Intent.loginReciprocate.rawValue,
+              let uri = code.rendezvous.transport?.uri,
               let rendezvousURL = URL(string: uri),
               let key = code.rendezvous.key else {
             MXLog.debug("[QRLoginService] QR code invalid")
@@ -189,8 +190,6 @@ class QRLoginService: NSObject, QRLoginServiceProtocol {
         }
         
         state = .waitingForConfirmation(validationCode)
-        
-        // TODO: check compatibility of intents
         
         MXLog.debug("[QRLoginService] Waiting for available protocols")
         guard case let .success(data) = await rendezvousService.receive(),

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/Mock/MockQRLoginService.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/Mock/MockQRLoginService.swift
@@ -26,7 +26,7 @@ class MockQRLoginService: QRLoginServiceProtocol {
          canDisplayQR: Bool = true) {
         self.state = state
         self.mode = mode
-        self.mockCanDisplayQR = canDisplayQR
+        mockCanDisplayQR = canDisplayQR
     }
 
     // MARK: - QRLoginServiceProtocol

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/QRLoginServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/QRLoginServiceProtocol.swift
@@ -46,7 +46,7 @@ enum QRLoginServiceState: Equatable {
     case waitingForRemoteSignIn
     case failed(error: QRLoginServiceError)
     // This is really an MXSession but that would break RiotSwiftUI
-    case completed(session: Any)
+    case completed(session: Any, securityCompleted: Bool)
 
     static func == (lhs: QRLoginServiceState, rhs: QRLoginServiceState) -> Bool {
         switch (lhs, rhs) {

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Loading/MockAuthenticationQRLoginLoadingScreenState.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Loading/MockAuthenticationQRLoginLoadingScreenState.swift
@@ -48,7 +48,7 @@ enum MockAuthenticationQRLoginLoadingScreenState: MockScreenState, CaseIterable 
         case .waitingForRemoteSignIn:
             viewModel = .init(qrLoginService: MockQRLoginService(withState: .waitingForRemoteSignIn))
         case .completed:
-            viewModel = .init(qrLoginService: MockQRLoginService(withState: .completed(session: "")))
+            viewModel = .init(qrLoginService: MockQRLoginService(withState: .completed(session: "", securityCompleted: true)))
         }
         
         // can simulate service and viewModel actions here if needs be.

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Scan/Coordinator/AuthenticationQRLoginScanCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Scan/Coordinator/AuthenticationQRLoginScanCoordinator.swift
@@ -15,8 +15,8 @@
 //
 
 import CommonKit
-import SwiftUI
 import MatrixSDK
+import SwiftUI
 
 struct AuthenticationQRLoginScanCoordinatorParameters {
     let navigationRouter: NavigationRouterType

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Start/Coordinator/AuthenticationQRLoginStartCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Start/Coordinator/AuthenticationQRLoginStartCoordinator.swift
@@ -25,7 +25,7 @@ struct AuthenticationQRLoginStartCoordinatorParameters {
 
 enum AuthenticationQRLoginStartCoordinatorResult {
     /// Login with QR done
-    case done(session: MXSession)
+    case done(session: MXSession, securityCompleted: Bool)
 }
 
 final class AuthenticationQRLoginStartCoordinator: Coordinator, Presentable {
@@ -119,12 +119,12 @@ final class AuthenticationQRLoginStartCoordinator: Coordinator, Presentable {
             default:
                 showFailureScreenIfNeeded()
             }
-        case .completed(let session):
+        case .completed(let session, let securityCompleted):
             guard let session = session as? MXSession else {
                 showFailureScreenIfNeeded()
                 return
             }
-            callback?(.done(session: session))
+            callback?(.done(session: session, securityCompleted: securityCompleted))
         default:
             break
         }

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Test/Unit/UserSessionListItemViewDataFactoryTests.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Test/Unit/UserSessionListItemViewDataFactoryTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionsOverview.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionsOverview.swift
@@ -24,7 +24,7 @@ struct UserSessionsOverview: View {
     private let maxOtherSessionsToDisplay = 5
     
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             VStack(alignment: .leading, spacing: 0) {
                 ScrollView {
                     if hasSecurityRecommendations {

--- a/RiotTests/Modules/Authentication/Mocks/MockAuthenticationRestClient.swift
+++ b/RiotTests/Modules/Authentication/Mocks/MockAuthenticationRestClient.swift
@@ -216,6 +216,6 @@ class MockAuthenticationRestClient: AuthenticationRestClient {
     // MARK: Versions
 
     func supportedMatrixVersions() async throws -> MXMatrixVersions {
-        throw MockError.unhandled
+        return MXMatrixVersions()
     }
 }


### PR DESCRIPTION
This PR adds E2EE setup support for sessions created through QR Code login rendezvous channels. It locally verifies the existing devices and then proceeds to recoving the secrets and finishing the session setup. It also slightly changes the authentication flows to cater to this