### PR TITLE
Poll not usable after logging out and back in

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2197,6 +2197,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     [[[ReviewSessionAlertSnoozeController alloc] init] clearSnooze];
     
+    [TimelinePollProvider.shared reset];
+    
 #ifdef MX_CALL_STACK_ENDPOINT
     // Erase all created certificates and private keys by MXEndpointCallStack
     for (MXKAccount *account in MXKAccountManager.sharedManager.accounts)

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
@@ -23,8 +23,6 @@ class TimelinePollProvider: NSObject {
     var session: MXSession?
     var coordinatorsForEventIdentifiers = [String: TimelinePollCoordinator]()
     
-    private override init() { }
-    
     /// Create or retrieve the poll timeline coordinator for this event and return
     /// a view to be displayed in the timeline
     func buildTimelinePollVCForEvent(_ event: MXEvent) -> UIViewController? {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
@@ -16,13 +16,14 @@
 
 import Foundation
 
-class TimelinePollProvider {
+@objcMembers
+class TimelinePollProvider: NSObject {
     static let shared = TimelinePollProvider()
     
     var session: MXSession?
     var coordinatorsForEventIdentifiers = [String: TimelinePollCoordinator]()
     
-    private init() { }
+    private override init() { }
     
     /// Create or retrieve the poll timeline coordinator for this event and return
     /// a view to be displayed in the timeline
@@ -48,5 +49,9 @@ class TimelinePollProvider {
     /// Retrieve the poll timeline coordinator for the given event or nil if it hasn't been created yet
     func timelinePollCoordinatorForEventIdentifier(_ eventIdentifier: String) -> TimelinePollCoordinator? {
         coordinatorsForEventIdentifiers[eventIdentifier]
+    }
+    
+    func reset() {
+        coordinatorsForEventIdentifiers.removeAll()
     }
 }

--- a/changelog.d/7070.bugfix
+++ b/changelog.d/7070.bugfix
@@ -1,0 +1,1 @@
+Poll not usable after logging out and back in.


### PR DESCRIPTION
Closes #7070 

Fix for

> After I logged out and in again I had four bug cases:
> - I could not end the poll (pressing the button did nothing)
> - I could not see changed votes by others
> - I could not see the closed poll after someone else closed it
> - When I changed my vote, the others did not get an event from me.

