### PR TITLE
Rich Text Composer: On iPhone in Landscape mode the fullscreen toggle should be hidden

### DIFF
--- a/Riot/Modules/Room/RoomViewController.xib
+++ b/Riot/Modules/Room/RoomViewController.xib
@@ -36,7 +36,6 @@
                 <outlet property="userSuggestionContainerView" destination="oni-F4-X1U" id="0js-Ji-8Mm"/>
                 <outlet property="view" destination="iN0-l3-epB" id="ieV-u7-rXU"/>
                 <outletCollection property="toolbarContainerConstraints" destination="T1Y-r9-bYV" id="wax-9P-KGn"/>
-                <outletCollection property="toolbarContainerConstraints" destination="ave-fu-X1D" id="gBl-7F-srT"/>
                 <outletCollection property="toolbarContainerConstraints" destination="pRw-S0-6WL" id="q4S-0g-sqQ"/>
                 <outletCollection property="toolbarContainerConstraints" destination="QO8-nF-xys" id="aQe-20-4Pq"/>
                 <outletCollection property="toolbarContainerConstraints" destination="acJ-g8-R7x" id="uEo-Ez-seV"/>

--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -286,9 +286,14 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     private func updateTextViewHeight() {
         let height = UIScreen.main.bounds.height
         let barOffset: CGFloat = 68
-        let toolbarHeight: CGFloat = 82
+        let toolbarHeight: CGFloat = 96
         let finalHeight = height - keyboardHeight - toolbarHeight - barOffset
         wysiwygViewModel.maxExpandedHeight = finalHeight
+        if finalHeight < 200 {
+            wysiwygViewModel.maxCompressedHeight = finalHeight > wysiwygViewModel.minHeight ? finalHeight : wysiwygViewModel.minHeight
+        } else {
+            wysiwygViewModel.maxCompressedHeight = 200
+        }
     }
     
     // MARK: - HtmlRoomInputToolbarViewProtocol

