### PR TITLE
Update Rich text editor library version

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "2469f27b7e1e51aaa135e09f9005eb10fda686e6"
+        "revision" : "1fbffd0321eb47abcd664ad19c6c943b60abf399"
       }
     },
     {

--- a/changelog.d/6930.bugfix
+++ b/changelog.d/6930.bugfix
@@ -1,0 +1,1 @@
+Labs: Rich text editor: Fix smart punctuation (e.g. double space transforms into dot)

--- a/changelog.d/6983.bugfix
+++ b/changelog.d/6983.bugfix
@@ -1,0 +1,1 @@
+Labs: Rich text editor: Fix input for keyboards that use symbols composition and replacement (e.g. Japanese Romaji, Korean)

--- a/changelog.d/7042.bugfix
+++ b/changelog.d/7042.bugfix
@@ -1,0 +1,1 @@
+Labs: Rich text editor: Fix keyboard suggestions for non-latin keyboards (e.g. Chinese Pinyin)

--- a/changelog.d/7086.bugfix
+++ b/changelog.d/7086.bugfix
@@ -1,0 +1,1 @@
+Labs: Rich text editor: Fix broken backspace around some type of whitespaces

--- a/project.yml
+++ b/project.yml
@@ -53,7 +53,7 @@ packages:
     branch: main
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    revision: 2469f27b7e1e51aaa135e09f9005eb10fda686e6
+    revision: 1fbffd0321eb47abcd664ad19c6c943b60abf399
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0


### PR DESCRIPTION
Fixes #6930

![Simulator Screen Recording - iPhone 13 Pro - 2022-11-21 at 18 49 11](https://user-images.githubusercontent.com/80891108/203125286-8213f955-b2df-4c73-93d9-9d288292afeb.gif)

Fixes #6983 (gif does make it look odd but it has the same behaviour as a standard keyboard & text field)

![Simulator Screen Recording - iPhone 13 Pro - 2022-11-21 at 18 50 03](https://user-images.githubusercontent.com/80891108/203125436-fd63e81a-1fae-450b-8d2c-6f66fb06dd44.gif)

Fixes #7042 

![Simulator Screen Recording - iPhone 13 Pro - 2022-11-21 at 18 46 13](https://user-images.githubusercontent.com/80891108/203124856-7c153e5e-8e96-4619-af3f-dc5b8afe58aa.gif)

Fixes #7086 

Library implementation details: https://github.com/matrix-org/matrix-rich-text-editor/pull/316