### PR TITLE
Fix AvatarView crash

### DIFF
--- a/Riot/Modules/Common/Avatar/AvatarView.swift
+++ b/Riot/Modules/Common/Avatar/AvatarView.swift
@@ -143,7 +143,7 @@ class AvatarView: UIView, Themable {
     
     private func updateAvatarContentMode(contentMode: UIView.ContentMode) {
         avatarImageView?.contentMode = contentMode
-        avatarImageView?.imageView.contentMode = contentMode
+        avatarImageView?.imageView?.contentMode = contentMode
     }
         
     // MARK: - Actions


### PR DESCRIPTION
This PR fixes a potential crash introduced by this PR: https://github.com/vector-im/element-ios/pull/6927 
It looks like sometimes the avatar view doesn't have the inner image view ready.