### PR TITLE
Fix hidden live location timeline tiles after text messages (PSG-1082)

### DIFF
--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -1193,6 +1193,9 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
             case MXEventTypePollStart:
                 shouldAddEvent = NO;
                 break;
+            case MXEventTypeBeaconInfo:
+                shouldAddEvent = NO;
+                break;
             case MXEventTypeCustom:
             {
                 if ([event.type isEqualToString:kWidgetMatrixEventTypeString]

--- a/changelog.d/pr-7220.bugfix
+++ b/changelog.d/pr-7220.bugfix
@@ -1,0 +1,1 @@
+Fix hidden live location timeline tiles after text messages


### PR DESCRIPTION
This prevents `MXEventTypeBeaconInfo` events from being added into other bubble cell data objects.

Previously, when starting a live location share right after sending a text message, the beacon info event would get appended into the text message's bubble cell data which prevented it from rendering.

Similarly, when restarting the app in such a situation the events would be getting reprocessed _in backwards order_ which meant the final beacon info landed in its own bubble cell data (causing it to render) but a beacon info right before the text message would now get combined with the text message causing it to go hidden.

To reproduce:

* Send a text message
* Start a live location share
* Notice that the map tile doesn't render

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-03 at 14 01 23](https://user-images.githubusercontent.com/1137962/210362193-4cf7e98d-fbba-4a2a-9484-bf8b29f0d50d.png)

