### PR TITLE
Filter out application section in session details (PSG-898)

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/UserSessionDetails/UserSessionDetailsViewModel.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionDetails/UserSessionDetailsViewModel.swift
@@ -77,15 +77,15 @@ class UserSessionDetailsViewModel: UserSessionDetailsViewModelType, UserSessionD
     private func applicationSection(sessionInfo: UserSessionInfo) -> UserSessionDetailsSectionViewData? {
         var sessionItems: [UserSessionDetailsSectionItemViewData] = []
 
-        if let name = sessionInfo.applicationName {
+        if let name = sessionInfo.applicationName, !name.isEmpty {
             sessionItems.append(.init(title: VectorL10n.userSessionDetailsApplicationName,
                                       value: name))
         }
-        if let version = sessionInfo.applicationVersion {
+        if let version = sessionInfo.applicationVersion, !version.isEmpty {
             sessionItems.append(.init(title: VectorL10n.userSessionDetailsApplicationVersion,
                                       value: version))
         }
-        if let url = sessionInfo.applicationURL {
+        if let url = sessionInfo.applicationURL, !url.isEmpty {
             sessionItems.append(.init(title: VectorL10n.userSessionDetailsApplicationUrl,
                                       value: url))
         }

--- a/changelog.d/pr-6898.bugfix
+++ b/changelog.d/pr-6898.bugfix
@@ -1,0 +1,1 @@
+Filter out application section in session details if needed.


### PR DESCRIPTION
Ticket -> https://element-io.atlassian.net/browse/PSG-898

**Description**
This PR hides the "Application" section in the session details when no information are available.