### PR TITLE
Codecov flags + PR build labels

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,3 +63,5 @@ jobs:
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          flags: unittests

--- a/.github/workflows/ci-ui-tests.yml
+++ b/.github/workflows/ci-ui-tests.yml
@@ -61,4 +61,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          flags: uitests
         

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -27,7 +27,11 @@ jobs:
   build:
     # Run job if secrets are available (not available for forks).
     needs: [check-secret]
-    if: needs.check-secret.outputs.out-key == 'true'
+    if: |
+      needs.check-secret.outputs.out-key == 'true' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Trigger-PR-Build')))
+
     name: Release
     runs-on: macos-12
     

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,12 @@ coverage:
 
 ignore:
   - "Riot/Generated"  # ignore the folder and all its contents
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - name_prefix: project-
+        type: project
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
This PR:
* introduces codecov flags for unit and ui tests and carries them forward automatically
* makes it so alpha builds only happen when the PR is labeled with `Trigger-PR-Build`