### PR TITLE
Different link colours are now supported and by default most links are now in blue in the timeline

### DIFF
--- a/DesignKit/Source/ColorValues.swift
+++ b/DesignKit/Source/ColorValues.swift
@@ -48,5 +48,7 @@ public struct ColorValues: Colors {
     
     public let ems: UIColor
     
+    public let links: UIColor
+    
     public let namesAndAvatars: [UIColor]
 }

--- a/DesignKit/Source/Colors.swift
+++ b/DesignKit/Source/Colors.swift
@@ -67,6 +67,10 @@ public protocol Colors {
     /// Global color: The EMS brand's purple colour.
     var ems: ColorType { get }
     
+    /// - Links
+    /// - Hyperlinks
+    var links: ColorType { get }
+    
     /// - Names in chat timeline
     /// - Avatars default states that include first name letter
     var namesAndAvatars: [ColorType] { get }

--- a/DesignKit/Source/ColorsSwiftUI.swift
+++ b/DesignKit/Source/ColorsSwiftUI.swift
@@ -21,7 +21,7 @@ import SwiftUI
  Struct for holding colors for use in SwiftUI.
  */
 public struct ColorSwiftUI: Colors {
-
+    
     public let accent: Color
     
     public let alert: Color
@@ -48,8 +48,10 @@ public struct ColorSwiftUI: Colors {
     
     public var ems: Color
     
-    public let namesAndAvatars: [Color]
+    public let links: Color
     
+    public let namesAndAvatars: [Color]
+        
     init(values: ColorValues) {
         accent = Color(values.accent)
         alert = Color(values.alert)
@@ -64,6 +66,7 @@ public struct ColorSwiftUI: Colors {
         navigation = Color(values.navigation)
         background = Color(values.background)
         ems = Color(values.ems)
+        links = Color(values.links)
         namesAndAvatars = values.namesAndAvatars.map({ Color($0) })
     }
 }

--- a/DesignKit/Source/ColorsUIkit.swift
+++ b/DesignKit/Source/ColorsUIkit.swift
@@ -45,6 +45,8 @@ import UIKit
     public let navigation: UIColor
 
     public let background: UIColor
+    
+    public let links: UIColor
 
     public let namesAndAvatars: [UIColor]
     
@@ -61,6 +63,7 @@ import UIKit
         tile = values.tile
         navigation = values.navigation
         background = values.background
+        links = values.links
         namesAndAvatars = values.namesAndAvatars
     }
 }

--- a/DesignKit/Variants/Colors/Dark/DarkColors.swift
+++ b/DesignKit/Variants/Colors/Dark/DarkColors.swift
@@ -34,6 +34,7 @@ public class DarkColors {
         navigation: UIColor(rgb:0x21262C),
         background: UIColor(rgb:0x15191E),
         ems: UIColor(rgb: 0x7E69FF),
+        links: UIColor(rgb: 0x0086E6),
         namesAndAvatars: [
             UIColor(rgb:0x368BD6),
             UIColor(rgb:0xAC3BA8),

--- a/DesignKit/Variants/Colors/Light/LightColors.swift
+++ b/DesignKit/Variants/Colors/Light/LightColors.swift
@@ -35,6 +35,7 @@ public class LightColors {
         navigation: UIColor(rgb:0xF4F6FA),
         background: UIColor(rgb:0xFFFFFF),
         ems: UIColor(rgb: 0x7E69FF),
+        links: UIColor(rgb: 0x0086E6),
         namesAndAvatars: [
             UIColor(rgb:0x368BD6),
             UIColor(rgb:0xAC3BA8),

--- a/Riot/Categories/MXKTableViewCellWithTextView.swift
+++ b/Riot/Categories/MXKTableViewCellWithTextView.swift
@@ -24,7 +24,6 @@ extension MXKTableViewCellWithTextView: Themable {
     func update(theme: Theme) {
         mxkTextView.backgroundColor = .clear
         mxkTextView.textColor = theme.textPrimaryColor
-        mxkTextView.tintColor = theme.tintColor
         backgroundColor = theme.backgroundColor
         contentView.backgroundColor = .clear
     }

--- a/Riot/Managers/Theme/Themes/DarkTheme.swift
+++ b/Riot/Managers/Theme/Themes/DarkTheme.swift
@@ -168,14 +168,8 @@ class DarkTheme: NSObject, Theme {
         searchBar.backgroundImage = UIImage() // Remove top and bottom shadow        
         searchBar.tintColor = self.tintColor
         
-        if #available(iOS 13.0, *) {
-            searchBar.searchTextField.backgroundColor = self.searchBackgroundColor
-            searchBar.searchTextField.textColor = self.searchPlaceholderColor
-        } else {
-            if let searchBarTextField = searchBar.vc_searchTextField {
-                searchBarTextField.textColor = self.searchPlaceholderColor
-            }
-        }
+        searchBar.searchTextField.backgroundColor = self.searchBackgroundColor
+        searchBar.searchTextField.textColor = self.searchPlaceholderColor
     }
     
     func applyStyle(onTextField texField: UITextField) {

--- a/Riot/Managers/Theme/Themes/DefaultTheme.swift
+++ b/Riot/Managers/Theme/Themes/DefaultTheme.swift
@@ -177,14 +177,8 @@ class DefaultTheme: NSObject, Theme {
             return
         }
         
-        if #available(iOS 13.0, *) {
-            searchBar.searchTextField.backgroundColor = self.searchBackgroundColor
-            searchBar.searchTextField.textColor = self.searchPlaceholderColor
-        } else {
-            if let searchBarTextField = searchBar.vc_searchTextField {
-                searchBarTextField.textColor = self.searchPlaceholderColor
-            }
-        }
+        searchBar.searchTextField.backgroundColor = self.searchBackgroundColor
+        searchBar.searchTextField.textColor = self.searchPlaceholderColor
     }
     
     func applyStyle(onTextField texField: UITextField) {

--- a/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultAttachmentBubbleCell.m
+++ b/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultAttachmentBubbleCell.m
@@ -28,9 +28,7 @@
     [super customizeTableViewCellRendering];
     
     self.roomNameLabel.textColor = ThemeService.shared.theme.textSecondaryColor;
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-    
+        
     [self updateUserNameColor];
 }
 

--- a/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultTextMsgBubbleCell.m
+++ b/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultTextMsgBubbleCell.m
@@ -30,8 +30,6 @@
     [self updateUserNameColor];
     
     self.roomNameLabel.textColor = ThemeService.shared.theme.textSecondaryColor;
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -51,6 +51,7 @@ class HTMLFormatter: NSObject {
             DTDefaultFontName: font.fontName,
             DTDefaultFontSize: font.pointSize,
             DTDefaultLinkDecoration: false,
+            DTDefaultLinkColor: UIColor.link,
             DTWillFlushBlockCallBack: sanitizeCallback
         ]
         options.merge(extraOptions) { (_, new) in new }

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/HTMLFormatter.swift
@@ -51,7 +51,7 @@ class HTMLFormatter: NSObject {
             DTDefaultFontName: font.fontName,
             DTDefaultFontSize: font.pointSize,
             DTDefaultLinkDecoration: false,
-            DTDefaultLinkColor: UIColor.link,
+            DTDefaultLinkColor: ThemeService.shared().theme.colors.links,
             DTWillFlushBlockCallBack: sanitizeCallback
         ]
         options.merge(extraOptions) { (_, new) in new }

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.h
@@ -367,6 +367,12 @@ typedef enum : NSUInteger {
 @property (nonatomic) UIColor *sendingTextColor;
 
 /**
+ Color used to display links and hyperlinks contentt.
+ Default is [UIColor linkColor].
+ */
+@property (nonatomic) UIColor *linksColor;
+
+/**
  Color used to display error text.
  Default is red.
  */

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1749,6 +1749,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
                 if (url.URL)
                 {
                     [str addAttribute:NSLinkAttributeName value:url.URL range:matchRange];
+                    [str addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:matchRange];
                 }
             }
         }

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -89,6 +89,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
         _encryptingTextColor = [UIColor lightGrayColor];
         _sendingTextColor = [UIColor lightGrayColor];
         _errorTextColor = [UIColor redColor];
+        _linksColor = [UIColor linkColor];
         _htmlBlockquoteBorderColor = [MXKTools colorWithRGBValue:0xDDDDDD];
         
         _defaultTextFont = [UIFont systemFontOfSize:14];
@@ -1749,7 +1750,7 @@ static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>(
                 if (url.URL)
                 {
                     [str addAttribute:NSLinkAttributeName value:url.URL range:matchRange];
-                    [str addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:matchRange];
+                    [str addAttribute:NSForegroundColorAttributeName value:self.linksColor range:matchRange];
                 }
             }
         }

--- a/Riot/Modules/MatrixKit/Utils/MXKTools.m
+++ b/Riot/Modules/MatrixKit/Utils/MXKTools.m
@@ -1083,6 +1083,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
                 // If the match is fully in the link, skip it
                 if (NSIntersectionRange(match.range, linkMatch.range).length == match.range.length)
                 {
+                    [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:linkMatch.range];
                     hasAlreadyLink = YES;
                     break;
                 }
@@ -1097,6 +1098,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
             NSString *link = [mutableAttributedString.string substringWithRange:match.range];
             link = [link stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
             [mutableAttributedString addAttribute:NSLinkAttributeName value:link range:match.range];
+            [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:match.range];
         }
     }];
 }

