### PR TITLE
Bugfix for placeholder flickering in the normal and new composer when there is a height change.

### DIFF
--- a/Riot/Modules/Room/MXKRoomViewController.h
+++ b/Riot/Modules/Room/MXKRoomViewController.h
@@ -74,11 +74,6 @@ typedef NS_ENUM(NSUInteger, MXKRoomViewControllerJoinRoomResult) {
     MXKAttachment *currentSharedAttachment;
     
     /**
-     The potential text input placeholder is saved when it is replaced temporarily
-     */
-    NSString *savedInputToolbarPlaceholder;
-    
-    /**
      Tell whether the input toolbar required to run an animation indicator.
      */
     BOOL isInputToolbarProcessing;

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5032,27 +5032,12 @@ static CGSize kThreadListBarButtonItemImageSize;
 {
     if (self.roomInputToolbarContainerHeightConstraint.constant != height)
     {
-        // Hide temporarily the placeholder to prevent its distortion during height animation
-        if (toolbarView.placeholder.length)
-        {
-            savedInputToolbarPlaceholder = toolbarView.placeholder;
-            toolbarView.placeholder = nil;
-        }
-            
         [super roomInputToolbarView:toolbarView heightDidChanged:height completion:^(BOOL finished) {
             
             if (completion)
             {
                 completion (finished);
             }
-            
-            // Consider here the saved placeholder only if no new placeholder has been defined during the height animation.
-            if (!toolbarView.placeholder && self->savedInputToolbarPlaceholder.length)
-            {
-                // Restore the placeholder if any
-                toolbarView.placeholder = self->savedInputToolbarPlaceholder;
-            }
-            self->savedInputToolbarPlaceholder = nil;
         }];
     }
 }

--- a/changelog.d/6949.bugfix
+++ b/changelog.d/6949.bugfix
@@ -1,0 +1,1 @@
+Fixed the placeholder flickering in the input toolbar when there is an height change.


### PR DESCRIPTION
Removed legacy lines of code which actually did nothing aside from cause the flickering of the placeholder.