### PR TITLE
Render replies to ended polls (PSG-1131)

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2368,6 +2368,8 @@ Tap the + to start adding people.";
 
 "poll_timeline_ended_text" = "Ended the poll";
 
+"poll_timeline_reply_ended_poll" = "Ended poll";
+
 // MARK: - Location sharing
 
 "location_sharing_title" = "Location";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4883,6 +4883,10 @@ public class VectorL10n: NSObject {
   public static var pollTimelineOneVote: String { 
     return VectorL10n.tr("Vector", "poll_timeline_one_vote") 
   }
+  /// Ended poll
+  public static var pollTimelineReplyEndedPoll: String { 
+    return VectorL10n.tr("Vector", "poll_timeline_reply_ended_poll") 
+  }
   /// Final results based on %lu votes
   public static func pollTimelineTotalFinalResults(_ p1: Int) -> String {
     return VectorL10n.tr("Vector", "poll_timeline_total_final_results", p1)

--- a/Riot/Modules/MatrixKit/Models/Room/MXKSendReplyEventStringLocalizer.swift
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKSendReplyEventStringLocalizer.swift
@@ -18,34 +18,38 @@ import Foundation
 
 class MXKSendReplyEventStringLocalizer: NSObject, MXSendReplyEventStringLocalizerProtocol {
     func senderSentAnImage() -> String {
-        return VectorL10n.messageReplyToSenderSentAnImage
+        VectorL10n.messageReplyToSenderSentAnImage
     }
 
     func senderSentAVideo() -> String {
-        return VectorL10n.messageReplyToSenderSentAVideo
+        VectorL10n.messageReplyToSenderSentAVideo
     }
 
     func senderSentAnAudioFile() -> String {
-        return VectorL10n.messageReplyToSenderSentAnAudioFile
+        VectorL10n.messageReplyToSenderSentAnAudioFile
     }
 
     func senderSentAVoiceMessage() -> String {
-        return VectorL10n.messageReplyToSenderSentAVoiceMessage
+        VectorL10n.messageReplyToSenderSentAVoiceMessage
     }
 
     func senderSentAFile() -> String {
-        return VectorL10n.messageReplyToSenderSentAFile
+        VectorL10n.messageReplyToSenderSentAFile
     }
 
     func senderSentTheirLocation() -> String {
-        return VectorL10n.messageReplyToSenderSentTheirLocation
+        VectorL10n.messageReplyToSenderSentTheirLocation
     }
     
     func senderSentTheirLiveLocation() -> String {
-        return VectorL10n.messageReplyToSenderSentTheirLiveLocation
+        VectorL10n.messageReplyToSenderSentTheirLiveLocation
     }
 
     func messageToReplyToPrefix() -> String {
-        return VectorL10n.messageReplyToMessageToReplyToPrefix
+        VectorL10n.messageReplyToMessageToReplyToPrefix
+    }
+    
+    func replyToEndedPoll() -> String {
+        VectorL10n.pollTimelineReplyEndedPoll
     }
 }

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -2024,8 +2024,13 @@ static NSString *const kEndedPollPattern = @"<mx-reply>.*<blockquote>.*<br>(.*)<
         endedPollRegex = [NSRegularExpression regularExpressionWithPattern:kEndedPollPattern options:NSRegularExpressionCaseInsensitive error:nil];
     });
     
-    NSTextCheckingResult* match = [endedPollRegex firstMatchInString:htmlString options:0 range:NSMakeRange(0, htmlString.length)];
     NSString* finalString = htmlString;
+    
+    if (repliedEvent.eventType != MXEventTypePollEnd) {
+        return finalString;
+    }
+    
+    NSTextCheckingResult* match = [endedPollRegex firstMatchInString:htmlString options:0 range:NSMakeRange(0, htmlString.length)];
     
     if (!(match && match.numberOfRanges > 1)) {
         // no useful match found

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1882,6 +1882,12 @@ static NSString *const kEndedPollPattern = @"<mx-reply>.*<blockquote>.*<br>(.*)<
             {
                 MXJSONModelSetString(repliedEventContent, repliedEvent.content[kMXMessageBodyKey]);
             }
+            if (!repliedEventContent && repliedEvent.eventType == MXEventTypePollStart) {
+                repliedEventContent = [MXEventContentPollStart modelFromJSON:repliedEvent.content].question;
+            }
+            if (!repliedEventContent && repliedEvent.eventType == MXEventTypePollEnd) {
+                repliedEventContent = MXSendReplyEventDefaultStringLocalizer.new.replyToEndedPoll;
+            }
         }
 
         // No message content in a non-redacted event. Formatter should use fallback.

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -31,7 +31,7 @@
 #import "GeneratedInterface-Swift.h"
 
 static NSString *const kHTMLATagRegexPattern = @"<a href=(?:'|\")(.*?)(?:'|\")>([^<]*)</a>";
