### PR TITLE
Fix Voice Broadcast buffering

### DIFF
--- a/Riot/Modules/Room/RoomCoordinator.swift
+++ b/Riot/Modules/Room/RoomCoordinator.swift
@@ -92,8 +92,8 @@ final class RoomCoordinator: NSObject, RoomCoordinatorProtocol {
         self.roomViewController.parentSpaceId = parameters.parentSpaceId
 
         TimelinePollProvider.shared.session = parameters.session
-        VoiceBroadcastPlaybackProvider.shared.session = parameters.session
-        VoiceBroadcastRecorderProvider.shared.session = parameters.session
+        VoiceBroadcastPlaybackProvider.shared.setSession(parameters.session) 
+        VoiceBroadcastRecorderProvider.shared.setSession(parameters.session)
         
         super.init()
     }

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -599,6 +599,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     
     [VoiceMessageMediaServiceProvider.sharedProvider pauseAllServices];
     [VoiceBroadcastRecorderProvider.shared pauseRecording];
+    [VoiceBroadcastPlaybackProvider.shared pausePlaying];
     
     // Stop the loading indicator even if the session is still in progress
     [self stopLoadingUserIndicator];

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackCoordinator.swift
@@ -76,4 +76,8 @@ final class VoiceBroadcastPlaybackCoordinator: Coordinator, Presentable {
     }
     
     func endVoiceBroadcast() {}
+    
+    func pausePlaying() {
+        viewModel.context.send(viewAction: .pause)
+    }
 }

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackProvider.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackProvider.swift
@@ -16,13 +16,13 @@
 
 import Foundation
 
-class VoiceBroadcastPlaybackProvider {
-    static let shared = VoiceBroadcastPlaybackProvider()
+@objc class VoiceBroadcastPlaybackProvider: NSObject {
+    @objc static let shared = VoiceBroadcastPlaybackProvider()
     
     private var session: MXSession?
     var coordinatorsForEventIdentifiers = [String: VoiceBroadcastPlaybackCoordinator]()
     
-    private init() { }
+    private override init() { }
     
     func setSession(_ session: MXSession) {
         if let currentSession = self.session {
@@ -63,5 +63,12 @@ class VoiceBroadcastPlaybackProvider {
     /// Retrieve the voiceBroadcast timeline coordinator for the given event or nil if it hasn't been created yet
     func voiceBroadcastPlaybackCoordinatorForEventIdentifier(_ eventIdentifier: String) -> VoiceBroadcastPlaybackCoordinator? {
         coordinatorsForEventIdentifiers[eventIdentifier]
+    }
+    
+    /// Pause current voice broadcast playback.
+    @objc public func pausePlaying() {
+        coordinatorsForEventIdentifiers.forEach { _, coordinator in
+            coordinator.pausePlaying()
+        }
     }
 }

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackProvider.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackProvider.swift
@@ -19,10 +19,20 @@ import Foundation
 class VoiceBroadcastPlaybackProvider {
     static let shared = VoiceBroadcastPlaybackProvider()
     
-    var session: MXSession?
+    private var session: MXSession?
     var coordinatorsForEventIdentifiers = [String: VoiceBroadcastPlaybackCoordinator]()
     
     private init() { }
+    
+    func setSession(_ session: MXSession) {
+        if let currentSession = self.session {
+            if currentSession != session {
+                // Clear all stored coordinators on new session
+                coordinatorsForEventIdentifiers.removeAll()
+            }
+        }
+        self.session = session
+    }
     
     /// Create or retrieve the voiceBroadcast timeline coordinator for this event and return
     /// a view to be displayed in the timeline

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/VoiceBroadcastPlaybackScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/VoiceBroadcastPlaybackScreenState.swift
@@ -42,7 +42,7 @@ enum MockVoiceBroadcastPlaybackScreenState: MockScreenState, CaseIterable {
     /// Generate the view struct for the screen state.
     var screenView: ([Any], AnyView) {
         
-        let details = (VoiceBroadcastPlaybackDetails)(senderDisplayName: "Alice", avatarData: AvatarInput(mxContentUri: "", matrixItemId: "!fakeroomid:matrix.org", displayName: "The name of the room"))
+        let details = VoiceBroadcastPlaybackDetails(senderDisplayName: "Alice", avatarData: AvatarInput(mxContentUri: "", matrixItemId: "!fakeroomid:matrix.org", displayName: "The name of the room"))
         let viewModel = MockVoiceBroadcastPlaybackViewModel(initialViewState: VoiceBroadcastPlaybackViewState(details: details, broadcastState: .live,  playbackState: .stopped, playingState: VoiceBroadcastPlayingState(duration: 10.0), bindings: VoiceBroadcastPlaybackViewStateBindings(progress: 0)))
         
         return (

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastRecorder/Coordinator/VoiceBroadcastRecorderProvider.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastRecorder/Coordinator/VoiceBroadcastRecorderProvider.swift
@@ -23,7 +23,7 @@ import Foundation
     
     // MARK: - Properties
     // MARK: Public
-    var session: MXSession?
+    private var session: MXSession?
     var coordinatorsForEventIdentifiers = [String: VoiceBroadcastRecorderCoordinator]()
     
     // MARK: Private
@@ -33,6 +33,16 @@ import Foundation
     private override init() { }
     
     // MARK: - Public
+    
+    func setSession(_ session: MXSession) {
+        if let currentSession = self.session {
+            if currentSession != session {
+                // Clear all stored coordinators on new session
+                coordinatorsForEventIdentifiers.removeAll()
+            }
+        }
+        self.session = session
+    }
     
     /// Create or retrieve the voiceBroadcast timeline coordinator for this event and return
     /// a view to be displayed in the timeline


### PR DESCRIPTION
- Fix crash observed after a clear cache
- Fix multiple voice broadcast issues related to the buffering state:
   - display the buffering mode when the user moves the current playback position
   - display the buffering mode in case of data shortage (see `stopIfVoiceBroadcastOver` update)
   - fix unexpected resume of paused playbacks
- Fix some typos
- Pause the potential playback when the user navigates outside the room

TODO: Pause the playback when the user clicks on the loading wheel (buffering state) to let the user cancel the action


