### PR TITLE
Remove 10s wait on failed initial sync

### DIFF
--- a/changelog.d/pr-7068.change
+++ b/changelog.d/pr-7068.change
@@ -1,0 +1,2 @@
+Initial sync: Remove 10s wait on failed initial sync
+


### PR DESCRIPTION
There is no reason to arbitrarily delay another sync, and waiting too long could lead to server clearing any cache it has.