### PR TITLE
Fix for formatted links appearing in black

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -51,9 +51,9 @@ class HTMLFormatter: NSObject {
             DTDefaultFontName: font.fontName,
             DTDefaultFontSize: font.pointSize,
             DTDefaultLinkDecoration: false,
-            // This fixes the issue where links are displayed in black
-            // However doesn't matter the value provided the color doesn't change
-            // From the default accent one
+            /* This fixes the issue where links are displayed in black
+             but no matter the value provided, the color never changes
+             from the default green one */
             DTDefaultLinkColor: "",
             DTWillFlushBlockCallBack: sanitizeCallback
         ]

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -52,8 +52,8 @@ class HTMLFormatter: NSObject {
             DTDefaultFontSize: font.pointSize,
             DTDefaultLinkDecoration: false,
             /* This fixes the issue where links are displayed in black
-             but no matter the value provided, the color never changes
-             from the default green one */
+             on DTCoreText 1.6.26, the provided value does not matter
+             the tintColor of the UI element will be used for links */
             DTDefaultLinkColor: "",
             DTWillFlushBlockCallBack: sanitizeCallback
         ]

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -114,27 +114,3 @@ extension HTMLFormatter {
         return stringBuilder?.generatedAttributedString()
     }
 }
-
-extension UIColor {
-    func toHexString() -> String {
-        var r:CGFloat = 0
-        var g:CGFloat = 0
-        var b:CGFloat = 0
-        var a:CGFloat = 0
-
-        getRed(&r, green: &g, blue: &b, alpha: &a)
-
-        let rgb:Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
-
-        return NSString(format:"#%06x", rgb) as String
-    }
-
-    convenience init(red: Int, green: Int, blue: Int) {
-        assert(red >= 0 && red <= 255, "Invalid red component")
-        assert(green >= 0 && green <= 255, "Invalid green component")
-        assert(blue >= 0 && blue <= 255, "Invalid blue component")
-
-        self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
-    }
-
-}

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -67,7 +67,6 @@ class HTMLFormatter: NSObject {
         MXKTools.removeDTCoreTextArtifacts(mutableString)
         postFormatOperations?(mutableString)
 
-
         return mutableString
     }
 

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -51,6 +51,10 @@ class HTMLFormatter: NSObject {
             DTDefaultFontName: font.fontName,
             DTDefaultFontSize: font.pointSize,
             DTDefaultLinkDecoration: false,
+            // This fixes the issue where links are displayed in black
+            // However doesn't matter the value provided the color doesn't change
+            // From the default accent one
+            DTDefaultLinkColor: "",
             DTWillFlushBlockCallBack: sanitizeCallback
         ]
         options.merge(extraOptions) { (_, new) in new }
@@ -62,6 +66,7 @@ class HTMLFormatter: NSObject {
         let mutableString = NSMutableAttributedString(attributedString: string)
         MXKTools.removeDTCoreTextArtifacts(mutableString)
         postFormatOperations?(mutableString)
+
 
         return mutableString
     }
@@ -108,4 +113,28 @@ extension HTMLFormatter {
 
         return stringBuilder?.generatedAttributedString()
     }
+}
+
+extension UIColor {
+    func toHexString() -> String {
+        var r:CGFloat = 0
+        var g:CGFloat = 0
+        var b:CGFloat = 0
+        var a:CGFloat = 0
+
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+
+        let rgb:Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
+
+        return NSString(format:"#%06x", rgb) as String
+    }
+
+    convenience init(red: Int, green: Int, blue: Int) {
+        assert(red >= 0 && red <= 255, "Invalid red component")
+        assert(green >= 0 && green <= 255, "Invalid green component")
+        assert(blue >= 0 && blue <= 255, "Invalid blue component")
+
+        self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
+    }
+
 }

--- a/changelog.d/7109.bugfix
+++ b/changelog.d/7109.bugfix
@@ -1,0 +1,1 @@
+Timeline: fixed an issue where formatted links appeared in black.


### PR DESCRIPTION
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-12-15 at 01 42 18](https://user-images.githubusercontent.com/34335419/207745714-89cbf451-1d85-429b-b21d-f592c08fdb25.png)
