### PR TITLE
CryptoV2 changes

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2288,7 +2288,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
                     // Stay in launching during the first server sync if the store is empty.
                     isLaunching = (mainSession.rooms.count == 0 && launchAnimationContainerView);
                     
-                    if (mainSession.crypto.crossSigning && mainSession.crypto.crossSigning.state == MXCrossSigningStateCrossSigningExists)
+                    if (mainSession.crypto.crossSigning && mainSession.crypto.crossSigning.state == MXCrossSigningStateCrossSigningExists && [mainSession.crypto isKindOfClass:[MXLegacyCrypto class]])
                     {
                         [(MXLegacyCrypto *)mainSession.crypto setOutgoingKeyRequestsEnabled:NO onComplete:nil];
                     }
@@ -3767,7 +3767,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 - (void)keyVerificationCoordinatorBridgePresenterDelegateDidComplete:(KeyVerificationCoordinatorBridgePresenter *)coordinatorBridgePresenter otherUserId:(NSString * _Nonnull)otherUserId otherDeviceId:(NSString * _Nonnull)otherDeviceId
 {
     id<MXCrypto> crypto = coordinatorBridgePresenter.session.crypto;
-    if (!crypto.backup.hasPrivateKeyInCryptoStore || !crypto.backup.enabled)
+    if ([crypto isKindOfClass:[MXLegacyCrypto class]] && (!crypto.backup.hasPrivateKeyInCryptoStore || !crypto.backup.enabled))
     {
         MXLogDebug(@"[AppDelegate][MXKeyVerification] requestAllPrivateKeys: Request key backup private keys");
         [(MXLegacyCrypto *)crypto setOutgoingKeyRequestsEnabled:YES onComplete:nil];

--- a/Riot/Modules/Authentication/SessionVerificationListener.swift
+++ b/Riot/Modules/Authentication/SessionVerificationListener.swift
@@ -78,7 +78,7 @@ class SessionVerificationListener {
         } else if session.state == .running {
             unregisterSessionStateChangeNotification()
             
-            if let crypto = session.crypto as? MXLegacyCrypto {
+            if let crypto = session.crypto {
                 let crossSigning = crypto.crossSigning
                 crossSigning.refreshState { [weak self] stateUpdated in
                     guard let self = self else { return }
@@ -101,7 +101,7 @@ class SessionVerificationListener {
                                     self.completion?(.authenticationIsComplete)
                                 } failure: { error in
                                     MXLog.error("[SessionVerificationListener] sessionStateDidChange: Bootstrap failed", context: error)
-                                    crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
+                                    (crypto as? MXLegacyCrypto)?.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                                     self.completion?(.authenticationIsComplete)
                                 }
                             } else {
@@ -111,12 +111,12 @@ class SessionVerificationListener {
                                     self.completion?(.authenticationIsComplete)
                                 } failure: { error in
                                     MXLog.error("[SessionVerificationListener] sessionStateDidChange: Do not know how to bootstrap cross-signing. Skip it.")
-                                    crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
+                                    (crypto as? MXLegacyCrypto)?.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                                     self.completion?(.authenticationIsComplete)
                                 }
                             }
                         } else {
-                            crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
+                            (crypto as? MXLegacyCrypto)?.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                             self.completion?(.authenticationIsComplete)
                         }
                     case .crossSigningExists:
@@ -125,12 +125,12 @@ class SessionVerificationListener {
                     default:
                         MXLog.debug("[SessionVerificationListener] sessionStateDidChange: Nothing to do")
                         
-                        crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
+                        (crypto as? MXLegacyCrypto)?.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                         self.completion?(.authenticationIsComplete)
                     }
                 } failure: { [weak self] error in
                     MXLog.error("[SessionVerificationListener] sessionStateDidChange: Fail to refresh crypto state", context: error)
-                    crypto.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
+                    (crypto as? MXLegacyCrypto)?.setOutgoingKeyRequestsEnabled(true, onComplete: nil)
                     self?.completion?(.authenticationIsComplete)
                 }
             } else {

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
@@ -92,21 +92,29 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
             //  be sure that session has completed its first sync
             if session.state >= .running {
                 
-                // Always send request instead of waiting for an incoming one as per recent EW changes
-                MXLog.debug("[KeyVerificationSelfVerifyWaitViewModel] loadData: Send a verification request to all devices instead of waiting")
-                
-                let keyVerificationService = KeyVerificationService()
-                self.verificationManager.requestVerificationByToDevice(withUserId: self.session.myUserId, deviceIds: nil, methods: keyVerificationService.supportedKeyVerificationMethods(), success: { [weak self] (keyVerificationRequest) in
-                    guard let self = self else {
-                        return
-                    }
+                if let existingRequest = verificationManager.pendingRequests.first(where: { $0.isFromMyUser && !$0.isFromMyDevice && $0.state == MXKeyVerificationRequestStatePending }) {
+                    MXLog.debug("[KeyVerificationSelfVerifyWaitViewModel] loadData: Accepting an existing self-verification request instead of starting a new one")
                     
-                    self.keyVerificationRequest = keyVerificationRequest
+                    registerTransactionDidStateChangeNotification()
+                    acceptKeyVerificationRequest(existingRequest)
+                } else {
                     
-                }, failure: { [weak self] error in
-                    self?.update(viewState: .error(error))
-                })
-                continueLoadData()
+                    // Always send request instead of waiting for an incoming one as per recent EW changes
+                    MXLog.debug("[KeyVerificationSelfVerifyWaitViewModel] loadData: Send a verification request to all devices instead of waiting")
+                    
+                    let keyVerificationService = KeyVerificationService()
+                    self.verificationManager.requestVerificationByToDevice(withUserId: self.session.myUserId, deviceIds: nil, methods: keyVerificationService.supportedKeyVerificationMethods(), success: { [weak self] (keyVerificationRequest) in
+                        guard let self = self else {
+                            return
+                        }
+                        
+                        self.keyVerificationRequest = keyVerificationRequest
+                        
+                    }, failure: { [weak self] error in
+                        self?.update(viewState: .error(error))
+                    })
+                    continueLoadData()
+                }
             } else {
                 //  show loader
                 self.update(viewState: .secretsRecoveryCheckingAvailability(VectorL10n.deviceVerificationSelfVerifyWaitRecoverSecretsCheckingAvailability))

--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -952,7 +952,10 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
         {
             // Force a reload of device keys at the next session start.
             // This will fix potential UISIs other peoples receive for our messages.
-            [(MXLegacyCrypto *)mxSession.crypto resetDeviceKeys];
+            if ([mxSession.crypto isKindOfClass:[MXLegacyCrypto class]])
+            {
+                [(MXLegacyCrypto *)mxSession.crypto resetDeviceKeys];
+            }
             
             // Clean other stores
             [mxSession.scanManager deleteAllAntivirusScans];

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -1445,13 +1445,11 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     
     NSString *sdkVersionInfo = [NSString stringWithFormat:@"Matrix SDK %@", MatrixSDKVersion];
     
-    NSString *olmVersionInfo = [NSString stringWithFormat:@"OLM %@", [OLMKit versionString]];    
-    
     [footerText appendFormat:@"%@\n", loggedUserInfo];
     [footerText appendFormat:@"%@\n", homeserverInfo];
     [footerText appendFormat:@"%@\n", appVersionInfo];
     [footerText appendFormat:@"%@\n", sdkVersionInfo];
-    [footerText appendFormat:@"%@", olmVersionInfo];
+    [footerText appendFormat:@"%@", self.mainSession.crypto.version];
     
     return [footerText copy];
 }

--- a/RiotShareExtension/Shared/ShareManager.m
+++ b/RiotShareExtension/Shared/ShareManager.m
@@ -102,7 +102,10 @@ static MXSession *fakeSession;
     [session setStore:self.fileStore success:^{
         MXStrongifyAndReturnIfNil(session);
         
-        ((MXLegacyCrypto *)session.crypto).warnOnUnknowDevices = NO; // Do not warn for unknown devices. We have cross-signing now
+        if ([session.crypto isKindOfClass:[MXLegacyCrypto class]])
+        {
+            ((MXLegacyCrypto *)session.crypto).warnOnUnknowDevices = NO; // Do not warn for unknown devices. We have cross-signing now
+        }
         
         self.selectedRooms = [NSMutableArray array];
         for (NSString *roomIdentifier in roomIdentifiers) {

--- a/SiriIntents/IntentHandlers/SendMessage/SendMessageIntentHandler.m
+++ b/SiriIntents/IntentHandlers/SendMessage/SendMessageIntentHandler.m
@@ -118,7 +118,10 @@
                     self.selectedRoom = [MXRoom loadRoomFromStore:fileStore withRoomId:roomID matrixSession:session];
 
                     // Do not warn for unknown devices. We have cross-signing now
-                    ((MXLegacyCrypto *)session.crypto).warnOnUnknowDevices = NO;
+                    if ([session.crypto isKindOfClass:[MXLegacyCrypto class]])
+                    {
+                        ((MXLegacyCrypto *)session.crypto).warnOnUnknowDevices = NO;
+                    }
 
                     MXWeakify(self);
                     [self.selectedRoom sendTextMessage:intent.content


### PR DESCRIPTION
A few changes to [CryptoV2 implementation](https://github.com/vector-im/element-ios/pull/6985) after extensive testing with polyjuce:

- always ensure correct type before typecasting to legacy crypto
- create new or accept existing self-verification request