### PR TITLE
Display sync progress on the loading screen

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1968,6 +1968,12 @@ Tap the + to start adding people.";
 "call_transfer_error_title" = "Error";
 "call_transfer_error_message" = "Call transfer failed";
 
+// MARK: - Launch loading
+
+"launch_loading_server_syncing" = "Syncing with the server";
+"launch_loading_server_syncing_nth_attempt" = "Syncing with the server\n(%@ attempt)";
+"launch_loading_processing_response" = "Processing data\n%@ %%";
+
 // MARK: - Home
 
 "home_empty_view_title" = "Welcome to %@,\n%@";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3179,6 +3179,18 @@ public class VectorL10n: NSObject {
   public static var later: String { 
     return VectorL10n.tr("Vector", "later") 
   }
+  /// Processing data\n%@ %%
+  public static func launchLoadingProcessingResponse(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "launch_loading_processing_response", p1)
+  }
+  /// Syncing with the server
+  public static var launchLoadingServerSyncing: String { 
+    return VectorL10n.tr("Vector", "launch_loading_server_syncing") 
+  }
+  /// Syncing with the server\n(%@ attempt)
+  public static func launchLoadingServerSyncingNthAttempt(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "launch_loading_server_syncing_nth_attempt", p1)
+  }
   /// Leave
   public static var leave: String { 
     return VectorL10n.tr("Vector", "leave") 

--- a/Riot/Modules/Analytics/SentryMonitoringClient.swift
+++ b/Riot/Modules/Analytics/SentryMonitoringClient.swift
@@ -42,6 +42,10 @@ struct SentryMonitoringClient {
             options.enableNetworkTracking = false
             
             options.beforeSend = { event in
+                // Use the actual error message as issue fingerprint
+                if let message = event.message?.formatted {
+                    event.fingerprint = [message]
+                }
                 MXLog.debug("[SentryMonitoringClient] Issue detected: \(event)")
                 return event
             }

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2394,7 +2394,17 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     {
         MXLogDebug(@"[AppDelegate] showLaunchAnimation");
         
-        LaunchLoadingView *launchLoadingView = [LaunchLoadingView instantiate];
+        LaunchLoadingView *launchLoadingView;
+        if (MXSDKOptions.sharedInstance.enableSyncProgress)
+        {
+            MXSession *mainSession = self.mxSessions.firstObject;
+            launchLoadingView = [LaunchLoadingView instantiateWithSyncProgress:mainSession.syncProgress];
+        }
+        else
+        {
+            launchLoadingView = [LaunchLoadingView instantiateWithSyncProgress:nil];
+        }
+                
         launchLoadingView.frame = window.bounds;
         [launchLoadingView updateWithTheme:ThemeService.shared.theme];
         launchLoadingView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;

--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -613,7 +613,8 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     
     /// Replace the contents of the navigation router with a loading animation.
     private func showLoadingAnimation() {
-        let loadingViewController = LaunchLoadingViewController()
+        let syncProgress: MXSessionSyncProgress? = MXSDKOptions.sharedInstance().enableSyncProgress ? session?.syncProgress : nil
+        let loadingViewController = LaunchLoadingViewController(syncProgress: syncProgress)
         loadingViewController.modalPresentationStyle = .fullScreen
         
         // Replace the navigation stack with the loading animation

--- a/Riot/Modules/Authentication/Legacy/LegacyAuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/Legacy/LegacyAuthenticationCoordinator.swift
@@ -106,7 +106,8 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
     // MARK: - Private
     
     private func showLoadingAnimation() {
-        let loadingViewController = LaunchLoadingViewController()
+        let syncProgress: MXSessionSyncProgress? = MXSDKOptions.sharedInstance().enableSyncProgress ? session?.syncProgress : nil
+        let loadingViewController = LaunchLoadingViewController(syncProgress: syncProgress)
         loadingViewController.modalPresentationStyle = .fullScreen
         
         // Replace the navigation stack with the loading animation

--- a/Riot/Modules/LaunchLoading/LaunchLoadingView.xib
+++ b/Riot/Modules/LaunchLoading/LaunchLoadingView.xib
@@ -1,32 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB" customClass="LaunchLoadingView" customModule="Riot" customModuleProvider="target">
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB" customClass="LaunchLoadingView" customModule="Element" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3KG-IR-FPV" customClass="ElementView" customModule="Riot" customModuleProvider="target">
+                <view contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3KG-IR-FPV" customClass="ElementView" customModule="Element" customModuleProvider="target">
                     <rect key="frame" x="95" y="219" width="130" height="130"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
+                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzS-bN-Pht">
+                    <rect key="frame" x="20" y="528" width="280" height="0.0"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <color key="textColor" systemColor="systemGrayColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
+                <constraint firstAttribute="trailing" secondItem="wzS-bN-Pht" secondAttribute="trailing" constant="20" id="Naf-Cc-qLq"/>
+                <constraint firstAttribute="bottom" secondItem="wzS-bN-Pht" secondAttribute="bottom" constant="40" id="cnE-Pn-Wb2"/>
                 <constraint firstItem="3KG-IR-FPV" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="ig4-YX-FoT"/>
                 <constraint firstItem="3KG-IR-FPV" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="r9K-7c-fjh"/>
+                <constraint firstItem="wzS-bN-Pht" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="uZP-JW-dVR"/>
             </constraints>
             <connections>
                 <outlet property="animationView" destination="3KG-IR-FPV" id="Are-fn-laY"/>
+                <outlet property="statusLabel" destination="wzS-bN-Pht" id="Mj2-rn-i5x"/>
             </connections>
             <point key="canvasLocation" x="136.875" y="132.5"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Riot/Modules/LaunchLoading/LaunchLoadingViewController.swift
+++ b/Riot/Modules/LaunchLoading/LaunchLoadingViewController.swift
@@ -21,10 +21,10 @@ class LaunchLoadingViewController: UIViewController, Reusable {
     
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     
-    init() {
+    init(syncProgress: MXSessionSyncProgress?) {
         super.init(nibName: "LaunchLoadingViewController", bundle: nil)
         
-        let launchLoadingView = LaunchLoadingView.instantiate()
+        let launchLoadingView = LaunchLoadingView.instantiate(syncProgress: syncProgress)
         launchLoadingView.update(theme: ThemeService.shared().theme)
         view.vc_addSubViewMatchingParent(launchLoadingView)
         

--- a/changelog.d/pr-7101.change
+++ b/changelog.d/pr-7101.change
@@ -1,0 +1,2 @@
+Loading: Display sync progress on the loading screen
+


### PR DESCRIPTION
Related [SDK change](https://github.com/matrix-org/matrix-ios-sdk/pull/1643)

Use changes in the SDK to display sync status on the launch loading screen, if the feature flag is enabled. The design is a simple copy that can be further tweaked, as the flag is currently disabled, and only enabled on Element-R builds.

Unrelatedly, change the fingerprint of Sentry issues to match the message of the issue

| Syncing | Processing |
|---------|------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-23 at 09 53 04](https://user-images.githubusercontent.com/3922159/203529087-8dbf1a65-ff2a-4f9a-a26a-47143f942d93.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-23 at 09 53 34](https://user-images.githubusercontent.com/3922159/203529109-622e077c-f2b8-4f1a-97f8-4a4eea36779f.png) |

