### PR TITLE
Handle decryption errors in polls (PSG-1023)

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2347,6 +2347,8 @@ Tap the + to start adding people.";
 
 "poll_timeline_not_closed_subtitle" = "Please try again";
 
+"poll_timeline_decryption_error" = "Due to decryption errors, some votes may not be counted";
+
 // MARK: - Location sharing
 
 "location_sharing_title" = "Location";

--- a/Riot/Categories/Sequence.swift
+++ b/Riot/Categories/Sequence.swift
@@ -1,0 +1,28 @@
+// 
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+extension Sequence {
+    func group<GroupID: Hashable>(by keyPath: KeyPath<Element, GroupID>) -> [GroupID: [Element]] {
+        var result: [GroupID: [Element]] = .init()
+        
+        for item in self {
+            let groupId = item[keyPath: keyPath]
+            result[groupId] = (result[groupId] ?? []) + [item]
+        }
+        
+        return result
+    }
+}

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4839,6 +4839,10 @@ public class VectorL10n: NSObject {
   public static var pollEditFormUpdateFailureTitle: String { 
     return VectorL10n.tr("Vector", "poll_edit_form_update_failure_title") 
   }
+  /// Due to decryption errors, some votes may not be counted
+  public static var pollTimelineDecryptionError: String { 
+    return VectorL10n.tr("Vector", "poll_timeline_decryption_error") 
+  }
   /// Please try again
   public static var pollTimelineNotClosedSubtitle: String { 
     return VectorL10n.tr("Vector", "poll_timeline_not_closed_subtitle") 

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -83,10 +83,6 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
 
     func start() { }
     
-    func handleErroredRelatedEventsIds(_ ids: Set<String>?, to parentEvent: String) {
-        pollAggregator.handleErroredRelatedEventsIds(ids, to: parentEvent)
-    }
-    
     func toPresentable() -> UIViewController {
         VectorHostingController(rootView: TimelinePollView(viewModel: viewModel.context))
     }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -83,6 +83,10 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
 
     func start() { }
     
+    func handleErroredRelatedEventsIds(_ ids: Set<String>?, to parentEvent: String) {
+        pollAggregator.handleErroredRelatedEventsIds(ids, to: parentEvent)
+    }
+    
     func toPresentable() -> UIViewController {
         VectorHostingController(rootView: TimelinePollView(viewModel: viewModel.context))
     }
@@ -132,7 +136,8 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
                                    totalAnswerCount: poll.totalAnswerCount,
                                    type: pollKindToTimelinePollType(poll.kind),
                                    maxAllowedSelections: poll.maxAllowedSelections,
-                                   hasBeenEdited: poll.hasBeenEdited)
+                                   hasBeenEdited: poll.hasBeenEdited,
+                                   hasDecryptionError: poll.hasDecryptionError)
     }
     
     private func pollKindToTimelinePollType(_ kind: PollKind) -> TimelinePollType {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
@@ -76,20 +76,19 @@ private extension TimelinePollProvider {
     func updateDecryptionErrorsObserver(newSession: MXSession?) {
         removeObserverIfNeeded()
         
-        guard let session = newSession else {
+        guard let newSession = newSession else {
             return
         }
         
-        decryptionErrorsObserver = NotificationCenter.default.addObserver(forName: .mxSessionDidFailToDecryptEvents, object: session, queue: .main) { [weak self] notification in
+        decryptionErrorsObserver = NotificationCenter.default.addObserver(forName: .mxSessionDidFailToDecryptEvents, object: newSession, queue: .main) { [weak self] notification in
             guard
-                let self = self,
-                notification.object as? MXSession == session,
+                notification.object as? MXSession == newSession,
                 let failedEvents = notification.userInfo?[kMXSessionNotificationEventsArrayKey] as? [MXEvent]
             else {
                 return
             }
             
-            self.storeErroredEvents(failedEvents)
+            self?.storeErroredEvents(failedEvents)
         }
     }
     

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Test/Unit/TimelinePollViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Test/Unit/TimelinePollViewModelTests.swift
@@ -35,7 +35,8 @@ class TimelinePollViewModelTests: XCTestCase {
                                                totalAnswerCount: 3,
                                                type: .disclosed,
                                                maxAllowedSelections: 1,
-                                               hasBeenEdited: false)
+                                               hasBeenEdited: false,
+                                               hasDecryptionError: false)
         
         viewModel = TimelinePollViewModel(timelinePollDetails: timelinePoll)
         context = viewModel.context

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
@@ -64,13 +64,15 @@ struct TimelinePollDetails {
     var type: TimelinePollType
     var maxAllowedSelections: UInt
     var hasBeenEdited = true
+    var hasDecryptionError: Bool
     
     init(question: String, answerOptions: [TimelinePollAnswerOption],
          closed: Bool,
          totalAnswerCount: UInt,
          type: TimelinePollType,
          maxAllowedSelections: UInt,
-         hasBeenEdited: Bool) {
+         hasBeenEdited: Bool,
+         hasDecryptionError: Bool) {
         self.question = question
         self.answerOptions = answerOptions
         self.closed = closed
@@ -78,6 +80,7 @@ struct TimelinePollDetails {
         self.type = type
         self.maxAllowedSelections = maxAllowedSelections
         self.hasBeenEdited = hasBeenEdited
+        self.hasDecryptionError = hasDecryptionError
     }
     
     var hasCurrentUserVoted: Bool {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
@@ -38,7 +38,8 @@ enum MockTimelinePollScreenState: MockScreenState, CaseIterable {
                                        totalAnswerCount: 20,
                                        type: self == .closedDisclosed || self == .openDisclosed ? .disclosed : .undisclosed,
                                        maxAllowedSelections: 1,
-                                       hasBeenEdited: false)
+                                       hasBeenEdited: false,
+                                       hasDecryptionError: false)
         
         let viewModel = TimelinePollViewModel(timelinePollDetails: poll)
         

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollAnswerOptionButton.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollAnswerOptionButton.swift
@@ -152,7 +152,8 @@ struct TimelinePollAnswerOptionButton_Previews: PreviewProvider {
                             totalAnswerCount: 100,
                             type: type,
                             maxAllowedSelections: 1,
-                            hasBeenEdited: false)
+                            hasBeenEdited: false,
+                            hasDecryptionError: false)
     }
     
     static func buildAnswerOption(text: String = "Test", selected: Bool, winner: Bool = false) -> TimelinePollAnswerOption {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
@@ -49,6 +49,7 @@ struct TimelinePollView: View {
             .fixedSize(horizontal: false, vertical: true)
             
             Text(totalVotesString)
+                .lineLimit(2)
                 .font(theme.fonts.footnote)
                 .foregroundColor(theme.colors.tertiaryContent)
         }
@@ -61,6 +62,10 @@ struct TimelinePollView: View {
     
     private var totalVotesString: String {
         let poll = viewModel.viewState.poll
+        
+        if poll.hasDecryptionError, poll.totalAnswerCount > 0 {
+            return VectorL10n.pollTimelineDecryptionError
+        }
         
         if poll.closed {
             if poll.totalAnswerCount == 1 {

--- a/changelog.d/pr-7206.change
+++ b/changelog.d/pr-7206.change
@@ -1,0 +1,1 @@
+Polls: show decryption errors in timeline during aggregations.


### PR DESCRIPTION
### Description

This PR adds the logic for showing decryption errors in polls.

### Dependency

https://github.com/matrix-org/matrix-ios-sdk/pull/1673

### Result in the timeline
<img src="https://user-images.githubusercontent.com/19324622/209354194-883fb7b5-9ba3-46a0-8068-e7b1982b7264.png" width=50% height=50%>

