### PR TITLE
Hide old sessions list when the new dm is enabled (PSG-716)

### DIFF
--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -324,7 +324,7 @@ TableViewSectionsDelegate>
     
     // Crypto sessions section
         
-    if (RiotSettings.shared.settingsSecurityScreenShowSessions)
+    if (RiotSettings.shared.settingsSecurityScreenShowSessions && !RiotSettings.shared.enableNewSessionManager)
     {
         Section *sessionsSection = [Section sectionWithTag:SECTION_CRYPTO_SESSIONS];
         

--- a/changelog.d/pr-6999.change
+++ b/changelog.d/pr-6999.change
@@ -1,0 +1,1 @@
+Hide the old session list when the new device manager is enabled.


### PR DESCRIPTION
### Description
This PR hides the old session list when the new device manager is enabled.

![poc](https://user-images.githubusercontent.com/19324622/198315425-f285aeed-d1c5-44ab-aba7-cdce4eb5617c.gif)