### PR TITLE
Device manager: Identify inactive sessions.

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardView.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardView.swift
@@ -65,13 +65,18 @@ struct UserSessionCardView: View {
             
             if showExtraInformations {
                 VStack(spacing: 2) {
-                    if let lastActivityDateString = viewData.lastActivityDateString, lastActivityDateString.isEmpty == false {
-                        Text(lastActivityDateString)
-                            .font(theme.fonts.footnote)
-                            .foregroundColor(theme.colors.secondaryContent)
-                            .multilineTextAlignment(.center)
+                    HStack {
+                        if let lastActivityIcon = viewData.lastActivityIcon {
+                            Image(lastActivityIcon)
+                                .padding(.leading, 2)
+                        }
+                        if let lastActivityDateString = viewData.lastActivityDateString, lastActivityDateString.isEmpty == false {
+                            Text(lastActivityDateString)
+                                .font(theme.fonts.footnote)
+                                .foregroundColor(theme.colors.secondaryContent)
+                                .multilineTextAlignment(.center)
+                        }
                     }
-                    
                     if let lastSeenIPInfo = viewData.lastSeenIPInfo, lastSeenIPInfo.isEmpty == false {
                         Text(lastSeenIPInfo)
                             .font(theme.fonts.footnote)

--- a/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardViewData.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardViewData.swift
@@ -32,6 +32,8 @@ struct UserSessionCardViewData {
     
     let lastActivityDateString: String?
     
+    var lastActivityIcon: String?
+    
     let lastSeenIPInfo: String?
     
     let deviceAvatarViewData: DeviceAvatarViewData
@@ -93,17 +95,22 @@ struct UserSessionCardViewData {
          verificationState: UserSessionInfo.VerificationState,
          lastActivityTimestamp: TimeInterval?,
          lastSeenIP: String?,
-         isCurrentSessionDisplayMode: Bool = false) {
+         isCurrentSessionDisplayMode: Bool = false,
+         isActive: Bool) {
         self.sessionId = sessionId
         sessionName = UserSessionNameFormatter.sessionName(deviceType: deviceType, sessionDisplayName: sessionDisplayName)
         self.verificationState = verificationState
         
         var lastActivityDateString: String?
-        
         if let lastActivityTimestamp = lastActivityTimestamp {
-            lastActivityDateString = UserSessionLastActivityFormatter.lastActivityDateString(from: lastActivityTimestamp)
+            if isActive {
+                lastActivityDateString = UserSessionLastActivityFormatter.lastActivityDateString(from: lastActivityTimestamp)
+            } else {
+                let dateString = InactiveUserSessionLastActivityFormatter.lastActivityDateString(from: lastActivityTimestamp)
+                lastActivityDateString = VectorL10n.userInactiveSessionItemWithDate(dateString)
+                lastActivityIcon = Asset.Images.userSessionListItemInactiveSession.name
+            }
         }
-        
         self.lastActivityDateString = lastActivityDateString
         lastSeenIPInfo = lastSeenIP
         deviceAvatarViewData = DeviceAvatarViewData(deviceType: deviceType, verificationState: verificationState)
@@ -120,6 +127,7 @@ extension UserSessionCardViewData {
                   verificationState: sessionInfo.verificationState,
                   lastActivityTimestamp: sessionInfo.lastSeenTimestamp,
                   lastSeenIP: sessionInfo.lastSeenIP,
-                  isCurrentSessionDisplayMode: sessionInfo.isCurrent)
+                  isCurrentSessionDisplayMode: sessionInfo.isCurrent,
+                  isActive: sessionInfo.isActive)
     }
 }

--- a/changelog.d/6881.wip
+++ b/changelog.d/6881.wip
@@ -1,0 +1,1 @@
+Device manager: Identify inactive sessions.


### PR DESCRIPTION
closes #6881 

Session tiles for inactive sessions show ‘inactive for 90+ days’ UI

![Screenshot 2022-10-14 at 12 18 59](https://user-images.githubusercontent.com/1991792/195811393-9a922b65-61e7-4255-bfe0-d9d0e20e4752.png)
