### PR TITLE
Change display name fallback for sessions

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/Common/UserSessionNameFormatter.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Common/UserSessionNameFormatter.swift
@@ -19,7 +19,7 @@ import Foundation
 /// Enables to build user session name
 enum UserSessionNameFormatter {
     /// Session name with client name and session display name
-    static func sessionName(deviceType: DeviceType, sessionDisplayName: String?) -> String {
-        sessionDisplayName?.vc_nilIfEmpty() ?? deviceType.name
+    static func sessionName(sessionId: String, sessionDisplayName: String?) -> String {
+        sessionDisplayName?.vc_nilIfEmpty() ?? sessionId
     }
 }

--- a/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardViewData.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Common/View/UserSessionCardViewData.swift
@@ -102,7 +102,7 @@ struct UserSessionCardViewData {
          isCurrentSessionDisplayMode: Bool = false,
          isActive: Bool) {
         self.sessionId = sessionId
-        sessionName = UserSessionNameFormatter.sessionName(deviceType: deviceType, sessionDisplayName: sessionDisplayName)
+        sessionName = UserSessionNameFormatter.sessionName(sessionId: sessionId, sessionDisplayName: sessionDisplayName)
         self.verificationState = verificationState
         
         var lastActivityDateString: String?

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionListItemViewDataFactory.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionListItemViewDataFactory.swift
@@ -19,7 +19,7 @@ import Foundation
 struct UserSessionListItemViewDataFactory {
     func create(from sessionInfo: UserSessionInfo,
                 isSelected: Bool = false) -> UserSessionListItemViewData {
-        let sessionName = UserSessionNameFormatter.sessionName(deviceType: sessionInfo.deviceType,
+        let sessionName = UserSessionNameFormatter.sessionName(sessionId: sessionInfo.id,
                                                                sessionDisplayName: sessionInfo.name)
         let sessionDetails = buildSessionDetails(sessionInfo: sessionInfo)
         let deviceAvatarViewData = DeviceAvatarViewData(deviceType: sessionInfo.deviceType,


### PR DESCRIPTION
### Description

This PR changes the fallback for sessions' names to the session id instead of the session's device type.

<img src="https://user-images.githubusercontent.com/19324622/210061644-e5b1400d-8d48-417a-8410-ddcce461bf70.png" width=50% height=50%>