-static NSString *const kEndedPollPattern = @"<mx-reply>.*<blockquote>.*<br>(.*)</blockquote></mx-reply>";
+static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*)</blockquote></mx-reply>";
 
 @interface MXKEventFormatter ()
 {
@@ -2027,7 +2027,7 @@ static NSString *const kEndedPollPattern = @"<mx-reply>.*<blockquote>.*<br>(.*)<
     static dispatch_once_t onceToken;
     
     dispatch_once(&onceToken, ^{
-        endedPollRegex = [NSRegularExpression regularExpressionWithPattern:kEndedPollPattern options:NSRegularExpressionCaseInsensitive error:nil];
+        endedPollRegex = [NSRegularExpression regularExpressionWithPattern:kRepliedTextPattern options:NSRegularExpressionCaseInsensitive error:nil];
     });
     
     NSString* finalString = htmlString;

--- a/RiotTests/MatrixKitTests/MXKEventFormatterSwiftTests.swift
+++ b/RiotTests/MatrixKitTests/MXKEventFormatterSwiftTests.swift
@@ -29,9 +29,10 @@ private enum Constants {
     static let expectedEditedHTML = "<mx-reply><blockquote><a href=\"https://matrix.to/#/someRoomId/repliedEventId\">In reply to</a> <a href=\"https://matrix.to/#/alice\">alice</a><br>Edited message</blockquote></mx-reply>Reply"
     static let expectedEditedHTMLWithNewContent = "<mx-reply><blockquote><a href=\"https://matrix.to/#/someRoomId/repliedEventId\">In reply to</a> <a href=\"https://matrix.to/#/alice\">alice</a><br>New content</blockquote></mx-reply>Reply"
     static let expectedEditedHTMLWithParsedItalic = "<mx-reply><blockquote><a href=\"https://matrix.to/#/someRoomId/repliedEventId\">In reply to</a> <a href=\"https://matrix.to/#/alice\">alice</a><br>New content</blockquote></mx-reply><em>Reply</em>"
+    static let expectedReplyToPollEndedEvent = "<mx-reply><blockquote><a href=\"https://matrix.to/#/someRoomId/repliedEventId\">In reply to</a> <a href=\"https://matrix.to/#/alice\">alice</a><br>Ended poll</blockquote></mx-reply>Reply"
 }
 
-class MXKEventFormatterTests: XCTestCase {
+class MXKEventFormatterSwiftTests: XCTestCase {
     func testBuildHTMLString() {
         let formatter = MXKEventFormatter()
         let repliedEvent = MXEvent()
@@ -72,5 +73,40 @@ class MXKEventFormatterTests: XCTestCase {
         repliedEvent.wireContent[kMXMessageBodyKey] = nil
         repliedEvent.wireContent[kMXMessageContentKeyNewContent] = nil
         XCTAssertNil(buildHTML())
+    }
+    
+    func testBuildHTMLStringWithPollEndedReply() {
+        let formatter = MXKEventFormatter()
+        let repliedEvent: MXEvent = .mockEvent(eventType: kMXEventTypeStringPollEnd, body: nil)
+        
+        let event = MXEvent()
+        event.sender = "bob"
+        event.wireType = kMXEventTypeStringRoomMessage
+        event.wireContent = [
+            kMXMessageTypeKey: kMXMessageTypeText,
+            kMXMessageBodyKey: Constants.replyBody,
+            kMXEventRelationRelatesToKey: [kMXEventContentRelatesToKeyInReplyTo: ["event_id": Constants.repliedEventId]]
+        ]
+        
+        let formattedText = formatter.buildHTMLString(for: event, inReplyTo: repliedEvent)
+        
+        XCTAssertEqual(formattedText, Constants.expectedReplyToPollEndedEvent)
+    }
+}
+
+private extension MXEvent {
+    static func mockEvent(eventType: String, body: String? = Constants.repliedEventBody) -> MXEvent {
+        let repliedEvent = MXEvent()
+        repliedEvent.sender = "alice"
+        repliedEvent.roomId = Constants.roomId
+        repliedEvent.eventId = Constants.repliedEventId
+        repliedEvent.wireType = eventType
+        repliedEvent.wireContent = [kMXMessageTypeKey: kMXMessageTypeText]
+        
+        if let body = body {
+            repliedEvent.wireContent[kMXMessageBodyKey] = body
+        }
+        
+        return repliedEvent
     }
 }

--- a/RiotTests/MatrixKitTests/MXKEventFormatterSwiftTests.swift
+++ b/RiotTests/MatrixKitTests/MXKEventFormatterSwiftTests.swift
@@ -35,17 +35,10 @@ private enum Constants {
 class MXKEventFormatterSwiftTests: XCTestCase {
     func testBuildHTMLString() {
         let formatter = MXKEventFormatter()
-        let repliedEvent = MXEvent()
+        let repliedEvent: MXEvent = .mockEvent(eventType: kMXEventTypeStringRoomMessage)
         let event = MXEvent()
         func buildHTML() -> String? { return formatter.buildHTMLString(for: event, inReplyTo: repliedEvent) }
 
-        // Initial setup.
-        repliedEvent.sender = "alice"
-        repliedEvent.roomId = Constants.roomId
-        repliedEvent.eventId = Constants.repliedEventId
-        repliedEvent.wireType = kMXEventTypeStringRoomMessage
-        repliedEvent.wireContent = [kMXMessageTypeKey: kMXMessageTypeText,
-                                    kMXMessageBodyKey: Constants.repliedEventBody]
         event.sender = "bob"
         event.wireType = kMXEventTypeStringRoomMessage
         event.wireContent = [

--- a/changelog.d/pr-7284.change
+++ b/changelog.d/pr-7284.change
@@ -1,0 +1,1 @@
+Polls: render replies to poll events better.


### PR DESCRIPTION
### Description

This PR replaces the "Ended poll" placeholder inside replies to `m.poll.end` events.

The placeholder will be replaced with one of the following in order:
- The `question` of the related `m.poll.start` event
- The localized version of "Ended poll"

### Dependency
https://github.com/matrix-org/matrix-ios-sdk/pull/1685

### Result
<img src="https://user-images.githubusercontent.com/19324622/213217259-13c1154f-f065-4cec-91c7-d084374de05f.png" width=50% height=50%>