--- a/RiotSwiftUI/Modules/Room/Composer/MockComposerScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/MockComposerScreenState.swift
@@ -32,9 +32,9 @@ enum MockComposerScreenState: MockScreenState, CaseIterable {
         let bindings = ComposerBindings(focused: false)
         
         switch self {
-        case .send: viewModel = ComposerViewModel(initialViewState: ComposerViewState(textFormattingEnabled: true, bindings: bindings))
-        case .edit: viewModel = ComposerViewModel(initialViewState: ComposerViewState(sendMode: .edit, textFormattingEnabled: true, bindings: bindings))
-        case .reply: viewModel = ComposerViewModel(initialViewState: ComposerViewState(eventSenderDisplayName: "TestUser", sendMode: .reply, textFormattingEnabled: true, bindings: bindings))
+        case .send: viewModel = ComposerViewModel(initialViewState: ComposerViewState(textFormattingEnabled: true, isLandscapePhone: false, bindings: bindings))
+        case .edit: viewModel = ComposerViewModel(initialViewState: ComposerViewState(sendMode: .edit, textFormattingEnabled: true, isLandscapePhone: false, bindings: bindings))
+        case .reply: viewModel = ComposerViewModel(initialViewState: ComposerViewState(eventSenderDisplayName: "TestUser", sendMode: .reply, textFormattingEnabled: true, isLandscapePhone: false, bindings: bindings))
         }
         
         let wysiwygviewModel = WysiwygComposerViewModel(minHeight: 20, maxCompressedHeight: 360)

--- a/RiotSwiftUI/Modules/Room/Composer/Model/ComposerModels.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/Model/ComposerModels.swift
@@ -34,8 +34,8 @@ struct FormatItem {
 enum FormatType {
     case bold
     case italic
-    case strikethrough
     case underline
+    case strikethrough
 }
 
 extension FormatType: CaseIterable, Identifiable {

--- a/RiotSwiftUI/Modules/Room/Composer/Model/ComposerViewState.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/Model/ComposerViewState.swift
@@ -20,6 +20,7 @@ struct ComposerViewState: BindableState {
     var eventSenderDisplayName: String?
     var sendMode: ComposerSendMode = .send
     var textFormattingEnabled: Bool
+    var isLandscapePhone: Bool
     var placeholder: String?
     
     var bindings: ComposerBindings
@@ -46,6 +47,10 @@ extension ComposerViewState {
         case .reply: return Asset.Images.inputReplyIcon.name
         default: return nil
         }
+    }
+    
+    var isForcedMinimised: Bool {
+        isLandscapePhone || !textFormattingEnabled
     }
 }
 

--- a/RiotSwiftUI/Modules/Room/Composer/Model/ComposerViewState.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/Model/ComposerViewState.swift
@@ -49,7 +49,7 @@ extension ComposerViewState {
         }
     }
     
-    var isForcedMinimised: Bool {
+    var isMinimiseForced: Bool {
         isLandscapePhone || !textFormattingEnabled
     }
 }

--- a/RiotSwiftUI/Modules/Room/Composer/Test/Unit/ComposerViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/Test/Unit/ComposerViewModelTests.swift
@@ -23,8 +23,13 @@ final class ComposerViewModelTests: XCTestCase {
     var context: ComposerViewModel.Context!
     
     override func setUpWithError() throws {
-        viewModel = ComposerViewModel(initialViewState: ComposerViewState(textFormattingEnabled: true,
-                                                                          bindings: ComposerBindings(focused: false)))
+        viewModel = ComposerViewModel(
+            initialViewState: ComposerViewState(
+                textFormattingEnabled: true,
+                isLandscapePhone: false,
+                bindings: ComposerBindings(focused: false)
+            )
+        )
         context = viewModel.context
     }
     

--- a/RiotSwiftUI/Modules/Room/Composer/View/Composer.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/View/Composer.swift
@@ -35,7 +35,7 @@ struct Composer: View {
     
     private var isLandscapeIphone: Bool {
         let device = UIDevice.current
-        return device.isPhone && device.orientation.isLandscape
+        return device.userInterfaceIdiom == .phone && device.orientation.isLandscape
     }
     
     private let horizontalPadding: CGFloat = 12

--- a/RiotSwiftUI/Modules/Room/Composer/View/Composer.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/View/Composer.swift
@@ -31,12 +31,6 @@ struct Composer: View {
     @Environment(\.theme) private var theme: ThemeSwiftUI
     
     @State private var isActionButtonShowing = false
-    @State private var isToggleButtonHidden = false
-    
-    private var isLandscapeIphone: Bool {
-        let device = UIDevice.current
-        return device.userInterfaceIdiom == .phone && device.orientation.isLandscape
-    }
     
     private let horizontalPadding: CGFloat = 12
     private let borderHeight: CGFloat = 40
@@ -122,7 +116,7 @@ struct Composer: View {
                         wysiwygViewModel.setup()
                     }
                 }
-                if viewModel.viewState.textFormattingEnabled {
+                if !viewModel.viewState.isForcedMinimised {
                     Button {
                         wysiwygViewModel.maximised.toggle()
                     } label: {
@@ -132,7 +126,6 @@ struct Composer: View {
                             .frame(width: 16, height: 16)
                     }
                     .accessibilityIdentifier(toggleButtonAcccessibilityIdentifier)
-                    .isHidden(isToggleButtonHidden)
                     .padding(.leading, 12)
                     .padding(.trailing, 4)
                 }
@@ -204,7 +197,6 @@ struct Composer: View {
             self.resizeAnimationDuration = resizeAnimationDuration
             self.sendMessageAction = sendMessageAction
             self.showSendMediaActions = showSendMediaActions
-            self._isToggleButtonHidden = State(initialValue: isLandscapeIphone)
         }
     
     var body: some View {
@@ -238,11 +230,10 @@ struct Composer: View {
         }
         .padding(.horizontal, horizontalPadding)
         .padding(.bottom, 4)
-        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
-            if wysiwygViewModel.maximised, isLandscapeIphone {
+        .onChange(of: viewModel.viewState.isForcedMinimised) { newValue in
+            if wysiwygViewModel.maximised && newValue {
                 wysiwygViewModel.maximised = false
             }
-            isToggleButtonHidden = isLandscapeIphone
         }
     }
 }

--- a/RiotSwiftUI/Modules/Room/Composer/View/Composer.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/View/Composer.swift
@@ -116,7 +116,7 @@ struct Composer: View {
                         wysiwygViewModel.setup()
                     }
                 }
-                if !viewModel.viewState.isForcedMinimised {
+                if !viewModel.viewState.isMinimiseForced {
                     Button {
                         wysiwygViewModel.maximised.toggle()
                     } label: {
@@ -230,7 +230,7 @@ struct Composer: View {
         }
         .padding(.horizontal, horizontalPadding)
         .padding(.bottom, 4)
-        .onChange(of: viewModel.viewState.isForcedMinimised) { newValue in
+        .onChange(of: viewModel.viewState.isMinimiseForced) { newValue in
             if wysiwygViewModel.maximised && newValue {
                 wysiwygViewModel.maximised = false
             }

--- a/RiotSwiftUI/Modules/Room/Composer/ViewModel/ComposerViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/ViewModel/ComposerViewModel.swift
@@ -63,6 +63,15 @@ final class ComposerViewModel: ComposerViewModelType, ComposerViewModelProtocol 
         }
     }
     
+    var isLandscapePhone: Bool {
+        get {
+            state.isLandscapePhone
+        }
+        set {
+            state.isLandscapePhone = newValue
+        }
+    }
+    
     var isFocused: Bool {
         state.bindings.focused
     }

--- a/RiotSwiftUI/Modules/Room/Composer/ViewModel/ComposerViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/ViewModel/ComposerViewModelProtocol.swift
@@ -24,6 +24,7 @@ protocol ComposerViewModelProtocol {
     var eventSenderDisplayName: String? { get set }
     var placeholder: String? { get set }
     var isFocused: Bool { get }
+    var isLandscapePhone: Bool { get set }
     
     func dismissKeyboard()
     func showKeyboard()

--- a/changelog.d/7096.change
+++ b/changelog.d/7096.change
@@ -1,0 +1,1 @@
+Rich Text Editor: on iPhones when in landscape mode the fullscreen mode is disabled.


### PR DESCRIPTION
![IMG_6710FAB796C9-1](https://user-images.githubusercontent.com/34335419/203381007-026c751b-39a8-43c0-b599-1ebcc8330816.jpeg)


Also moved the position of underline and strikethrough to match the design and improved the landscape sizing, when the view is compressed.
Also I removed a constraint reference from the XIB, that was probably causing a freezing when minimising in some cases.