### PR TITLE
Force a layout on the room bubble cell messageTextView to get a corre…

### DIFF
--- a/Riot/Categories/MXKRoomBubbleTableViewCell+Riot.m
+++ b/Riot/Categories/MXKRoomBubbleTableViewCell+Riot.m
@@ -623,6 +623,10 @@ NSString *const kMXKRoomBubbleCellKeyVerificationIncomingRequestDeclinePressed =
             selectedComponentHeight = roomBubbleTableViewCell.frame.size.height - selectedComponentPositionY;
         }
         
+        // Force the textView used underneath to layout its frame properly
+        [roomBubbleTableViewCell setNeedsLayout];
+        [roomBubbleTableViewCell layoutIfNeeded];
+        
         selectedComponenContentViewYOffset = roomBubbleTableViewCell.messageTextView.frame.origin.y;
     }
     

--- a/changelog.d/pr-7064.bugfix
+++ b/changelog.d/pr-7064.bugfix
@@ -1,0 +1,1 @@
+Fixed timeline layout issues for reactions and attachments


### PR DESCRIPTION
This PR forces a layout on the bubbleCell messageTextView used for computing the heights of the bubble components. It will ensure the reactions and other attachment views are layed out correctly.