### PR TITLE
Unverified sessions alert

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -437,4 +437,7 @@ final class BuildSettings: NSObject {
     static let qrLoginEnableDisplayingQRs = false
     
     static let rendezvousServerBaseURL = URL(string: "https://rendezvous.lab.element.dev/")!
+    
+    // MARK: - Alerts
+    static let showUnverifiedSessionsAlert = true
 }

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1548,9 +1548,8 @@ Tap the + to start adding people.";
 "key_verification_self_verify_current_session_alert_validate_action" = "Verify";
 
 // Unverified sessions
-
-"key_verification_self_verify_unverified_sessions_alert_title" = "Review where you're logged in";
-"key_verification_self_verify_unverified_sessions_alert_message" = "Verify all your sessions to ensure your account & messages are safe.";
+"key_verification_alert_title" = "You have unverified sessions";
+"key_verification_alert_body" = "Review to ensure your account is safe.";
 "key_verification_self_verify_unverified_sessions_alert_validate_action" = "Review";
 
 // MARK: Self verification wait

--- a/Riot/Categories/Date+Calculation.swift
+++ b/Riot/Categories/Date+Calculation.swift
@@ -1,0 +1,25 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+extension Date {
+    
+    func daysBetween(date: Date) -> Int {
+        let components = Calendar.current.dateComponents([.day], from: self, to: date)
+        return components.day ?? 0
+    }
+}

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2923,6 +2923,14 @@ public class VectorL10n: NSObject {
   public static var keyBackupSetupTitle: String { 
     return VectorL10n.tr("Vector", "key_backup_setup_title") 
   }
+  /// Review to ensure your account is safe.
+  public static var keyVerificationAlertBody: String { 
+    return VectorL10n.tr("Vector", "key_verification_alert_body") 
+  }
+  /// You have unverified sessions
+  public static var keyVerificationAlertTitle: String { 
+    return VectorL10n.tr("Vector", "key_verification_alert_title") 
+  }
   /// You need to bootstrap cross-signing first.
   public static var keyVerificationBootstrapNotSetupMessage: String { 
     return VectorL10n.tr("Vector", "key_verification_bootstrap_not_setup_message") 
@@ -3006,14 +3014,6 @@ public class VectorL10n: NSObject {
   /// Verify
   public static var keyVerificationSelfVerifyCurrentSessionAlertValidateAction: String { 
     return VectorL10n.tr("Vector", "key_verification_self_verify_current_session_alert_validate_action") 
-  }
-  /// Verify all your sessions to ensure your account & messages are safe.
-  public static var keyVerificationSelfVerifyUnverifiedSessionsAlertMessage: String { 
-    return VectorL10n.tr("Vector", "key_verification_self_verify_unverified_sessions_alert_message") 
-  }
-  /// Review where you're logged in
-  public static var keyVerificationSelfVerifyUnverifiedSessionsAlertTitle: String { 
-    return VectorL10n.tr("Vector", "key_verification_self_verify_unverified_sessions_alert_title") 
   }
   /// Review
   public static var keyVerificationSelfVerifyUnverifiedSessionsAlertValidateAction: String { 

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -200,9 +200,6 @@ final class RiotSettings: NSObject {
     @UserDefault(key: "hideVerifyThisSessionAlert", defaultValue: false, storage: defaults)
     var hideVerifyThisSessionAlert
     
-    @UserDefault(key: "hideReviewSessionsAlert", defaultValue: false, storage: defaults)
-    var hideReviewSessionsAlert
-    
     @UserDefault(key: "matrixApps", defaultValue: false, storage: defaults)
     var matrixApps
     

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -638,6 +638,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     [self.pushNotificationService applicationDidBecomeActive];
     
     [self configurePinCodeScreenFor:application createIfRequired:NO];
+    
+    [self checkCrossSigningForSession:self.mxSessions.firstObject];
 }
 
 - (void)configurePinCodeScreenFor:(UIApplication *)application
@@ -2192,6 +2194,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     // Reset analytics
     [Analytics.shared reset];
+    
+    [[[ReviewSessionAlertSnoozeController alloc] init] clearSnooze];
     
 #ifdef MX_CALL_STACK_ENDPOINT
     // Erase all created certificates and private keys by MXEndpointCallStack

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -60,7 +60,7 @@ class AllChatsViewController: HomeViewController {
     
     private let tableViewPaginationThrottler = MXThrottler(minimumDelay: 0.1)
     
-    private var reviewSessionAlertHasBeenDisplayed: Bool = false
+    private let reviewSessionAlertSnoozeController = ReviewSessionAlertSnoozeController()
     
     private var bannerView: UIView? {
         didSet {
@@ -72,9 +72,7 @@ class AllChatsViewController: HomeViewController {
     private var isOnboardingCoordinatorPreparing: Bool = false
 
     private var allChatsOnboardingCoordinatorBridgePresenter: AllChatsOnboardingCoordinatorBridgePresenter?
-    
-    private var currentAlert: UIAlertController?
-    
+
     @IBOutlet private var toolbar: UIToolbar!
     private var isToolbarHidden: Bool = false {
         didSet {
@@ -821,12 +819,13 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     /// - Parameters:
     ///   - session: the matrix session.
     func presentVerifyCurrentSessionAlertIfNeeded(with session: MXSession) {
-        guard !RiotSettings.shared.hideVerifyThisSessionAlert, !reviewSessionAlertHasBeenDisplayed, !isOnboardingInProgress else {
+        guard !RiotSettings.shared.hideVerifyThisSessionAlert,
+              !isOnboardingInProgress,
+              presentedViewController == nil,
+              viewIfLoaded?.window != nil else {
             return
         }
         
-        reviewSessionAlertHasBeenDisplayed = true
-
         // Force verification if required by the HS configuration
         guard !session.vc_homeserverConfiguration().encryption.isSecureBackupRequired else {
             MXLog.debug("[AllChatsViewController] presentVerifyCurrentSessionAlertIfNeededWithSession: Force verification of the device")
@@ -842,21 +841,16 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     /// - Parameters:
     ///   - session: the matrix session.
     func presentReviewUnverifiedSessionsAlertIfNeeded(with session: MXSession) {
-        guard !reviewSessionAlertHasBeenDisplayed else {
+        guard BuildSettings.showUnverifiedSessionsAlert,
+              !reviewSessionAlertSnoozeController.isSnoozed(),
+              presentedViewController == nil,
+              viewIfLoaded?.window != nil else {
             return
         }
-        
+
         let devices = mainSession.crypto.devices(forUser: mainSession.myUserId).values
-        var userHasOneUnverifiedDevice = false
-        for device in devices {
-            if !device.trustLevel.isCrossSigningVerified {
-                userHasOneUnverifiedDevice = true
-                break
-            }
-        }
-        
+        let userHasOneUnverifiedDevice = devices.contains(where: {!$0.trustLevel.isCrossSigningVerified})
         if userHasOneUnverifiedDevice {
-            reviewSessionAlertHasBeenDisplayed = true
             presentReviewUnverifiedSessionsAlert(with: session)
         }
     }
@@ -968,8 +962,6 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     private func presentVerifyCurrentSessionAlert(with session: MXSession) {
         MXLog.debug("[AllChatsViewController] presentVerifyCurrentSessionAlertWithSession")
         
-        currentAlert?.dismiss(animated: true, completion: nil)
-        
         let alert = UIAlertController(title: VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertTitle,
                                       message: VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertMessage,
                                       preferredStyle: .alert)
@@ -989,13 +981,10 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
         }))
         
         self.present(alert, animated: true)
-        currentAlert = alert
     }
 
     private func presentReviewUnverifiedSessionsAlert(with session: MXSession) {
         MXLog.debug("[AllChatsViewController] presentReviewUnverifiedSessionsAlert")
-        
-        currentAlert?.dismiss(animated: true, completion: nil)
         
         let alert = UIAlertController(title: VectorL10n.keyVerificationAlertTitle,
                                       message: VectorL10n.keyVerificationAlertBody,
@@ -1007,10 +996,11 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
             self.showSettingsSecurityScreen(with: session)
         }))
         
-        alert.addAction(UIAlertAction(title: VectorL10n.later, style: .cancel))
+        alert.addAction(UIAlertAction(title: VectorL10n.later, style: .cancel, handler: { [weak self] _ in
+            self?.reviewSessionAlertSnoozeController.snooze()
+        }))
         
         present(alert, animated: true)
-        currentAlert = alert
     }
 
     private func showSettingsSecurityScreen(with session: MXSession) {
@@ -1026,7 +1016,12 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
         
         settingsViewController.loadViewIfNeeded()
         AppDelegate.theDelegate().restoreInitialDisplay {
-            self.navigationController?.viewControllers = [self, settingsViewController, securityViewController]
+            if RiotSettings.shared.enableNewSessionManager {
+                self.navigationController?.viewControllers = [self, settingsViewController]
+                settingsViewController.showUserSessionsFlow()
+            } else {
+                self.navigationController?.viewControllers = [self, settingsViewController, securityViewController]
+            }
         }
     }
     
@@ -1049,7 +1044,6 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     }
 
     private func resetReviewSessionsFlags() {
-        reviewSessionAlertHasBeenDisplayed = false
         RiotSettings.shared.hideVerifyThisSessionAlert = false
     }
     

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -997,8 +997,8 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
         
         currentAlert?.dismiss(animated: true, completion: nil)
         
-        let alert = UIAlertController(title: VectorL10n.keyVerificationSelfVerifyUnverifiedSessionsAlertTitle,
-                                      message: VectorL10n.keyVerificationSelfVerifyUnverifiedSessionsAlertMessage,
+        let alert = UIAlertController(title: VectorL10n.keyVerificationAlertTitle,
+                                      message: VectorL10n.keyVerificationAlertBody,
                                       preferredStyle: .alert)
         
         alert.addAction(UIAlertAction(title: VectorL10n.keyVerificationSelfVerifyUnverifiedSessionsAlertValidateAction,

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -842,7 +842,7 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     /// - Parameters:
     ///   - session: the matrix session.
     func presentReviewUnverifiedSessionsAlertIfNeeded(with session: MXSession) {
-        guard !RiotSettings.shared.hideReviewSessionsAlert, !reviewSessionAlertHasBeenDisplayed else {
+        guard !reviewSessionAlertHasBeenDisplayed else {
             return
         }
         
@@ -1009,10 +1009,6 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
         
         alert.addAction(UIAlertAction(title: VectorL10n.later, style: .cancel))
         
-        alert.addAction(UIAlertAction(title: VectorL10n.doNotAskAgain, style: .destructive, handler: { action in
-            RiotSettings.shared.hideReviewSessionsAlert = true
-        }))
-        
         present(alert, animated: true)
         currentAlert = alert
     }
@@ -1055,7 +1051,6 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     private func resetReviewSessionsFlags() {
         reviewSessionAlertHasBeenDisplayed = false
         RiotSettings.shared.hideVerifyThisSessionAlert = false
-        RiotSettings.shared.hideReviewSessionsAlert = false
     }
     
     private func presentOnboardingFlow() {

--- a/Riot/Modules/Home/AllChats/ReviewSessionAlertSnoozeController.swift
+++ b/Riot/Modules/Home/AllChats/ReviewSessionAlertSnoozeController.swift
@@ -1,0 +1,49 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@objcMembers
+class ReviewSessionAlertSnoozeController: NSObject {
+    
+    private let userDefaults: UserDefaults
+    private let snoozeDateKey = "ReviewSessionAlertSnoozeController_snoozeDateKey"
+    private let minDaysBetweenAlerts = 7
+    
+    // for Objective-C
+    convenience override init() {
+        self.init(userDefaults: UserDefaults.standard)
+    }
+    
+    init(userDefaults: UserDefaults = UserDefaults.standard) {
+        self.userDefaults = userDefaults
+    }
+    
+    func isSnoozed() -> Bool {
+        guard  let lastDisplayedDate = userDefaults.object(forKey: snoozeDateKey) as? Date else {
+            return false
+        }
+        return lastDisplayedDate.daysBetween(date: Date()) <= minDaysBetweenAlerts
+    }
+    
+    func snooze() {
+        userDefaults.set(Date(), forKey: snoozeDateKey)
+    }
+    
+    func clearSnooze() {
+        userDefaults.removeObject(forKey: snoozeDateKey)
+    }
+}

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -6760,8 +6760,8 @@ static CGSize kThreadListBarButtonItemImageSize;
     
     [currentAlert dismissViewControllerAnimated:NO completion:nil];
     
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[VectorL10n keyVerificationSelfVerifyUnverifiedSessionsAlertTitle]
-                                                                   message:[VectorL10n keyVerificationSelfVerifyUnverifiedSessionsAlertMessage]
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[VectorL10n keyVerificationAlertTitle]
+                                                                   message:[VectorL10n keyVerificationAlertBody]
                                                             preferredStyle:UIAlertControllerStyleAlert];
     
     [alert addAction:[UIAlertAction actionWithTitle:[VectorL10n keyVerificationSelfVerifyUnverifiedSessionsAlertValidateAction]

--- a/Riot/Modules/Settings/SettingsViewController.h
+++ b/Riot/Modules/Settings/SettingsViewController.h
@@ -20,5 +20,6 @@
 
 + (instancetype)instantiate;
 
+- (void)showUserSessionsFlow;
 @end
 

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -934,8 +934,8 @@
     
     [currentAlert dismissViewControllerAnimated:NO completion:nil];
     
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[VectorL10n keyVerificationSelfVerifyUnverifiedSessionsAlertTitle]
-                                                                   message:[VectorL10n keyVerificationSelfVerifyUnverifiedSessionsAlertMessage]
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[VectorL10n keyVerificationAlertTitle]
+                                                                   message:[VectorL10n keyVerificationAlertBody]
                                                             preferredStyle:UIAlertControllerStyleAlert];
     
     [alert addAction:[UIAlertAction actionWithTitle:[VectorL10n keyVerificationSelfVerifyUnverifiedSessionsAlertValidateAction]

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -903,7 +903,7 @@
 
 - (void)presentReviewUnverifiedSessionsAlertIfNeededWithSession:(MXSession*)session
 {
-    if (RiotSettings.shared.hideReviewSessionsAlert || self.reviewSessionAlertHasBeenDisplayed)
+    if (self.reviewSessionAlertHasBeenDisplayed)
     {
         return;
     }
@@ -948,13 +948,6 @@
                                               style:UIAlertActionStyleCancel
                                             handler:nil]];
     
-    [alert addAction:[UIAlertAction actionWithTitle:[VectorL10n doNotAskAgain]
-                                              style:UIAlertActionStyleDestructive
-                                            handler:^(UIAlertAction * action) {
-                                                RiotSettings.shared.hideReviewSessionsAlert = YES;
-                                            }]];
-    
-    
     [self presentViewController:alert animated:YES completion:nil];
     
     currentAlert = alert;
@@ -975,7 +968,6 @@
 {
     self.reviewSessionAlertHasBeenDisplayed = NO;
     RiotSettings.shared.hideVerifyThisSessionAlert = NO;
-    RiotSettings.shared.hideReviewSessionsAlert = NO;
 }
 
 #pragma mark - UITabBarDelegate

--- a/RiotTests/ReviewSessionAlertSnoozeControllerTests.swift
+++ b/RiotTests/ReviewSessionAlertSnoozeControllerTests.swift
@@ -1,0 +1,66 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+@testable import Element
+
+final class ReviewSessionAlertSnoozeControllerTests: XCTestCase {
+
+    private let snoozeDateKey = "ReviewSessionAlertSnoozeController_snoozeDateKey"
+    private var userDefaults = UserDefaults(suiteName: "testSuit")!
+    private var sut: ReviewSessionAlertSnoozeController!
+    
+    override func setUpWithError() throws {
+        userDefaults.removePersistentDomain(forName: "testSuit")
+        sut = ReviewSessionAlertSnoozeController(userDefaults: userDefaults)
+    }
+
+    func test_whenAlertNotSnoozedBefore_isSnoozedFalse() {
+        XCTAssertFalse(sut.isSnoozed())
+    }
+    
+    func test_whenAlertSnoozedYesterday_isSnoozedTrue() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())
+        userDefaults.set(yesterday, forKey: snoozeDateKey)
+        XCTAssertTrue(sut.isSnoozed())
+    }
+    
+    func test_whenAlertSnoozed8DaysAgo_isSnoozedFalse() {
+        let eightDaysAgo = Calendar.current.date(byAdding: .day, value: -8, to: Date())
+        userDefaults.set(eightDaysAgo, forKey: snoozeDateKey)
+        XCTAssertFalse(sut.isSnoozed())
+    }
+    
+    func test_whenAlertSnoozed7DaysAgo_isSnoozedTrue() {
+        let eightDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date())
+        userDefaults.set(eightDaysAgo, forKey: snoozeDateKey)
+        XCTAssertTrue(sut.isSnoozed())
+    }
+    
+    func test_whenAlertSnoozed_isSnoozedTrue() {
+        XCTAssertFalse(sut.isSnoozed())
+        sut.snooze()
+        XCTAssertTrue(sut.isSnoozed())
+    }
+    
+    func test_whenClearSnooze_isSnoozedFalse() {
+        sut.snooze()
+        XCTAssertTrue(sut.isSnoozed())
+        sut.clearSnooze()
+        XCTAssertFalse(sut.isSnoozed())
+    }
+}

--- a/changelog.d/7056.feature
+++ b/changelog.d/7056.feature
@@ -1,0 +1,1 @@
+Unverified sessions alert.


### PR DESCRIPTION
Closses #7043 

Change current unverified sessions alert using following ACs:

- A dedicated build setting / equivalent exists that allows to toggle the alerts on / off
- The default value of the build setting is on
- The alert reuses the existing UX
- The alert title is “You have unverified sessions”
- The alert body is “Review to ensure your account is safe.”
- The alert contains two options: “Review” and “Later”
  - “Review” takes the user to the currently active device manager (when the flag is OFF the current one, when it is ON the new one).
  - “Later” snoozes the alert for one week. The delay is stored per device and not synced across all devices in the account.
  - The existing "Do not ask again" from iOS is removed. It's only shown on that platform and can't be reverted intuitively (sign out and sign in).
- The alert is displayed after:
  - logging in to a new session and fully verifying that session
  - opening the app (regardless of whether it’s from the background or a cold launch)
- The alert is displayed only when:
  - there is at least one unverified session
  - and the current session itself is not verified
  - and the user is not within a snooze period
  - and the build setting is enabled
- On sign out clear snooze delay 

<img width="438" alt="Screenshot 2022-11-09 at 15 19 38" src="https://user-images.githubusercontent.com/1991792/200840861-1175bc67-b279-46a3-af40-5c141d3df498.png">

