### PR TITLE
Fix clearCache method on VoiceMessageAttachmentCacheManager

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift
@@ -137,7 +137,7 @@ class VoiceMessageAttachmentCacheManager {
         durations.removeAll()
         finalURLs.removeAll()
         
-        if FileManager.default.fileExists(atPath: temporaryFilesFolderURL.absoluteString) {
+        if FileManager.default.fileExists(atPath: temporaryFilesFolderURL.path) {
             do {
                 try FileManager.default.removeItem(at: temporaryFilesFolderURL)
             } catch {

--- a/changelog.d/pr-7244.bugfix
+++ b/changelog.d/pr-7244.bugfix
@@ -1,0 +1,1 @@
+Fix an issue preventing temporary audio files to be deleted.


### PR DESCRIPTION
voice messages temporary audio files are not deleted when clearing the cache because we are testing the existence of the temporary directory url using absoluteString instead of path.
