### PR TITLE
Deprecate legacy device-to-device verification

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.h
+++ b/Riot/Modules/Application/LegacyAppDelegate.h
@@ -195,7 +195,9 @@ UINavigationControllerDelegate
 - (BOOL)presentIncomingKeyVerificationRequest:(id<MXKeyVerificationRequest>)incomingKeyVerificationRequest
                                     inSession:(MXSession*)session;
 
-- (BOOL)presentUserVerificationForRoomMember:(MXRoomMember*)roomMember session:(MXSession*)mxSession;
+- (BOOL)presentUserVerificationForRoomMember:(MXRoomMember*)roomMember
+                                     session:(MXSession*)mxSession
+                                  completion:(void (^)(void))completion;
 
 - (BOOL)presentCompleteSecurityForSession:(MXSession*)mxSession;
 

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -128,6 +128,11 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
      If any the currently displayed key verification dialog
      */
     KeyVerificationCoordinatorBridgePresenter *keyVerificationCoordinatorBridgePresenter;
+    
+    /**
+     Completion block for the requester of key verification
+     */
+    void (^keyVerificationCompletionBlock)(void);
 
     /**
      Currently displayed secure backup setup
@@ -3697,7 +3702,9 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     return presented;
 }
 
-- (BOOL)presentUserVerificationForRoomMember:(MXRoomMember*)roomMember session:(MXSession*)mxSession
+- (BOOL)presentUserVerificationForRoomMember:(MXRoomMember*)roomMember
+                                     session:(MXSession*)mxSession
+                                  completion:(void (^)(void))completion;
 {
     MXLogDebug(@"[AppDelegate][MXKeyVerification] presentUserVerificationForRoomMember: %@", roomMember);
     
@@ -3710,6 +3717,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         [keyVerificationCoordinatorBridgePresenter presentFrom:self.presentedViewController roomMember:roomMember animated:YES];
         
         presented = YES;
+        
+        keyVerificationCompletionBlock = completion;
     }
     else
     {
@@ -3762,6 +3771,11 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     }];
     
     keyVerificationCoordinatorBridgePresenter = nil;
+    
+    if (keyVerificationCompletionBlock) {
+        keyVerificationCompletionBlock();
+    }
+    keyVerificationCompletionBlock = nil;
 }
 
 #pragma mark - New request

--- a/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinator.swift
@@ -324,12 +324,8 @@ extension KeyVerificationCoordinator: KeyVerificationDataLoadingCoordinatorDeleg
 
 // MARK: - DeviceVerificationStartCoordinatorDelegate
 extension KeyVerificationCoordinator: DeviceVerificationStartCoordinatorDelegate {
-    func deviceVerificationStartCoordinator(_ coordinator: DeviceVerificationStartCoordinatorType, didCompleteWithOutgoingTransaction transaction: MXSASTransaction) {
-        self.showVerifyBySAS(transaction: transaction, animated: true)
-    }
-
-    func deviceVerificationStartCoordinator(_ coordinator: DeviceVerificationStartCoordinatorType, didTransactionCancelled transaction: MXSASTransaction) {
-        self.didCancel()
+    func deviceVerificationStartCoordinator(_ coordinator: DeviceVerificationStartCoordinatorType, otherDidAcceptRequest request: MXKeyVerificationRequest) {
+        self.showVerifyByScanning(keyVerificationRequest: request, animated: true)
     }
 
     func deviceVerificationStartCoordinatorDidCancel(_ coordinator: DeviceVerificationStartCoordinatorType) {

--- a/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartCoordinator.swift
@@ -63,13 +63,9 @@ extension DeviceVerificationStartCoordinator: DeviceVerificationStartViewModelCo
     func deviceVerificationStartViewModelDidUseLegacyVerification(_ viewModel: DeviceVerificationStartViewModelType) {
         self.delegate?.deviceVerificationStartCoordinatorDidCancel(self) 
     }
-
-    func deviceVerificationStartViewModel(_ viewModel: DeviceVerificationStartViewModelType, didCompleteWithOutgoingTransaction transaction: MXSASTransaction) {
-        self.delegate?.deviceVerificationStartCoordinator(self, didCompleteWithOutgoingTransaction: transaction)
-    }
-
-    func deviceVerificationStartViewModel(_ viewModel: DeviceVerificationStartViewModelType, didTransactionCancelled transaction: MXSASTransaction) {
-        self.delegate?.deviceVerificationStartCoordinator(self, didTransactionCancelled: transaction)
+    
+    func deviceVerificationStartViewModel(_ viewModel: DeviceVerificationStartViewModelType, otherDidAcceptRequest request: MXKeyVerificationRequest) {
+        self.delegate?.deviceVerificationStartCoordinator(self, otherDidAcceptRequest: request)
     }
     
     func deviceVerificationStartViewModelDidCancel(_ viewModel: DeviceVerificationStartViewModelType) {

--- a/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartCoordinatorType.swift
+++ b/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartCoordinatorType.swift
@@ -19,8 +19,7 @@
 import Foundation
 
 protocol DeviceVerificationStartCoordinatorDelegate: AnyObject {
-    func deviceVerificationStartCoordinator(_ coordinator: DeviceVerificationStartCoordinatorType, didCompleteWithOutgoingTransaction transaction: MXSASTransaction)
-    func deviceVerificationStartCoordinator(_ coordinator: DeviceVerificationStartCoordinatorType, didTransactionCancelled transaction: MXSASTransaction)
+    func deviceVerificationStartCoordinator(_ coordinator: DeviceVerificationStartCoordinatorType, otherDidAcceptRequest request: MXKeyVerificationRequest)
 
     func deviceVerificationStartCoordinatorDidCancel(_ coordinator: DeviceVerificationStartCoordinatorType)
 }

--- a/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartViewModel.swift
@@ -29,7 +29,7 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     private let otherUser: MXUser
     private let otherDevice: MXDeviceInfo
 
-    private var transaction: MXSASTransaction!
+    private var request: MXKeyVerificationRequest?
     
     // MARK: Public
 
@@ -52,12 +52,12 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
         case .beginVerifying:
             self.beginVerifying()
         case .verifyUsingLegacy:
-           self.cancelTransaction()
+           self.cancelRequest()
            self.update(viewState: .verifyUsingLegacy(self.session, self.otherDevice))
         case .verifiedUsingLegacy:
             self.coordinatorDelegate?.deviceVerificationStartViewModelDidUseLegacyVerification(self)
         case .cancel:
-            self.cancelTransaction()
+            self.cancelRequest()
             self.coordinatorDelegate?.deviceVerificationStartViewModelDidCancel(self)
         }
     }
@@ -67,30 +67,22 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     private func beginVerifying() {
         self.update(viewState: .loading)
 
-        self.verificationManager.beginKeyVerification(withUserId: self.otherUser.userId, andDeviceId: self.otherDevice.deviceId, method: MXKeyVerificationMethodSAS, success: { [weak self] (transaction) in
-
-            guard let sself = self else {
-                return
-            }
-            guard let sasTransaction = transaction as? MXSASTransaction, !sasTransaction.isIncoming  else {
+        self.verificationManager.requestVerificationByToDevice(withUserId: otherUser.userId, deviceIds: [otherDevice.deviceId], methods: [MXKeyVerificationMethodSAS], success: { [weak self] request in
+            guard let self = self else {
                 return
             }
 
-            sself.transaction = sasTransaction
+            self.request = request
 
-            sself.update(viewState: .loaded)
-            sself.registerTransactionDidStateChangeNotification(transaction: sasTransaction)
+            self.update(viewState: .loaded)
+            self.registerKeyVerificationRequestDidChangeNotification(for: request)
         }, failure: {[weak self]  error in
             self?.update(viewState: .error(error))
         })
     }
 
-    private func cancelTransaction() {
-        guard let transaction = self.transaction  else {
-            return
-        }
-
-        transaction.cancel(with: MXTransactionCancelCode.user())
+    private func cancelRequest() {
+        request?.cancel(with: MXTransactionCancelCode.user(), success: nil)
     }
     
     private func update(viewState: DeviceVerificationStartViewState) {
@@ -98,37 +90,41 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     }
 
 
-    // MARK: - MXKeyVerificationTransactionDidChange
+    // MARK: - MXKeyVerificationRequestDidChange
 
-    private func registerTransactionDidStateChangeNotification(transaction: MXSASTransaction) {
-        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
+    private func registerKeyVerificationRequestDidChangeNotification(for request: MXKeyVerificationRequest) {
+        NotificationCenter.default.addObserver(self, selector: #selector(requestDidStateChange(notification:)), name: .MXKeyVerificationRequestDidChange, object: request)
     }
     
-    private func unregisterTransactionDidStateChangeNotification() {
-        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
+    private func unregisterKeyVerificationRequestDidChangeNotification() {
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationRequestDidChange, object: nil)
     }
-
-    @objc private func transactionDidStateChange(notification: Notification) {
-        guard let transaction = notification.object as? MXSASTransaction, !transaction.isIncoming else {
+    
+    @objc private func requestDidStateChange(notification: Notification) {
+        guard let request = notification.object as? MXKeyVerificationRequest, request.requestId == self.request?.requestId else {
             return
         }
 
-        switch transaction.state {
-        case MXSASTransactionStateShowSAS:
-            self.unregisterTransactionDidStateChangeNotification()
-            self.coordinatorDelegate?.deviceVerificationStartViewModel(self, didCompleteWithOutgoingTransaction: transaction)
-        case MXSASTransactionStateCancelled:
-            guard let reason = transaction.reasonCancelCode else {
+        switch request.state {
+        case MXKeyVerificationRequestStateAccepted, MXKeyVerificationRequestStateReady:
+            self.unregisterKeyVerificationRequestDidChangeNotification()
+            self.coordinatorDelegate?.deviceVerificationStartViewModel(self, otherDidAcceptRequest: request)
+            
+        case MXKeyVerificationRequestStateCancelled:
+            guard let reason = request.reasonCancelCode else {
                 return
             }
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterKeyVerificationRequestDidChangeNotification()
             self.update(viewState: .cancelled(reason))
-        case MXSASTransactionStateCancelledByMe:
-            guard let reason = transaction.reasonCancelCode else {
+        case MXKeyVerificationRequestStateCancelledByMe:
+            guard let reason = request.reasonCancelCode else {
                 return
             }
-            self.unregisterTransactionDidStateChangeNotification()
+            self.unregisterKeyVerificationRequestDidChangeNotification()
             self.update(viewState: .cancelledByMe(reason))
+        case MXKeyVerificationRequestStateExpired:
+            self.unregisterKeyVerificationRequestDidChangeNotification()
+            self.update(viewState: .error(UserVerificationStartViewModelError.keyVerificationRequestExpired))
         default:
             break
         }

--- a/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartViewModelType.swift
+++ b/Riot/Modules/KeyVerification/Device/Start/DeviceVerificationStartViewModelType.swift
@@ -25,8 +25,7 @@ protocol DeviceVerificationStartViewModelViewDelegate: AnyObject {
 protocol DeviceVerificationStartViewModelCoordinatorDelegate: AnyObject {
     func deviceVerificationStartViewModelDidUseLegacyVerification(_ viewModel: DeviceVerificationStartViewModelType)
 
-    func deviceVerificationStartViewModel(_ viewModel: DeviceVerificationStartViewModelType, didCompleteWithOutgoingTransaction transaction: MXSASTransaction)
-    func deviceVerificationStartViewModel(_ viewModel: DeviceVerificationStartViewModelType, didTransactionCancelled transaction: MXSASTransaction)
+    func deviceVerificationStartViewModel(_ viewModel: DeviceVerificationStartViewModelType, otherDidAcceptRequest request: MXKeyVerificationRequest)
 
     func deviceVerificationStartViewModelDidCancel(_ viewModel: DeviceVerificationStartViewModelType)
 }

--- a/Riot/Modules/KeyVerification/User/UserVerificationCoordinator.swift
+++ b/Riot/Modules/KeyVerification/User/UserVerificationCoordinator.swift
@@ -189,6 +189,7 @@ extension UserVerificationCoordinator: KeyVerificationCoordinatorDelegate {
     
     func keyVerificationCoordinatorDidComplete(_ coordinator: KeyVerificationCoordinatorType, otherUserId: String, otherDeviceId: String) {
         dismissPresenter(coordinator: coordinator)
+        delegate?.userVerificationCoordinatorDidComplete(self)
     }
     
     func keyVerificationCoordinatorDidCancel(_ coordinator: KeyVerificationCoordinatorType) {

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -440,7 +440,9 @@
 
 - (void)startUserVerification
 {
-    [[AppDelegate theDelegate] presentUserVerificationForRoomMember:self.mxRoomMember session:self.mainSession];
+    [[AppDelegate theDelegate] presentUserVerificationForRoomMember:self.mxRoomMember session:self.mainSession completion:^{
+        [self refreshUserEncryptionTrustLevel];
+    }];
 }
 
 - (void)presentUserVerification
@@ -1332,6 +1334,7 @@
 
 - (void)keyVerificationCoordinatorBridgePresenterDelegateDidComplete:(KeyVerificationCoordinatorBridgePresenter *)coordinatorBridgePresenter otherUserId:(NSString * _Nonnull)otherUserId otherDeviceId:(NSString * _Nonnull)otherDeviceId
 {
+    [self refreshUserEncryptionTrustLevel];
     [self dismissKeyVerificationCoordinatorBridgePresenter];
 }
 

--- a/changelog.d/pr-6937.change
+++ b/changelog.d/pr-6937.change
@@ -1,0 +1,1 @@
+Verification: Deprecate legacy device-to-device verification


### PR DESCRIPTION
Corresponding [SDK change](https://github.com/matrix-org/matrix-ios-sdk/pull/1613)

Deprecate legacy device-to-device verification that begins with `m.key.verification.start` events rather than `m.key.verification.request`. This means that device verification will be observing verification request rather than a transaction