### PR TITLE
Pause voice broadcast listening on new voice broadcast recording (#7192)

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2451,6 +2451,9 @@ static CGSize kThreadListBarButtonItemImageSize;
         return;
     }
     
+    // Prevents listening a VB when recording a new one
+    [VoiceBroadcastPlaybackProvider.shared pausePlaying];
+    
     // Request the voice broadcast service to start recording - No service is returned if someone else is already broadcasting in the room
     [session getOrCreateVoiceBroadcastServiceFor:self.roomDataSource.room completion:^(VoiceBroadcastService *voiceBroadcastService) {
         if (voiceBroadcastService) {

--- a/changelog.d/7192.bugfix
+++ b/changelog.d/7192.bugfix
@@ -1,0 +1,1 @@
+Voice Broadcast: Pause voice broadcast listening on new voice broadcast recording


### PR DESCRIPTION
Resolves #7192 

Steps to test:
- Start listening a stopped VB (not a live one)
- Start a new VB recording.
- Playback must stop before the recorder starts.