### PR TITLE
Fix voicebroadcast playback slider on seek

### DIFF
--- a/changelog.d/7252.bugfix
+++ b/changelog.d/7252.bugfix
@@ -1,0 +1,1 @@
+Voice Broadcast: Fixed an issue where the voice broadcast audio player progress bar behaved unexpectedly.


### PR DESCRIPTION
Fixes #7252 

This PR resolves the following issues on the Voice Broadcast audio player:
- the progress bar did not behave as expected after a seek.
- the progress bar did not always reach the end after the playback was finished.
- the displayLink was not paused when stopping or pausing the audio player.