--- a/Riot/Modules/MatrixKit/Utils/MXKTools.m
+++ b/Riot/Modules/MatrixKit/Utils/MXKTools.m
@@ -1043,7 +1043,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
     // This allows to check for normal url based links (like https://element.io)
     // And set back the default link color
     NSArray *matches = [linkDetector matchesInString: [mutableAttributedString string] options:0 range: NSMakeRange(0,mutableAttributedString.length)];
-    if (matches && matches.count > 0)
+    if (matches)
     {
         for (NSTextCheckingResult *match in matches)
         {

--- a/Riot/Modules/MatrixKit/Utils/MXKTools.m
+++ b/Riot/Modules/MatrixKit/Utils/MXKTools.m
@@ -1052,7 +1052,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
             NSURLComponents *url = [[NSURLComponents new] initWithURL:matchUrl resolvingAgainstBaseURL:NO];
             if (url.URL)
             {
-                [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:matchRange];
+                [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.colors.links range:matchRange];
             }
         }
     }
@@ -1103,7 +1103,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
                 if (NSIntersectionRange(match.range, linkMatch.range).length == match.range.length)
                 {
                     // but before we set the right color
-                    [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:linkMatch.range];
+                    [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.colors.links range:linkMatch.range];
                     hasAlreadyLink = YES;
                     break;
                 }
