### PR TITLE
Device Manager: Navigating to session overview goes to session details

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
@@ -149,8 +149,8 @@ final class UserSessionsFlowCoordinator: Coordinator, Presentable {
         coordinator.completion = { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case let .openSessionDetails(sessionInfo: session):
-                self.openSessionDetails(sessionInfo: session)
+            case let .openSessionOverview(sessionInfo: session):
+                self.openSessionOverview(sessionInfo: session)
             }
         }
         pushScreen(with: coordinator)

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/Coordinator/UserOtherSessionsCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/Coordinator/UserOtherSessionsCoordinator.swift
@@ -55,7 +55,7 @@ final class UserOtherSessionsCoordinator: Coordinator, Presentable {
             guard let self = self else { return }
             switch result {
             case let .showUserSessionOverview(sessionInfo: session):
-                self.completion?(.openSessionDetails(sessionInfo: session))
+                self.completion?(.openSessionOverview(sessionInfo: session))
             }
             MXLog.debug("[UserOtherSessionsCoordinator] UserOtherSessionsViewModel did complete with result: \(result).")
         }

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/UserOtherSessionsModels.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/UserOtherSessionsModels.swift
@@ -19,7 +19,7 @@ import Foundation
 // MARK: - Coordinator
 
 enum UserOtherSessionsCoordinatorResult {
-    case openSessionDetails(sessionInfo: UserSessionInfo)
+    case openSessionOverview(sessionInfo: UserSessionInfo)
 }
 
 // MARK: View model

--- a/changelog.d/6877.bugfix
+++ b/changelog.d/6877.bugfix
@@ -1,0 +1,1 @@
+Device Manager: Navigating to session overview goes to session details.


### PR DESCRIPTION
closes #6877

Selecting a session from other sessions screen should go to session overview. 