### PR TITLE
Display info dialogs when we prevent the user from starting a new voice broadcast

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2189,6 +2189,12 @@ Tap the + to start adding people.";
 "voice_message_stop_locked_mode_recording" = "Tap on your recording to stop or listen";
 "voice_message_lock_screen_placeholder" = "Voice message";
 
+// Mark: - Voice broadcast
+"voice_broadcast_unauthorized_title" = "Can't start a new voice broadcast";
+"voice_broadcast_permission_denied_message" = "You don't have the required permissions to start a voice broadcast in this room. Contact a room administrator to upgrade your permissions.";
+"voice_broadcast_blocked_by_someone_else_message" = "Someone else is already recording a voice broadcast. Wait for their voice broadcast to end to start a new one.";
+"voice_broadcast_already_in_progress_message" = "You are already recording a voice broadcast. Please end your current voice broadcast to start a new one.";
+
 // Mark: - Version check
 
 "version_check_banner_title_supported" = "We’re ending support for iOS %@";
@@ -2503,6 +2509,7 @@ To enable access, tap Settings> Location and select Always";
 "wysiwyg_composer_start_action_location" = "Location";
 "wysiwyg_composer_start_action_camera" = "Camera";
 "wysiwyg_composer_start_action_text_formatting" = "Text Formatting";
+"wysiwyg_composer_start_action_voice_broadcast" = "Voice broadcast";
 
 // Formatting Actions
 "wysiwyg_composer_format_action_bold" = "Apply bold format";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -9051,6 +9051,22 @@ public class VectorL10n: NSObject {
   public static var voice: String { 
     return VectorL10n.tr("Vector", "voice") 
   }
+  /// You are already recording a voice broadcast. Please end your current voice broadcast to start a new one.
+  public static var voiceBroadcastAlreadyInProgressMessage: String { 
+    return VectorL10n.tr("Vector", "voice_broadcast_already_in_progress_message") 
+  }
+  /// Someone else is already recording a voice broadcast. Wait for their voice broadcast to end to start a new one.
+  public static var voiceBroadcastBlockedBySomeoneElseMessage: String { 
+    return VectorL10n.tr("Vector", "voice_broadcast_blocked_by_someone_else_message") 
+  }
+  /// You don't have the required permissions to start a voice broadcast in this room. Contact a room administrator to upgrade your permissions.
+  public static var voiceBroadcastPermissionDeniedMessage: String { 
+    return VectorL10n.tr("Vector", "voice_broadcast_permission_denied_message") 
+  }
+  /// Can't start a new voice broadcast
+  public static var voiceBroadcastUnauthorizedTitle: String { 
+    return VectorL10n.tr("Vector", "voice_broadcast_unauthorized_title") 
+  }
   /// Voice message
   public static var voiceMessageLockScreenPlaceholder: String { 
     return VectorL10n.tr("Vector", "voice_message_lock_screen_placeholder") 
@@ -9206,6 +9222,10 @@ public class VectorL10n: NSObject {
   /// Text Formatting
   public static var wysiwygComposerStartActionTextFormatting: String { 
     return VectorL10n.tr("Vector", "wysiwyg_composer_start_action_text_formatting") 
+  }
+  /// Voice broadcast
+  public static var wysiwygComposerStartActionVoiceBroadcast: String { 
+    return VectorL10n.tr("Vector", "wysiwyg_composer_start_action_voice_broadcast") 
   }
   /// Yes
   public static var yes: String { 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1775,15 +1775,20 @@ static CGSize kThreadListBarButtonItemImageSize;
     || self.customizedRoomDataSource.jitsiWidget;
 }
 
+- (BOOL)canSendStateEventWithType:(MXEventTypeString)eventTypeString
+{
+    MXRoomPowerLevels *powerLevels = [self.roomDataSource.roomState powerLevels];
+    NSInteger requiredPower = [powerLevels minimumPowerLevelForSendingEventAsStateEvent:eventTypeString];
+    NSInteger myPower = [powerLevels powerLevelOfUserWithUserID:self.roomDataSource.mxSession.myUserId];
+    return myPower >= requiredPower;
+}
+
 /**
  Returns a flag for the current user whether it's privileged to add/remove Jitsi widgets to this room.
  */
 - (BOOL)canEditJitsiWidget
 {
-    MXRoomPowerLevels *powerLevels = [self.roomDataSource.roomState powerLevels];
-    NSInteger requiredPower = [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kWidgetModularEventTypeString];
-    NSInteger myPower = [powerLevels powerLevelOfUserWithUserID:self.roomDataSource.mxSession.myUserId];
-    return myPower >= requiredPower;
+    return [self canSendStateEventWithType:kWidgetModularEventTypeString];
 }
 
 - (void)registerURLPreviewNotifications
@@ -2327,26 +2332,7 @@ static CGSize kThreadListBarButtonItemImageSize;
             if ([self.inputToolbarView isKindOfClass:RoomInputToolbarView.class]) {
                 ((RoomInputToolbarView *) self.inputToolbarView).actionMenuOpened = NO;
             }
-            
-            // TODO: Init and start voice broadcast
-            MXSession* session = self.roomDataSource.mxSession;
-            [session getOrCreateVoiceBroadcastServiceFor:self.roomDataSource.room completion:^(VoiceBroadcastService *voiceBroadcastService) {
-                if (voiceBroadcastService) {
-                    if ([VoiceBroadcastInfo isStoppedFor:[voiceBroadcastService getState]]) {
-                        [session.voiceBroadcastService startVoiceBroadcastWithSuccess:^(NSString * _Nullable success) {
-                        
-                        } failure:^(NSError * _Nonnull error) {
-                            
-                        }];
-                    } else {
-                        [session.voiceBroadcastService stopVoiceBroadcastWithSuccess:^(NSString * _Nullable success) {
-                        
-                        } failure:^(NSError * _Nonnull error) {
-                            
-                        }];
-                    }
-                }
-            }];            
+            [self roomInputToolbarViewDidTapVoiceBroadcast];
         }]];
     }
     roomInputView.actionsBar.actionItems = actionItems;
