### PR TITLE
Past poll history UI (PSG-1027)

### DIFF
--- a/RiotSwiftUI/Modules/Room/PollHistory/MockPollHistoryScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/MockPollHistoryScreenState.swift
@@ -45,10 +45,10 @@ enum MockPollHistoryScreenState: MockScreenState, CaseIterable {
             pollHistoryMode = .past
         case .activeEmpty:
             pollHistoryMode = .active
-            pollService.pollListData = []
+            pollService.activePollsData = []
         case .pastEmpty:
             pollHistoryMode = .past
-            pollService.pollListData = []
+            pollService.pastPollsData = []
         }
         
         let viewModel = PollHistoryViewModel(mode: pollHistoryMode, pollService: pollService)

--- a/RiotSwiftUI/Modules/Room/PollHistory/PollHistoryModels.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/PollHistoryModels.swift
@@ -33,7 +33,7 @@ struct PollHistoryViewBindings {
 
 struct PollHistoryViewState: BindableState {
     init(mode: PollHistoryMode) {
-        self.bindings = .init(mode: mode)
+        bindings = .init(mode: mode)
     }
     
     var bindings: PollHistoryViewBindings
@@ -42,4 +42,5 @@ struct PollHistoryViewState: BindableState {
 
 enum PollHistoryViewAction {
     case viewAppeared
+    case segmentDidChange
 }

--- a/RiotSwiftUI/Modules/Room/PollHistory/Service/Mock/MockPollHistoryService.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/Service/Mock/MockPollHistoryService.swift
@@ -15,15 +15,30 @@
 //
 
 final class MockPollHistoryService: PollHistoryServiceProtocol {
-    var pollListData: [PollListData] = (1..<10)
+    var activePollsData: [PollListData] = (1..<10)
         .map { index in
-            PollListData(startDate: .init().addingTimeInterval(-CGFloat(index) * 3600), question: "Do you like the poll number \(index)?")
-        }
-        .sorted { poll1, poll2 in
-            poll1.startDate > poll2.startDate
+            PollListData(
+                startDate: .init().addingTimeInterval(-CGFloat(index) * 3600),
+                question: "Do you like the active poll number \(index)?",
+                numberOfVotes: 30,
+                winningOption: nil
+            )
         }
     
+    var pastPollsData: [PollListData] = (1..<10)
+        .map { index in
+            PollListData(
+                startDate: .init().addingTimeInterval(-CGFloat(index) * 3600),
+                question: "Do you like the past poll number \(index)?",
+                numberOfVotes: 30,
+                winningOption: .init(id: "id", text: "Yes, of course!", count: 20, winner: true, selected: true)
+            )
+        }
+
     func fetchHistory() async throws -> [PollListData] {
-        pollListData
+        (activePollsData + pastPollsData)
+            .sorted { poll1, poll2 in
+                poll1.startDate > poll2.startDate
+            }
     }
 }

--- a/RiotSwiftUI/Modules/Room/PollHistory/Test/UI/PollHistoryUITests.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/Test/UI/PollHistoryUITests.swift
@@ -18,29 +18,51 @@ import RiotSwiftUI
 import XCTest
 
 class PollHistoryUITests: MockScreenTestCase {
-    func testPollHistoryHasContent() {
+    func testActivePollHistoryHasContent() {
         app.goToScreenWithIdentifier(MockPollHistoryScreenState.active.title)
         let title = app.navigationBars.firstMatch.identifier
         let emptyText = app.staticTexts["PollHistory.emptyText"]
         let items = app.staticTexts["PollListItem.title"]
         let selectedSegment = app.buttons[VectorL10n.pollHistoryActiveSegmentTitle]
+        let winningOption = app.staticTexts["PollListData.winningOption"]
+        
         XCTAssertEqual(title, VectorL10n.pollHistoryTitle)
         XCTAssertTrue(items.exists)
         XCTAssertFalse(emptyText.exists)
         XCTAssertTrue(selectedSegment.exists)
         XCTAssertEqual(selectedSegment.value as? String, VectorL10n.accessibilitySelected)
+        XCTAssertFalse(winningOption.exists)
     }
     
-    func testPollHistoryShowsEmptyScreen() {
+    func testPastPollHistoryHasContent() {
+        app.goToScreenWithIdentifier(MockPollHistoryScreenState.past.title)
+        let title = app.navigationBars.firstMatch.identifier
+        let emptyText = app.staticTexts["PollHistory.emptyText"]
+        let items = app.staticTexts["PollListItem.title"]
+        let selectedSegment = app.buttons[VectorL10n.pollHistoryPastSegmentTitle]
+        let winningOption = app.staticTexts["PollListData.winningOption"]
+        
+        XCTAssertEqual(title, VectorL10n.pollHistoryTitle)
+        XCTAssertTrue(items.exists)
+        XCTAssertFalse(emptyText.exists)
+        XCTAssertTrue(selectedSegment.exists)
+        XCTAssertEqual(selectedSegment.value as? String, VectorL10n.accessibilitySelected)
+        XCTAssertTrue(winningOption.exists)
+    }
+    
+    func testPastPollHistoryIsEmpty() {
         app.goToScreenWithIdentifier(MockPollHistoryScreenState.pastEmpty.title)
         let title = app.navigationBars.firstMatch.identifier
         let emptyText = app.staticTexts["PollHistory.emptyText"]
         let items = app.staticTexts["PollListItem.title"]
         let selectedSegment = app.buttons[VectorL10n.pollHistoryPastSegmentTitle]
+        let winningOption = app.staticTexts["PollListData.winningOption"]
+        
         XCTAssertEqual(title, VectorL10n.pollHistoryTitle)
         XCTAssertFalse(items.exists)
         XCTAssertTrue(emptyText.exists)
         XCTAssertTrue(selectedSegment.exists)
         XCTAssertEqual(selectedSegment.value as? String, VectorL10n.accessibilitySelected)
+        XCTAssertFalse(winningOption.exists)
     }
 }

--- a/RiotSwiftUI/Modules/Room/PollHistory/View/PollHistory.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/View/PollHistory.swift
@@ -45,6 +45,9 @@ struct PollHistory: View {
         .onAppear {
             viewModel.send(viewAction: .viewAppeared)
         }
+        .onChange(of: viewModel.mode) { newValue in
+            viewModel.send(viewAction: .segmentDidChange)
+        }
     }
     
     private var pollListView: some View {

--- a/RiotSwiftUI/Modules/Room/PollHistory/View/PollHistory.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/View/PollHistory.swift
@@ -45,7 +45,7 @@ struct PollHistory: View {
         .onAppear {
             viewModel.send(viewAction: .viewAppeared)
         }
-        .onChange(of: viewModel.mode) { newValue in
+        .onChange(of: viewModel.mode) { _ in
             viewModel.send(viewAction: .segmentDidChange)
         }
     }

--- a/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
@@ -52,7 +52,10 @@ struct PollListItem: View {
             }
             
             if pollData.winningOption != nil {
-                optionView(winningOption: pollData.winningOption!)
+                VStack(alignment: .leading, spacing: 12) {
+                    optionView(winningOption: pollData.winningOption!)
+                    resultView
+                }
             }
         }
     }
@@ -95,6 +98,14 @@ struct PollListItem: View {
         } icon: {
             Image(uiImage: Asset.Images.pollWinnerIcon.image)
         }
+    }
+    
+    private var resultView: some View {
+        let text = pollData.numberOfVotes == 1 ? VectorL10n.pollTimelineTotalFinalResultsOneVote : VectorL10n.pollTimelineTotalFinalResults(Int(pollData.numberOfVotes))
+        
+        return Text(text)
+            .font(theme.fonts.footnote)
+            .foregroundColor(theme.colors.tertiaryContent)
     }
 }
 

--- a/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
@@ -70,7 +70,7 @@ struct PollListItem: View {
                 Text(pollData.winningOption!.text)
                     .font(theme.fonts.body)
                     .foregroundColor(theme.colors.primaryContent)
-                    .accessibilityLabel("PollListData.winningOption")
+                    .accessibilityIdentifier("PollListData.winningOption")
                 
                 Spacer()
                 

--- a/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
@@ -70,6 +70,7 @@ struct PollListItem: View {
                 Text(pollData.winningOption!.text)
                     .font(theme.fonts.body)
                     .foregroundColor(theme.colors.primaryContent)
+                    .accessibilityLabel("PollListData.winningOption")
                 
                 Spacer()
                 

--- a/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/View/PollListItem.swift
@@ -19,6 +19,8 @@ import SwiftUI
 struct PollListData {
     let startDate: Date
     let question: String
+    let numberOfVotes: UInt
+    let winningOption: TimelinePollAnswerOption?
 }
 
 struct PollListItem: View {
@@ -36,18 +38,62 @@ struct PollListItem: View {
             Text(pollData.formattedDate)
                 .foregroundColor(theme.colors.tertiaryContent)
                 .font(theme.fonts.caption1)
-
+            
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Image(uiImage: Asset.Images.pollHistory.image)
                     .resizable()
                     .frame(width: imageSize, height: imageSize)
-
+                
                 Text(pollData.question)
                     .foregroundColor(theme.colors.primaryContent)
                     .font(theme.fonts.body)
                     .lineLimit(2)
                     .accessibilityLabel("PollListItem.title")
             }
+            
+            if pollData.winningOption != nil {
+                optionView(winningOption: pollData.winningOption!)
+            }
+        }
+    }
+    
+    private var clipShape: some Shape {
+        RoundedRectangle(cornerRadius: 4.0)
+    }
+
+    private func optionView(winningOption: TimelinePollAnswerOption) -> some View {
+        VStack(alignment: .leading, spacing: 12.0) {
+            HStack(alignment: .top, spacing: 8.0) {
+                Text(pollData.winningOption!.text)
+                    .font(theme.fonts.body)
+                    .foregroundColor(theme.colors.primaryContent)
+                
+                Spacer()
+                
+                votesText(winningOption: winningOption)
+            }
+            
+            ProgressView(value: Double(winningOption.count),
+                         total: Double(pollData.numberOfVotes))
+                .progressViewStyle(LinearProgressViewStyle())
+                .scaleEffect(x: 1.0, y: 1.2, anchor: .center)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8.0)
+        .padding(.top, 12.0)
+        .padding(.bottom, 12.0)
+        .clipShape(clipShape)
+        .overlay(clipShape.stroke(theme.colors.accent, lineWidth: 1.0))
+        .accentColor(theme.colors.accent)
+    }
+    
+    private func votesText(winningOption: TimelinePollAnswerOption) -> some View {
+        Label {
+            Text(winningOption.count == 1 ? VectorL10n.pollTimelineOneVote : VectorL10n.pollTimelineVotesCount(Int(winningOption.count)))
+                .font(theme.fonts.footnote)
+                .foregroundColor(theme.colors.accent)
+        } icon: {
+            Image(uiImage: Asset.Images.pollWinnerIcon.image)
         }
     }
 }
@@ -72,6 +118,24 @@ private extension DateFormatter {
 
 struct PollListItem_Previews: PreviewProvider {
     static var previews: some View {
-        PollListItem(pollData: .init(startDate: .init(), question: "Did you like this poll?"))
+        Group {
+            let pollData1 = PollListData(
+                startDate: .init(),
+                question: "Do you like polls?",
+                numberOfVotes: 30,
+                winningOption: .init(id: "id", text: "Yes, of course!", count: 18, winner: true, selected: true)
+            )
+            
+            PollListItem(pollData: pollData1)
+            
+            let pollData2 = PollListData(
+                startDate: .init(),
+                question: "Do you like polls?",
+                numberOfVotes: 30,
+                winningOption: nil)
+            
+            PollListItem(pollData: pollData2)
+        }
+        .padding()
     }
 }

--- a/changelog.d/pr-7278.change
+++ b/changelog.d/pr-7278.change
@@ -1,0 +1,1 @@
+Polls: poll history UI for past polls.


### PR DESCRIPTION
### Description

This pr adds the UI for rendering ended polls in the "past polls" tab.

**Notes**
- The UI is currently populated with mocked data
- Because of the above model objects are likely going to change

### Result

<img src="https://user-images.githubusercontent.com/19324622/212958239-f3ba0165-2a8c-4c34-a07c-3473388a6c8b.png" width=50% height=50%>
