### PR TITLE
Display migration progress during startup

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1977,6 +1977,7 @@ Tap the + to start adding people.";
 
 // MARK: - Launch loading
 
+"launch_loading_migrating_data" = "Migrating data\n%@ %%";
 "launch_loading_server_syncing" = "Syncing with the server";
 "launch_loading_server_syncing_nth_attempt" = "Syncing with the server\n(%@ attempt)";
 "launch_loading_processing_response" = "Processing data\n%@ %%";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3179,6 +3179,10 @@ public class VectorL10n: NSObject {
   public static var later: String { 
     return VectorL10n.tr("Vector", "later") 
   }
+  /// Migrating data\n%@ %%
+  public static func launchLoadingMigratingData(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "launch_loading_migrating_data", p1)
+  }
   /// Processing data\n%@ %%
   public static func launchLoadingProcessingResponse(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "launch_loading_processing_response", p1)

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2395,14 +2395,14 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         MXLogDebug(@"[AppDelegate] showLaunchAnimation");
         
         LaunchLoadingView *launchLoadingView;
-        if (MXSDKOptions.sharedInstance.enableSyncProgress)
+        if (MXSDKOptions.sharedInstance.enableStartupProgress)
         {
             MXSession *mainSession = self.mxSessions.firstObject;
-            launchLoadingView = [LaunchLoadingView instantiateWithSyncProgress:mainSession.syncProgress];
+            launchLoadingView = [LaunchLoadingView instantiateWithStartupProgress:mainSession.startupProgress];
         }
         else
         {
-            launchLoadingView = [LaunchLoadingView instantiateWithSyncProgress:nil];
+            launchLoadingView = [LaunchLoadingView instantiateWithStartupProgress:nil];
         }
                 
         launchLoadingView.frame = window.bounds;

--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -613,8 +613,8 @@ final class AuthenticationCoordinator: NSObject, AuthenticationCoordinatorProtoc
     
     /// Replace the contents of the navigation router with a loading animation.
     private func showLoadingAnimation() {
-        let syncProgress: MXSessionSyncProgress? = MXSDKOptions.sharedInstance().enableSyncProgress ? session?.syncProgress : nil
-        let loadingViewController = LaunchLoadingViewController(syncProgress: syncProgress)
+        let startupProgress: MXSessionStartupProgress? = MXSDKOptions.sharedInstance().enableStartupProgress ? session?.startupProgress : nil
+        let loadingViewController = LaunchLoadingViewController(startupProgress: startupProgress)
         loadingViewController.modalPresentationStyle = .fullScreen
         
         // Replace the navigation stack with the loading animation

--- a/Riot/Modules/Authentication/Legacy/LegacyAuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/Legacy/LegacyAuthenticationCoordinator.swift
@@ -106,8 +106,8 @@ final class LegacyAuthenticationCoordinator: NSObject, AuthenticationCoordinator
     // MARK: - Private
     
     private func showLoadingAnimation() {
-        let syncProgress: MXSessionSyncProgress? = MXSDKOptions.sharedInstance().enableSyncProgress ? session?.syncProgress : nil
-        let loadingViewController = LaunchLoadingViewController(syncProgress: syncProgress)
+        let startupProgress: MXSessionStartupProgress? = MXSDKOptions.sharedInstance().enableStartupProgress ? session?.startupProgress : nil
+        let loadingViewController = LaunchLoadingViewController(startupProgress: startupProgress)
         loadingViewController.modalPresentationStyle = .fullScreen
         
         // Replace the navigation stack with the loading animation

--- a/Riot/Modules/LaunchLoading/LaunchLoadingViewController.swift
+++ b/Riot/Modules/LaunchLoading/LaunchLoadingViewController.swift
@@ -21,10 +21,10 @@ class LaunchLoadingViewController: UIViewController, Reusable {
     
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     
-    init(syncProgress: MXSessionSyncProgress?) {
+    init(startupProgress: MXSessionStartupProgress?) {
         super.init(nibName: "LaunchLoadingViewController", bundle: nil)
         
-        let launchLoadingView = LaunchLoadingView.instantiate(syncProgress: syncProgress)
+        let launchLoadingView = LaunchLoadingView.instantiate(startupProgress: startupProgress)
         launchLoadingView.update(theme: ThemeService.shared().theme)
         view.vc_addSubViewMatchingParent(launchLoadingView)
         

--- a/changelog.d/pr-7286.change
+++ b/changelog.d/pr-7286.change
@@ -1,0 +1,1 @@
+CryptoV2: Display migration progress during startup


### PR DESCRIPTION
Related [SDK change](https://github.com/matrix-org/matrix-ios-sdk/pull/1687)

Display progress for the newly added `migratingData` stage during session startup that is shown on the loading page

|Loading|
|--------|
|  ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-18 at 16 41 06](https://user-images.githubusercontent.com/3922159/213242249-8c82191a-2046-4ee6-a61a-94405b4a19bc.png) |