@@ -2434,6 +2420,48 @@ static CGSize kThreadListBarButtonItemImageSize;
     [documentPickerPresenter presentDocumentPickerWith:allowedUTIs from:self animated:YES completion:nil];
     
     self.documentPickerPresenter = documentPickerPresenter;
+}
+
+- (void)roomInputToolbarViewDidTapVoiceBroadcast
+{
+    // Check first the room permission
+    if (![self canSendStateEventWithType:VoiceBroadcastSettings.eventType])
+    {
+        [self showAlertWithTitle:[VectorL10n voiceBroadcastUnauthorizedTitle] message:[VectorL10n voiceBroadcastPermissionDeniedMessage]];
+        return;
+    }
+    
+    MXSession* session = self.roomDataSource.mxSession;
+    // Check whether the user is not already broadcasting here or in another room
+    if (session.voiceBroadcastService)
+    {
+        [self showAlertWithTitle:[VectorL10n voiceBroadcastUnauthorizedTitle] message:[VectorL10n voiceBroadcastAlreadyInProgressMessage]];
+        
+        //*** Temporary code - To be removed ***
+        // We stop here the current voice broadcasting (required until the actual stop button is available)
+        [session.voiceBroadcastService stopVoiceBroadcastWithSuccess:^(NSString * _Nullable success) {
+            [session tearDownVoiceBroadcastService];
+        } failure:^(NSError * _Nonnull error) {
+        }];
+        //*** End ***
+        
+        return;
+    }
+    
+    // Request the voice broadcast service to start recording - No service is returned if someone else is already broadcasting in the room
+    [session getOrCreateVoiceBroadcastServiceFor:self.roomDataSource.room completion:^(VoiceBroadcastService *voiceBroadcastService) {
+        if (voiceBroadcastService) {
+            [voiceBroadcastService startVoiceBroadcastWithSuccess:^(NSString * _Nullable success) {
+            
+            } failure:^(NSError * _Nonnull error) {
+                
+            }];
+        }
+        else
+        {
+            [self showAlertWithTitle:[VectorL10n voiceBroadcastUnauthorizedTitle] message:[VectorL10n voiceBroadcastBlockedBySomeoneElseMessage]];
+        }
+    }];
 }
 
 /**
@@ -5069,6 +5097,10 @@ static CGSize kThreadListBarButtonItemImageSize;
     if (RiotSettings.shared.roomScreenAllowFilesAction)
     {
         [actionItems addObject:@(ComposerCreateActionAttachments)];
+    }
+    if (RiotSettings.shared.enableVoiceBroadcast && !self.isNewDirectChat)
+    {
+        [actionItems addObject:@(ComposerCreateActionVoiceBroadcast)];
     }
     if (BuildSettings.pollsEnabled && self.displayConfiguration.sendingPollsEnabled && !self.isNewDirectChat)
     {
@@ -8006,6 +8038,9 @@ static CGSize kThreadListBarButtonItemImageSize;
                 break;
             case ComposerCreateActionAttachments:
                 [self roomInputToolbarViewDidTapFileUpload];
+                break;
+            case ComposerCreateActionVoiceBroadcast:
+                [self roomInputToolbarViewDidTapVoiceBroadcast];
                 break;
             case ComposerCreateActionPolls:
                 [self.delegate roomViewControllerDidRequestPollCreationFormPresentation:self];

--- a/Riot/Modules/VoiceBroadcast/MXSession+VoiceBroadcast.swift
+++ b/Riot/Modules/VoiceBroadcast/MXSession+VoiceBroadcast.swift
@@ -28,4 +28,8 @@ extension MXSession {
     @objc public func getOrCreateVoiceBroadcastService(for room: MXRoom, completion: @escaping (VoiceBroadcastService?) -> Void) {
         VoiceBroadcastServiceProvider.shared.getOrCreateVoiceBroadcastService(for: room, completion: completion)
     }
+    
+    @objc public func tearDownVoiceBroadcastService() {
+        VoiceBroadcastServiceProvider.shared.tearDownVoiceBroadcastService()
+    }
 }

--- a/RiotSwiftUI/Modules/Room/Composer/CreateActionList/Model/ComposerCreateActionListModels.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/CreateActionList/Model/ComposerCreateActionListModels.swift
@@ -42,6 +42,8 @@ struct ComposerCreateActionListViewState: BindableState {
     case stickers
     /// Upload an attachment
     case attachments
+    /// Voice broadcast
+    case voiceBroadcast
     /// Create a Poll
     case polls
     /// Add a location
@@ -63,6 +65,8 @@ extension ComposerCreateAction {
             return VectorL10n.wysiwygComposerStartActionStickers
         case .attachments:
             return VectorL10n.wysiwygComposerStartActionAttachments
+        case .voiceBroadcast:
+            return VectorL10n.wysiwygComposerStartActionVoiceBroadcast
         case .polls:
             return VectorL10n.wysiwygComposerStartActionPolls
         case .location:
@@ -80,6 +84,8 @@ extension ComposerCreateAction {
             return "stickersAction"
         case .attachments:
             return "attachmentsAction"
+        case .voiceBroadcast:
+            return "voiceBroadcastAction"
         case .polls:
             return "pollsAction"
         case .location:
@@ -97,6 +103,8 @@ extension ComposerCreateAction {
             return Asset.Images.actionSticker.name
         case .attachments:
             return Asset.Images.actionFile.name
+        case .voiceBroadcast:
+            return Asset.Images.actionLive.name
         case .polls:
             return Asset.Images.actionPoll.name
         case .location:


### PR DESCRIPTION
- Update the existing implementation used to start/stop a voice broadcast in order to handle the different cases where voice broadcast is denied
- Add the optional Voice broadcast action to the new wysiwyg composer
- no change-log has been added because the feature is still hidden behind a Labs flag

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/8969772/196818494-c8cf24ca-ea9f-43ef-96ef-6be9f9fa52f7.png">
