### PR TITLE
Download device keys for self prior to verification checks

### DIFF
--- a/changelog.d/pr-7142.bugfix
+++ b/changelog.d/pr-7142.bugfix
@@ -1,0 +1,1 @@
+Fix E2EE set up failure whilst signing in using QR code


### PR DESCRIPTION
This PR resolves the equivalent of https://github.com/vector-im/element-android/issues/7676 but for iOS.

There is a race in the current QR implementation around device keys.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>