### PR TITLE
Prevent autolayout crashes when showing toast notifications

### DIFF
--- a/Riot/Modules/Common/UserIndicators/ViewPresenters/ToastViewPresenter.swift
+++ b/Riot/Modules/Common/UserIndicators/ViewPresenters/ToastViewPresenter.swift
@@ -22,10 +22,6 @@ import MatrixSDK
 /// A presenter responsible for showing / hiding a toast view for loading spinners or success messages.
 /// It is managed by an `UserIndicator`, meaning the `present` and `dismiss` methods will be called when the parent `UserIndicator` starts or completes.
 class ToastViewPresenter: UserIndicatorViewPresentable {
-    struct Constants {
-        static let navigationBarPatting = CGFloat(12)
-    }
-    
     private let viewState: ToastViewState
     private let presentationContext: UserIndicatorPresentationContext
     private weak var view: UIView?
@@ -46,19 +42,11 @@ class ToastViewPresenter: UserIndicatorViewPresentable {
         self.view = view
         
         view.translatesAutoresizingMaskIntoConstraints = false
-        if let navigation = viewController.topNavigationController {
-            navigation.view.addSubview(view)
-            NSLayoutConstraint.activate([
-                view.centerXAnchor.constraint(equalTo: navigation.view.centerXAnchor),
-                view.topAnchor.constraint(equalTo: navigation.navigationBar.safeAreaLayoutGuide.bottomAnchor, constant: Constants.navigationBarPatting)
-            ])
-        } else {
-            viewController.view.addSubview(view)
-            NSLayoutConstraint.activate([
-                view.centerXAnchor.constraint(equalTo: viewController.view.centerXAnchor),
-                view.topAnchor.constraint(equalTo: viewController.view.topAnchor)
-            ])
-        }
+        viewController.view.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.centerXAnchor.constraint(equalTo: viewController.view.centerXAnchor),
+            view.topAnchor.constraint(equalTo: viewController.view.safeAreaLayoutGuide.topAnchor)
+        ])
         
         view.alpha = 0
         view.transform = .init(translationX: 0, y: 5)
@@ -83,15 +71,5 @@ class ToastViewPresenter: UserIndicatorViewPresentable {
             view.removeFromSuperview()
         }
         animator?.startAnimation()
-    }
-}
-
-private extension UIViewController {
-    var topNavigationController: UINavigationController? {
-        var controller: UINavigationController? = self as? UINavigationController ?? navigationController
-        while controller?.navigationController != nil {
-            controller = controller?.navigationController
-        }
-        return controller
     }
 }

--- a/changelog.d/pr-7046.bugfix
+++ b/changelog.d/pr-7046.bugfix
@@ -1,0 +1,1 @@
+Prevent autolayout crashes when showing toast notifications


### PR DESCRIPTION
Prevent `Unable to activate constraint with anchors .. because they have no common ancestor.` crashes. Only link toasts to the top safe area instead of the navigation controller