### PR TITLE
Fix Element Alpha workflow

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -13,22 +13,10 @@ env:
   MX_GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
 
 jobs:
-  check-secret:
-    runs-on: macos-12
-    outputs:
-      out-key: ${{ steps.out-key.outputs.defined }}
-    steps:
-        - id: out-key
-          env:
-            P12_KEY: ${{ secrets.ALPHA_CERTIFICATES_P12 }}
-            P12_PASSWORD_KEY: ${{ secrets.ALPHA_CERTIFICATES_P12 }}
-          if: "${{ env.P12_KEY != '' || env.P12_PASSWORD_KEY != '' }}"
-          run: echo "::set-output name=defined::true"
   build:
-    # Run job if secrets are available (not available for forks).
-    needs: [check-secret]
+    # Don't run for forks as secrets are unavailable.
     if: |
-      needs.check-secret.outputs.out-key == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event_name == 'push' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Trigger-PR-Build')))
 

--- a/changelog.d/pr-7256.build
+++ b/changelog.d/pr-7256.build
@@ -1,0 +1,1 @@
+Fix Element Alpha workflow not being able to run.


### PR DESCRIPTION
`set-output` is deprecated and the generated warning fails the secret check.
This change [matches the workflow](https://github.com/vector-im/element-x-ios/blob/3d1266ca255585436bc368fc9318f0c2eff8db35/.github/workflows/release-alpha.yml#L12) used on ElementX which compares the PR's repo to make sure it matches the workflow's repo.
