### PR TITLE
Import progress for room keys

### DIFF
--- a/Riot/Modules/Settings/Security/SecureBackup/SettingsSecureBackupTableViewSection.swift
+++ b/Riot/Modules/Settings/Security/SecureBackup/SettingsSecureBackupTableViewSection.swift
@@ -140,8 +140,20 @@ private enum BackupRows {
                     .info(text: infoText),
                     .createSecureBackupAction
                 ]
-            case .keyBackup(let keyBackupVersion, _, _),
-                 .keyBackupNotTrusted(let keyBackupVersion, _):     // Manage the key backup in the same way for the moment
+            case .keyBackup(let keyBackupVersion, _, let progress):
+                if let progress = progress {
+                    backupRows = [
+                        .info(text: importProgressText(for: progress)),
+                        .deleteKeyBackupAction(keyBackupVersion: keyBackupVersion)
+                    ]
+                } else {
+                    backupRows = [
+                        .info(text: VectorL10n.securitySettingsSecureBackupInfoValid),
+                        .restoreFromKeyBackupAction(keyBackupVersion: keyBackupVersion, title: VectorL10n.securitySettingsSecureBackupRestore),
+                        .deleteKeyBackupAction(keyBackupVersion: keyBackupVersion)
+                    ]
+                }
+            case .keyBackupNotTrusted(let keyBackupVersion, _):
                 backupRows = [
                     .info(text: VectorL10n.securitySettingsSecureBackupInfoValid),
                     .restoreFromKeyBackupAction(keyBackupVersion: keyBackupVersion, title: VectorL10n.securitySettingsSecureBackupRestore),
@@ -160,8 +172,22 @@ private enum BackupRows {
                     .createKeyBackupAction,
                     .resetSecureBackupAction
                 ]
-            case .keyBackup(let keyBackupVersion, _, _),
-                 .keyBackupNotTrusted(let keyBackupVersion, _):     // Manage the key backup in the same way for the moment
+            case .keyBackup(let keyBackupVersion, _, let progress):
+                if let progress = progress {
+                    backupRows = [
+                        .info(text: importProgressText(for: progress)),
+                        .deleteKeyBackupAction(keyBackupVersion: keyBackupVersion),
+                        .resetSecureBackupAction
+                    ]
+                } else {
+                    backupRows = [
+                        .info(text: VectorL10n.securitySettingsSecureBackupInfoValid),
+                        .restoreFromKeyBackupAction(keyBackupVersion: keyBackupVersion, title: VectorL10n.securitySettingsSecureBackupRestore),
+                        .deleteKeyBackupAction(keyBackupVersion: keyBackupVersion),
+                        .resetSecureBackupAction
+                    ]
+                }
+            case .keyBackupNotTrusted(let keyBackupVersion, _):
                 backupRows = [
                     .info(text: VectorL10n.securitySettingsSecureBackupInfoValid),
                     .restoreFromKeyBackupAction(keyBackupVersion: keyBackupVersion, title: VectorL10n.securitySettingsSecureBackupRestore),
@@ -171,6 +197,11 @@ private enum BackupRows {
             }
         }
         self.backupRows = backupRows
+    }
+    
+    private func importProgressText(for progress: Progress) -> String {
+        let percentage = Int(round(progress.fractionCompleted * 100))
+        return VectorL10n.keyBackupRecoverFromPrivateKeyInfo + " \(percentage)%"
     }
 
     // MARK: - Cells -

--- a/Riot/Modules/Settings/Security/SecureBackup/SettingsSecureBackupViewState.swift
+++ b/Riot/Modules/Settings/Security/SecureBackup/SettingsSecureBackupViewState.swift
@@ -35,7 +35,7 @@ enum SettingsSecureBackupViewState {
     /// - keyBackupNotTrusted: There is a backup on the homeserver but it is not trusted
     enum KeyBackupState {
         case noKeyBackup
-        case keyBackup(MXKeyBackupVersion, MXKeyBackupVersionTrust, Progress)
+        case keyBackup(MXKeyBackupVersion, MXKeyBackupVersionTrust, Progress?)
         case keyBackupNotTrusted(MXKeyBackupVersion, MXKeyBackupVersionTrust)
     }
 }

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -1218,9 +1218,9 @@ TableViewSectionsDelegate>
         cell = [secureBackupSection cellForRowAtRow:rowTag];
     }
 #ifdef CROSS_SIGNING_AND_BACKUP_DEV
-    else if (section == SECTION_KEYBACKUP)
+    else if (sectionTag == SECTION_KEYBACKUP)
     {
-        cell = [keyBackupSection cellForRowAtRow:row];
+        cell = [keyBackupSection cellForRowAtRow:rowTag];
     }
 #endif
     else if (sectionTag == SECTION_CROSSSIGNING)

--- a/changelog.d/pr-7078.change
+++ b/changelog.d/pr-7078.change
@@ -1,0 +1,1 @@
+CryptoV2: Import progress for room keys


### PR DESCRIPTION
[SDK change](https://github.com/matrix-org/matrix-ios-sdk/pull/1637)

If we are actively importing keys from backup, display the current import progress as a percentage in the settings, whilst disabling the "restore from backup" button. The import progress replaces the previously unused backup progress.

To keep the progress updating I had to add a simple 1s timer, though I don't think this works very well with the current view model architecture, as it forces the entire section to refresh, leading to visible refresh of the other button rows. In practice only the WIP Crypto V2 will trigger this behaviour, because legacy crypto always returns nil for import progress. This means we can improve the UI behaviour in a future PR

| In progress | Done |
|------------|-------|
|  ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 12 01 49](https://user-images.githubusercontent.com/3922159/201915759-411bbc83-916a-44ae-8a1f-bab8c35b106a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 12 06 46](https://user-images.githubusercontent.com/3922159/201916103-f73b66e7-0016-44e2-991d-a9cb1d48fb14.png) |
