### PR TITLE
Remove "Leave" button on Room details screen

### DIFF
--- a/Riot/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Riot/Modules/Room/Settings/RoomSettingsViewController.m
@@ -52,8 +52,7 @@ enum
     ROOM_SETTINGS_MAIN_SECTION_ROW_TOPIC,
     ROOM_SETTINGS_MAIN_SECTION_ROW_TAG,
     ROOM_SETTINGS_MAIN_SECTION_ROW_DIRECT_CHAT,
-    ROOM_SETTINGS_MAIN_SECTION_ROW_MUTE_NOTIFICATIONS,
-    ROOM_SETTINGS_MAIN_SECTION_ROW_LEAVE
+    ROOM_SETTINGS_MAIN_SECTION_ROW_MUTE_NOTIFICATIONS
 };
 
 enum
@@ -515,7 +514,6 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     {
         [sectionMain addRowWithTag:ROOM_SETTINGS_MAIN_SECTION_ROW_MUTE_NOTIFICATIONS];
     }
-    [sectionMain addRowWithTag:ROOM_SETTINGS_MAIN_SECTION_ROW_LEAVE];
     [tmpSections addObject:sectionMain];
     
     if (RiotSettings.shared.roomSettingsScreenAllowChangingAccessSettings)
@@ -2325,22 +2323,6 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
                 cell = favoriteCell;
             }
         }
-        else if (row == ROOM_SETTINGS_MAIN_SECTION_ROW_LEAVE)
-        {
-            MXKTableViewCellWithButton *leaveCell = [tableView dequeueReusableCellWithIdentifier:[MXKTableViewCellWithButton defaultReuseIdentifier] forIndexPath:indexPath];
-            
-            NSString* title = [VectorL10n leave];
-            
-            [leaveCell.mxkButton setTitle:title forState:UIControlStateNormal];
-            [leaveCell.mxkButton setTitle:title forState:UIControlStateHighlighted];
-            [leaveCell.mxkButton setTintColor:ThemeService.shared.theme.tintColor];
-            leaveCell.mxkButton.titleLabel.font = [UIFont systemFontOfSize:17];
-            
-            [leaveCell.mxkButton  removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
-            [leaveCell.mxkButton addTarget:self action:@selector(onLeave:) forControlEvents:UIControlEventTouchUpInside];
-            
-            cell = leaveCell;
-        }
     }
     else if (section == SECTION_TAG_ACCESS)
     {
@@ -3195,76 +3177,6 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
 }
 
 #pragma mark - actions
-
-- (void)onLeave:(id)sender
-{
-    // Prompt user before leaving the room
-    __weak typeof(self) weakSelf = self;
-    
-    [currentAlert dismissViewControllerAnimated:NO completion:nil];
-    
-    NSString *title, *message;
-    if ([self.mainSession roomWithRoomId:self.roomId].isDirect)
-    {
-        title = [VectorL10n roomParticipantsLeavePromptTitleForDm];
-        message = [VectorL10n roomParticipantsLeavePromptMsgForDm];
-    }
-    else
-    {
-        title = [VectorL10n roomParticipantsLeavePromptTitle];
-        message = [VectorL10n roomParticipantsLeavePromptMsg];
-    }
-    
-    currentAlert = [UIAlertController alertControllerWithTitle:title
-                                                       message:message
-                                                preferredStyle:UIAlertControllerStyleAlert];
-    
-    [currentAlert addAction:[UIAlertAction actionWithTitle:[VectorL10n cancel]
-                                                     style:UIAlertActionStyleCancel
-                                                   handler:^(UIAlertAction * action) {
-                                                       
-                                                       if (weakSelf)
-                                                       {
-                                                           typeof(self) self = weakSelf;
-                                                           self->currentAlert = nil;
-                                                       }
-                                                       
-                                                   }]];
-    
-    [currentAlert addAction:[UIAlertAction actionWithTitle:[VectorL10n leave]
-                                                     style:UIAlertActionStyleDefault
-                                                   handler:^(UIAlertAction * action) {
-                                                       
-                                                       if (weakSelf)
-                                                       {
-                                                           typeof(self) self = weakSelf;
-                                                           self->currentAlert = nil;
-                                                           
-                                                           [self startActivityIndicator];
-                                                           [self->mxRoom leave:^{
-                                                               
-                                                               if (self.delegate) {
-                                                                   [self.delegate roomSettingsViewControllerDidLeaveRoom:self];
-                                                               } else {
-                                                                   [[LegacyAppDelegate theDelegate] restoreInitialDisplay:nil];
-                                                               }
-                                                               
-                                                           } failure:^(NSError *error) {
-                                                               
-                                                               [self stopActivityIndicator];
-                                                               
-                                                               MXLogDebug(@"[RoomSettingsViewController] Leave room failed");
-                                                               // Alert user
-                                                               [[AppDelegate theDelegate] showErrorAsAlert:error];
-                                                               
-                                                           }];
-                                                       }
-                                                       
-                                                   }]];
-    
-    [currentAlert mxk_setAccessibilityIdentifier:@"RoomSettingsVCLeaveAlert"];
-    [self presentViewController:currentAlert animated:YES completion:nil];
-}
 
 - (void)onRoomAvatarTap:(UITapGestureRecognizer *)recognizer
 {

--- a/changelog.d/pr-7275.change
+++ b/changelog.d/pr-7275.change
@@ -1,0 +1,1 @@
+Remove "Leave" button on Room details screen


### PR DESCRIPTION
As described in [this issue](https://github.com/tchapgouv/tchap-ios/issues/593), after the redesign of the room settings screen, there is now 2 "Leave" buttons on these screens : 1 at the first level, and 1 on the "Settings" one.

So, the goal of this PR is to remove the old one on "Settings".

**1st level screen :**
<img src="https://user-images.githubusercontent.com/25746885/214070873-93c1ca53-c6ab-4e60-af18-f471af93204f.png" width=25% height=25%>

**Settings screen before / After :**
<img src="https://user-images.githubusercontent.com/25746885/214071039-b70af83b-73f8-4d4e-85e2-8482e68af656.png" width=25% height=25%> -> <img src="https://user-images.githubusercontent.com/25746885/214071107-8a6d2c25-b214-4a88-a37e-0833216f88ea.png" width=25% height=25%>