### PR TITLE
Fix a crash when a voice message finishes.

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioPlayer.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioPlayer.swift
@@ -61,7 +61,8 @@ class VoiceMessageAudioPlayer: NSObject {
     }
     
     var currentTime: TimeInterval {
-        return abs(CMTimeGetSeconds(audioPlayer?.currentTime() ?? .zero))
+        let currentTime = abs(CMTimeGetSeconds(audioPlayer?.currentTime() ?? .zero))
+        return currentTime.isFinite ? currentTime : .zero
     }
     
     var playerItems: [AVPlayerItem] {

--- a/changelog.d/7074.bugfix
+++ b/changelog.d/7074.bugfix
@@ -1,0 +1,1 @@
+Voice Messages: Fix crash when voice message finishes playing.


### PR DESCRIPTION
When playing a voice message to the end, there is a crash with the `CALayer` as the waveform's progress gets set to `Double.nan`. This PR will set it to `.zero` in this instance.

Fixes #7074.