### PR TITLE
Improved detection of voice broadcast completion during playback 

### DIFF
--- a/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastAggregator.swift
+++ b/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastAggregator.swift
@@ -170,8 +170,8 @@ public class VoiceBroadcastAggregator {
                   let state = VoiceBroadcastInfoState(rawValue: voiceBroadcastInfo.state) else {
                 return
             }
-            // For .pause and .stopped, if there is a lastChunkSequence (ie its value is > 0), we store it
-            if [.stopped, .paused].contains(state), voiceBroadcastInfo.lastChunkSequence > 0 {
+            // For .pause and .stopped, update the last chunk sequence
+            if [.stopped, .paused].contains(state) {
                 self.voiceBroadcastLastChunkSequence = voiceBroadcastInfo.lastChunkSequence
             }
             self.delegate?.voiceBroadcastAggregator(self, didReceiveState: state)

--- a/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastAggregator.swift
+++ b/Riot/Modules/VoiceBroadcast/VoiceBroadcastSDK/VoiceBroadcastAggregator.swift
@@ -53,6 +53,8 @@ public class VoiceBroadcastAggregator {
     private var voiceBroadcastInfoStartEventContent: VoiceBroadcastInfo!
     private var voiceBroadcastSenderId: String!
     
+    public private(set) var voiceBroadcastLastChunkSequence: Int = 0
+    
     private var referenceEventsListener: Any?
     
     private var events: [MXEvent] = []
@@ -168,7 +170,10 @@ public class VoiceBroadcastAggregator {
                   let state = VoiceBroadcastInfoState(rawValue: voiceBroadcastInfo.state) else {
                 return
             }
-
+            // For .pause and .stopped, if there is a lastChunkSequence (ie its value is > 0), we store it
+            if [.stopped, .paused].contains(state), voiceBroadcastInfo.lastChunkSequence > 0 {
+                self.voiceBroadcastLastChunkSequence = voiceBroadcastInfo.lastChunkSequence
+            }
             self.delegate?.voiceBroadcastAggregator(self, didReceiveState: state)
         }
     }
@@ -187,6 +192,7 @@ public class VoiceBroadcastAggregator {
             }
             
             self.events.removeAll()
+            self.voiceBroadcastLastChunkSequence = 0
             
             let filteredChunk = response.chunk.filter { event in
                 event.sender == self.voiceBroadcastSenderId &&

--- a/changelog.d/pr-7273.change
+++ b/changelog.d/pr-7273.change
@@ -1,0 +1,1 @@
+Voice Broadcast: Improved detection of voice broadcast completion during playback.


### PR DESCRIPTION
For a voice broadcast, the paused/stopped state event contains a last_chunk_sequence indicating what the last chunk sequence number is.
During playback, we should use this last_chunk_sequence to detect whether we should stop playback or enter buffering state.