### PR TITLE
Do not retry initial sync on fatal errors

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -1677,6 +1677,14 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
                     NSString *myUserId = self.mxSession.myUser.userId;
                     [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                 }
+                
+                // If we encounter a fatal sync issue, we do not re-attempt sync as we cannot recover
+                // from this problem, and the user needs to restart / re-install the app
+                NSSet *fatalSyncErrors = [NSSet setWithArray:@[MXCryptoErrorDomain]];
+                if ([fatalSyncErrors containsObject:error.domain])
+                {
+                    return;
+                }
 
                 // Check if it is a network connectivity issue
                 AFNetworkReachabilityManager *networkReachabilityManager = [AFNetworkReachabilityManager sharedManager];

--- a/changelog.d/pr-7115.change
+++ b/changelog.d/pr-7115.change
@@ -1,0 +1,1 @@
+Session: Do not retry initial sync on fatal errors


### PR DESCRIPTION
If we encounter fatal error during initial sync (defined as a list of error domains), do not attempt another sync as this will not resolve the issue