@@ -1118,7 +1118,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
             NSString *link = [mutableAttributedString.string substringWithRange:match.range];
             link = [link stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
             [mutableAttributedString addAttribute:NSLinkAttributeName value:link range:match.range];
-            [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:match.range];
+            [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.colors.links range:match.range];
         }
     }];
 }

--- a/Riot/Modules/MatrixKit/Utils/MXKTools.m
+++ b/Riot/Modules/MatrixKit/Utils/MXKTools.m
@@ -46,6 +46,7 @@ static NSRegularExpression *eventIdRegex;
 static NSRegularExpression *httpLinksRegex;
 // A regex to find all HTML tags
 static NSRegularExpression *htmlTagsRegex;
+static NSDataDetector *linkDetector;
 
 @implementation MXKTools
 
@@ -60,7 +61,8 @@ static NSRegularExpression *htmlTagsRegex;
         eventIdRegex = [NSRegularExpression regularExpressionWithPattern:kMXToolsRegexStringForMatrixEventIdentifier options:NSRegularExpressionCaseInsensitive error:nil];
         
         httpLinksRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\b(https?://\\S*)\\b" options:NSRegularExpressionCaseInsensitive error:nil];
-        htmlTagsRegex  = [NSRegularExpression regularExpressionWithPattern:@"<(\\w+)[^>]*>" options:NSRegularExpressionCaseInsensitive error:nil];        
+        htmlTagsRegex  = [NSRegularExpression regularExpressionWithPattern:@"<(\\w+)[^>]*>" options:NSRegularExpressionCaseInsensitive error:nil];
+        linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
     });
 }
 
@@ -1037,6 +1039,23 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
     {
         [MXKTools createLinksInMutableAttributedString:mutableAttributedString matchingRegex:eventIdRegex];
     }
