### PR TITLE
Delete old account data (PSG-635)

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Service/MatrixSDK/UserSessionsDataProvider.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Service/MatrixSDK/UserSessionsDataProvider.swift
@@ -77,6 +77,15 @@ class UserSessionsDataProvider: UserSessionsDataProviderProtocol {
 }
 
 extension UserSessionsDataProvider {
+    private func deleteAccountDataIfNeeded(deviceList: [MXDevice]) {
+        let obsoletedDeviceAccountDataKeys = obsoletedDeviceAccountData(deviceList: deviceList,
+                                                                        accountDataEvents: session.accountData.allAccountDataEvents())
+        
+        for accountDataKey in obsoletedDeviceAccountDataKeys {
+            session.deleteAccountData(withType: accountDataKey, success: {}, failure: { _ in })
+        }
+    }
+    
     // internal just to facilitate tests
     func obsoletedDeviceAccountData(deviceList: [MXDevice], accountDataEvents: [String: Any]) -> Set<String> {
         let deviceAccountDataKeys = Set(
@@ -90,14 +99,5 @@ extension UserSessionsDataProvider {
         })
         
         return deviceAccountDataKeys.subtracting(expectedDeviceAccountDataKeys)
-    }
-    
-    private func deleteAccountDataIfNeeded(deviceList: [MXDevice]) {
-        let obsoletedDeviceAccountDataKeys = obsoletedDeviceAccountData(deviceList: deviceList,
-                                                                        accountDataEvents: session.accountData.allAccountDataEvents())
-        
-        for accountDataKey in obsoletedDeviceAccountDataKeys {
-            session.deleteAccountData(withType: accountDataKey, success: {}, failure: { _ in })
-        }
     }
 }

--- a/RiotTests/UserSessionsDataProviderTests.swift
+++ b/RiotTests/UserSessionsDataProviderTests.swift
@@ -106,7 +106,8 @@ class UserSessionCardViewDataTests: XCTestCase {
         let dataProvider = UserSessionsDataProvider(session: mxSession)
         
         let accountDataEvents: [String: Any] = [
-            "io.element.matrix_client_information.D": ""
+            "io.element.matrix_client_information.D": "",
+            "foo": ""
         ]
         
         let expectedObsoletedEvents: Set = [
@@ -123,7 +124,8 @@ class UserSessionCardViewDataTests: XCTestCase {
         let dataProvider = UserSessionsDataProvider(session: mxSession)
         
         let accountDataEvents: [String: Any] = [
-            "io.element.matrix_client_information.C": ""
+            "io.element.matrix_client_information.C": "",
+            "foo": ""
         ]
         
         let expectedObsoletedEvents: Set<String> = []
@@ -138,7 +140,7 @@ class UserSessionCardViewDataTests: XCTestCase {
         
         let expectedObsoletedEvents = Set(["D", "E", "F"].map { "io.element.matrix_client_information.\($0)"})
         
-        let accountDataEvents: [String: Any] = expectedObsoletedEvents.reduce(into: [:]) { partialResult, value in
+        let accountDataEvents: [String: Any] = expectedObsoletedEvents.reduce(into: ["foo": ""]) { partialResult, value in
             partialResult[value] = ""
         }
         

--- a/RiotTests/UserSessionsDataProviderTests.swift
+++ b/RiotTests/UserSessionsDataProviderTests.swift
@@ -100,9 +100,66 @@ class UserSessionCardViewDataTests: XCTestCase {
         
         XCTAssertEqual(verificationState, .permanentlyUnverified)
     }
+    
+    func testObsoletedDeviceInformation_someMatch() {
+        let mxSession = MockSession(canCrossSign: true)
+        let dataProvider = UserSessionsDataProvider(session: mxSession)
+        
+        let accountDataEvents: [String: Any] = [
+            "io.element.matrix_client_information.D": ""
+        ]
+        
+        let expectedObsoletedEvents: Set = [
+            "io.element.matrix_client_information.D"
+        ]
+        
+        let obsoletedEvents = dataProvider.obsoletedDeviceAccountData(deviceList: .mockDevices, accountDataEvents: accountDataEvents)
+        
+        XCTAssertEqual(obsoletedEvents, expectedObsoletedEvents)
+    }
+    
+    func testObsoletedDeviceInformation_noMatch() {
+        let mxSession = MockSession(canCrossSign: true)
+        let dataProvider = UserSessionsDataProvider(session: mxSession)
+        
+        let accountDataEvents: [String: Any] = [
+            "io.element.matrix_client_information.C": ""
+        ]
+        
+        let expectedObsoletedEvents: Set<String> = []
+        let obsoletedEvents = dataProvider.obsoletedDeviceAccountData(deviceList: .mockDevices, accountDataEvents: accountDataEvents)
+        
+        XCTAssertEqual(obsoletedEvents, expectedObsoletedEvents)
+    }
+    
+    func testObsoletedDeviceInformation_allMatch() {
+        let mxSession = MockSession(canCrossSign: true)
+        let dataProvider = UserSessionsDataProvider(session: mxSession)
+        
+        let expectedObsoletedEvents = Set(["D", "E", "F"].map { "io.element.matrix_client_information.\($0)"})
+        
+        let accountDataEvents: [String: Any] = expectedObsoletedEvents.reduce(into: [:]) { partialResult, value in
+            partialResult[value] = ""
+        }
+        
+        let obsoletedEvents = dataProvider.obsoletedDeviceAccountData(deviceList: .mockDevices, accountDataEvents: accountDataEvents)
+        
+        XCTAssertEqual(obsoletedEvents, expectedObsoletedEvents)
+    }
 }
 
 // MARK: Mocks
+
+private extension Array where Element == MXDevice {
+    static let mockDevices: [MXDevice] = {
+        ["A", "B", "C"]
+            .map {
+                let device = MXDevice()
+                device.deviceId = $0
+                return device
+            }
+    }()
+}
 
 // Device ID constants.
 private extension String {


### PR DESCRIPTION
### Description

This PR removes from the user's `account_data` device information that are outdated.
For more context see this [MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/3391).