### PR TITLE
Mitigate flickering on polls votes (PSG-816)

### DIFF
--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -60,7 +60,7 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
         }
         
         selectedAnswerIdentifiersSubject
-            .debounce(for: 1.0, scheduler: RunLoop.main)
+            .debounce(for: 2.0, scheduler: RunLoop.main)
             .removeDuplicates()
             .sink { [weak self] identifiers in
                 guard let self = self else { return }

--- a/changelog.d/5329.bugfix
+++ b/changelog.d/5329.bugfix
@@ -1,0 +1,1 @@
+Polls: mitigate flickering on vote.


### PR DESCRIPTION
This PR mitigate [this problem](https://github.com/vector-im/element-ios/issues/5329) by making larger the debounce of votes.

Fixes https://github.com/vector-im/element-ios/issues/5329