+    
+    // This allows to check for normal url based links (like https://element.io)
+    // And set back the default link color
+    NSArray *matches = [linkDetector matchesInString: [mutableAttributedString string] options:0 range: NSMakeRange(0,mutableAttributedString.length)];
+    if (matches && matches.count > 0)
+    {
+        for (NSTextCheckingResult *match in matches)
+        {
+            NSRange matchRange = [match range];
+            NSURL *matchUrl = [match URL];
+            NSURLComponents *url = [[NSURLComponents new] initWithURL:matchUrl resolvingAgainstBaseURL:NO];
+            if (url.URL)
+            {
+                [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:matchRange];
+            }
+        }
+    }
 }
 
 + (void)createLinksInMutableAttributedString:(NSMutableAttributedString*)mutableAttributedString matchingRegex:(NSRegularExpression*)regex
@@ -1083,6 +1102,7 @@ manualChangeMessageForVideo:(NSString*)manualChangeMessageForVideo
                 // If the match is fully in the link, skip it
                 if (NSIntersectionRange(match.range, linkMatch.range).length == match.range.length)
                 {
+                    // but before we set the right color
                     [mutableAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor linkColor] range:linkMatch.range];
                     hasAlreadyLink = YES;
                     break;

--- a/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
+++ b/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
@@ -67,6 +67,7 @@
 
 - (void)setAttributedText:(NSAttributedString *)attributedText
 {
+    self.linkTextAttributes = @{};
     if (@available(iOS 15.0, *)) {
         [self flushPills];
     }

--- a/Riot/Modules/Room/TimelineCells/RoomCreation/RoomCreationCollapsedBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/RoomCreation/RoomCreationCollapsedBubbleCell.m
@@ -26,8 +26,6 @@
 - (void)customizeTableViewCellRendering
 {
     [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 @end

--- a/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipBubbleCell.m
@@ -37,13 +37,6 @@
     xibPictureViewTopConstraintConstant = self.pictureViewTopConstraint.constant;
 }
 
-- (void)customizeTableViewCellRendering
-{
-    [super customizeTableViewCellRendering];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-}
-
 - (void)prepareForReuse
 {
     [super prepareForReuse];

--- a/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipCollapsedBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/RoomMembership/RoomMembershipCollapsedBubbleCell.m
@@ -26,13 +26,6 @@
 
 @implementation RoomMembershipCollapsedBubbleCell
 
-- (void)customizeTableViewCellRendering
-{
-    [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-}
-
 - (void)layoutSubviews
 {
     [super layoutSubviews];

--- a/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/TextMessage/Common/TextMessageBaseBubbleCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/TextMessage/Common/TextMessageBaseBubbleCell.swift
@@ -51,14 +51,6 @@ class TextMessageBaseBubbleCell: SizableBaseRoomCell, RoomCellURLPreviewDisplaya
     override func setupMessageTextViewLongPressGesture() {
         // Do nothing, otherwise default setup prevent link tap
     }
-    
-    override func update(theme: Theme) {
-        super.update(theme: theme)
-        
-        if let messageTextView = self.messageTextView {
-            messageTextView.tintColor = theme.tintColor
-        }
-    }
 }
 
 // MARK: - RoomCellTimestampDisplayable

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Incoming/Clear/RoomIncomingAttachmentBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Incoming/Clear/RoomIncomingAttachmentBubbleCell.m
@@ -28,8 +28,6 @@
     [super customizeTableViewCellRendering];
     
     [self updateUserNameColor];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Incoming/Clear/RoomIncomingAttachmentWithPaginationTitleBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Incoming/Clear/RoomIncomingAttachmentWithPaginationTitleBubbleCell.m
@@ -30,7 +30,6 @@
     [self updateUserNameColor];
     self.paginationLabel.textColor = ThemeService.shared.theme.tintColor;
     self.paginationSeparatorView.backgroundColor = ThemeService.shared.theme.tintColor;
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Incoming/Clear/RoomIncomingAttachmentWithoutSenderInfoBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Incoming/Clear/RoomIncomingAttachmentWithoutSenderInfoBubbleCell.m
@@ -23,13 +23,6 @@
 
 @implementation RoomIncomingAttachmentWithoutSenderInfoBubbleCell
 
-- (void)customizeTableViewCellRendering
-{
-    [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-}
-
 + (CGFloat)heightForCellData:(MXKCellData*)cellData withMaximumWidth:(CGFloat)maxWidth
 {
     CGFloat rowHeight = [self attachmentBubbleCellHeightForCellData:cellData withMaximumWidth:maxWidth];

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentBubbleCell.m
@@ -28,8 +28,6 @@
     [super customizeTableViewCellRendering];
     
     [self updateUserNameColor];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentWithPaginationTitleBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentWithPaginationTitleBubbleCell.m
@@ -30,7 +30,6 @@
     [self updateUserNameColor];
     self.paginationLabel.textColor = ThemeService.shared.theme.tintColor;
     self.paginationSeparatorView.backgroundColor = ThemeService.shared.theme.tintColor;
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentWithPaginationTitleWithoutSenderNameBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentWithPaginationTitleWithoutSenderNameBubbleCell.m
@@ -22,11 +22,5 @@
 
 @implementation RoomOutgoingAttachmentWithPaginationTitleWithoutSenderNameBubbleCell
 
-- (void)customizeTableViewCellRendering
-{
-    [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-}
 
 @end

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentWithoutSenderInfoBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/FileAttachment/Outgoing/Clear/RoomOutgoingAttachmentWithoutSenderInfoBubbleCell.m
@@ -24,13 +24,6 @@
 
 @implementation RoomOutgoingAttachmentWithoutSenderInfoBubbleCell
 
-- (void)customizeTableViewCellRendering
-{
-    [super customizeTableViewCellRendering];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-}
-
 - (void)render:(MXKCellData *)cellData
 {
     [super render:cellData];

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgBubbleCell.m
@@ -28,8 +28,6 @@
     [super customizeTableViewCellRendering];
     
     [self updateUserNameColor];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithPaginationTitleBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithPaginationTitleBubbleCell.m
@@ -30,7 +30,6 @@
     [self updateUserNameColor];
     self.paginationLabel.textColor = ThemeService.shared.theme.tintColor;
     self.paginationSeparatorView.backgroundColor = ThemeService.shared.theme.tintColor;
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 - (void)render:(MXKCellData *)cellData

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithPaginationTitleWithoutSenderNameBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithPaginationTitleWithoutSenderNameBubbleCell.m
@@ -22,11 +22,4 @@
 
 @implementation RoomIncomingTextMsgWithPaginationTitleWithoutSenderNameBubbleCell
 
-- (void)customizeTableViewCellRendering
-{
-    [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
-}
-
 @end

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithoutSenderInfoBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithoutSenderInfoBubbleCell.m
@@ -25,8 +25,6 @@
 - (void)customizeTableViewCellRendering
 {
     [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 @end

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithoutSenderNameBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Incoming/Clear/RoomIncomingTextMsgWithoutSenderNameBubbleCell.m
@@ -25,8 +25,6 @@
 - (void)customizeTableViewCellRendering
 {
     [super customizeTableViewCellRendering];
-
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 @end

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Outgoing/Clear/RoomOutgoingTextMsgBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Outgoing/Clear/RoomOutgoingTextMsgBubbleCell.m
@@ -28,8 +28,6 @@
     [super customizeTableViewCellRendering];
     
     [self updateUserNameColor];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Outgoing/Clear/RoomOutgoingTextMsgWithoutSenderInfoBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/Cells/TextMessage/Outgoing/Clear/RoomOutgoingTextMsgWithoutSenderInfoBubbleCell.m
@@ -25,8 +25,6 @@
 - (void)customizeTableViewCellRendering
 {
     [super customizeTableViewCellRendering];
-    
-    self.messageTextView.tintColor = ThemeService.shared.theme.tintColor;
 }
 
 @end

--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -44,7 +44,6 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     private var hostingViewController: VectorHostingController!
     private var wysiwygViewModel = WysiwygComposerViewModel(
         textColor: ThemeService.shared().theme.colors.primaryContent,
-        linkColor: ThemeService.shared().theme.colors.accent,
         codeBackgroundColor: ThemeService.shared().theme.selectedBackgroundColor
     )
     private var viewModel: ComposerViewModelProtocol!
@@ -299,7 +298,7 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     private func update(theme: Theme) {
         hostingViewController.view.backgroundColor = theme.colors.background
         wysiwygViewModel.textColor = theme.colors.primaryContent
-        wysiwygViewModel.linkColor = theme.colors.accent
+        wysiwygViewModel.linkColor = .link
         wysiwygViewModel.codeBackgroundColor = theme.selectedBackgroundColor
     }
     

--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -44,6 +44,7 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     private var hostingViewController: VectorHostingController!
     private var wysiwygViewModel = WysiwygComposerViewModel(
         textColor: ThemeService.shared().theme.colors.primaryContent,
+        linkColor: ThemeService.shared().theme.colors.links,
         codeBackgroundColor: ThemeService.shared().theme.selectedBackgroundColor
     )
     private var viewModel: ComposerViewModelProtocol!
@@ -298,6 +299,7 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     private func update(theme: Theme) {
         hostingViewController.view.backgroundColor = theme.colors.background
         wysiwygViewModel.textColor = theme.colors.primaryContent
+        wysiwygViewModel.linkColor = theme.colors.links
         wysiwygViewModel.codeBackgroundColor = theme.selectedBackgroundColor
     }
     

--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -298,7 +298,6 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     private func update(theme: Theme) {
         hostingViewController.view.backgroundColor = theme.colors.background
         wysiwygViewModel.textColor = theme.colors.primaryContent
-        wysiwygViewModel.linkColor = .link
         wysiwygViewModel.codeBackgroundColor = theme.selectedBackgroundColor
     }
     

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -384,8 +384,6 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
          [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@" %@", [VectorL10n eventFormatterMessageEditedMention]]
                                          attributes:@{
                                                       NSLinkAttributeName: linkActionString,
-                                                      // NOTE: Color is curretly overidden by UIText.tintColor as we use `NSLinkAttributeName`.
-                                                      // If we use UITextView.linkTextAttributes to set link color we will also have the issue that color will be the same for all kind of links.
                                                       NSForegroundColorAttributeName: self.editionMentionTextColor,
                                                       NSFontAttributeName: self.editionMentionTextFont
                                                       }]];

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -486,6 +486,7 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
         self.bingTextColor = ThemeService.shared.theme.noticeColor;
         self.encryptingTextColor = ThemeService.shared.theme.textPrimaryColor;
         self.sendingTextColor = ThemeService.shared.theme.textPrimaryColor;
+        self.linksColor = ThemeService.shared.theme.colors.links;
         self.errorTextColor = ThemeService.shared.theme.textPrimaryColor;
         self.showEditionMention = YES;
         self.editionMentionTextColor = ThemeService.shared.theme.textSecondaryColor;

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -359,7 +359,8 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
                                              attributes:@{
                                                           NSLinkAttributeName: linkActionString,
                                                           NSForegroundColorAttributeName: self.sendingTextColor,
-                                                          NSFontAttributeName: self.encryptedMessagesTextFont
+                                                          NSFontAttributeName: self.encryptedMessagesTextFont,
+                                                          NSUnderlineStyleAttributeName: [NSNumber numberWithInt:NSUnderlineStyleSingle] 
                                                           }]];
 
             [attributedStringWithRerequestMessage appendAttributedString:

--- a/RiotNSE/SupportingFiles/RiotNSE-Bridging-Header.h
+++ b/RiotNSE/SupportingFiles/RiotNSE-Bridging-Header.h
@@ -23,4 +23,6 @@
 
 #import "BuildInfo.h"
 
+#import "ThemeService.h"
+
 #endif /* RiotNSE_Bridging_Header_h */

--- a/RiotNSE/target.yml
+++ b/RiotNSE/target.yml
@@ -78,3 +78,5 @@ targets:
         - "**/*.md" # excludes all files with the .md extension
     - path: ../Riot/Modules/Room/TimelineCells/Styles/RoomTimelineStyleIdentifier.swift
     - path: ../Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/MatrixSDK
+    - path: ../Riot/Managers/Theme
+    - path: ../Riot/Categories/UIColor.swift

--- a/RiotTests/MatrixKitTests/MXKEventFormatterTests.m
+++ b/RiotTests/MatrixKitTests/MXKEventFormatterTests.m
@@ -414,7 +414,7 @@
     NSString *s = @"Matrix HQ room is at https://matrix.to/#/room/#matrix:matrix.org.";
     NSAttributedString *as = [eventFormatter renderString:s forEvent:anEvent];
 
-    __block bool hasLink = false;
+    __block BOOL hasLink = false;
 
     [as enumerateAttributesInRange:NSMakeRange(0, as.length) options:(0) usingBlock:^(NSDictionary<NSString *,id> * _Nonnull attrs, NSRange range, BOOL * _Nonnull stop) {
         if (attrs[NSLinkAttributeName]) {

--- a/RiotTests/MatrixKitTests/MXKEventFormatterTests.m
+++ b/RiotTests/MatrixKitTests/MXKEventFormatterTests.m
@@ -414,14 +414,16 @@
     NSString *s = @"Matrix HQ room is at https://matrix.to/#/room/#matrix:matrix.org.";
     NSAttributedString *as = [eventFormatter renderString:s forEvent:anEvent];
 
-    __block NSUInteger ranges = 0;
+    __block bool hasLink = false;
 
     [as enumerateAttributesInRange:NSMakeRange(0, as.length) options:(0) usingBlock:^(NSDictionary<NSString *,id> * _Nonnull attrs, NSRange range, BOOL * _Nonnull stop) {
-
-        ranges++;
+        if (attrs[NSLinkAttributeName]) {
+            hasLink = true;
+            *stop = true;
+        }
     }];
 
-    XCTAssertEqual(ranges, 1, @"There should be no link in this case. We let the UI manage the link");
+    XCTAssertEqual(hasLink, false, @"There should be no link in this case. We let the UI manage the link");
 }
 
 #pragma mark - Event sender/target info

--- a/SiriIntents/SupportingFiles/SiriIntents-Bridging-Header.h
+++ b/SiriIntents/SupportingFiles/SiriIntents-Bridging-Header.h
@@ -16,3 +16,4 @@
 
 #import "MatrixKit-Bridging-Header.h"
 #import "BuildInfo.h"
+#import "ThemeService.h"

--- a/SiriIntents/target.yml
+++ b/SiriIntents/target.yml
@@ -66,3 +66,5 @@ targets:
         - "**/*.md" # excludes all files with the .md extension
     - path: ../Riot/Modules/Room/TimelineCells/Styles/RoomTimelineStyleIdentifier.swift
     - path: ../Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/MatrixSDK
+    - path: ../Riot/Managers/Theme
+    - path: ../Riot/Categories/UIColor.swift

--- a/changelog.d/2292.change
+++ b/changelog.d/2292.change
@@ -1,1 +1,0 @@
-Links are now in blue like on web and Android.

--- a/changelog.d/2292.change
+++ b/changelog.d/2292.change
@@ -1,0 +1,1 @@
+Links are now in blue like on web and Android.

--- a/changelog.d/2419.bugfix
+++ b/changelog.d/2419.bugfix
@@ -1,0 +1,1 @@
+Hyperlinks are now blue and should now be distinguishable from unsent messages in encrypted rooms.

--- a/changelog.d/2419.bugfix
+++ b/changelog.d/2419.bugfix
@@ -1,1 +1,0 @@
-Hyperlinks are now blue and should now be distinguishable from unsent messages in encrypted rooms.

--- a/changelog.d/5148.bugfix
+++ b/changelog.d/5148.bugfix
@@ -1,0 +1,1 @@
+The (edited) tag for messages is now light grey like on web and Android.

--- a/changelog.d/5437.bugfix
+++ b/changelog.d/5437.bugfix
@@ -1,1 +1,0 @@
-HTML links should now be displayed in default system blue.

--- a/changelog.d/5437.bugfix
+++ b/changelog.d/5437.bugfix
@@ -1,0 +1,1 @@
+HTML links should now be displayed in default system blue.

--- a/changelog.d/7263.bugfix
+++ b/changelog.d/7263.bugfix
@@ -1,0 +1,1 @@
+Timeline's tag and hyperlinks match now in colour Android and Web.

--- a/changelog.d/7263.bugfix
+++ b/changelog.d/7263.bugfix
@@ -1,1 +1,1 @@
-Timeline's tag and hyperlinks match now in colour Android and Web.
+Timeline's links and hyperlinks match now the blue colour of Android and Web.


### PR DESCRIPTION
By default most of the links are now displayed in blue just like Android and Web.
Also different links with different colours are also supported now, in fact the `(edited)` link for example (used to check changes for en edited message) is now displayed in light grey just like on Android and Web.
Also the `in reply to` text message is displayed in blue like on Android.

The WYSIWYG too will also display during editing the links in blue.
![IMG_0111](https://user-images.githubusercontent.com/34335419/211937402-9a93ad49-361c-43fe-92ce-e447248ac663.PNG)

This fixes the following issues:
https://github.com/vector-im/element-ios/issues/7263
https://github.com/vector-im/element-ios/issues/5437
https://github.com/vector-im/element-ios/issues/5148
https://github.com/vector-im/element-ios/issues/2419
https://github.com/vector-im/element-ios/issues/2292