### PR TITLE
Issue in height calculation for RTL text when there is headIndent and…

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1379,6 +1379,24 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
                         // Build the attributed string with the right font and color for the event
                         attributedDisplayText = [self renderString:body forEvent:event];
                     }
+                    
+                    // Issue in height calculation for RTL text when there is headIndent and firstlineheadIndent.
+                    if(attributedDisplayText != nil) {
+                        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"(?s).*\\p{Arabic}.*"];
+                        if ([predicate evaluateWithObject:body]) {
+                            NSMutableAttributedString *attString = [[NSMutableAttributedString alloc] initWithAttributedString:attributedDisplayText];
+
+                            NSMutableParagraphStyle *paragraphStyle = [attributedDisplayText attribute:NSParagraphStyleAttributeName atIndex:0 effectiveRange:nil];
+                            if (paragraphStyle) {
+                                paragraphStyle.baseWritingDirection = NSWritingDirectionRightToLeft;
+                                paragraphStyle.alignment = NSTextAlignmentJustified;
+                                paragraphStyle.headIndent = 0;
+                                paragraphStyle.firstLineHeadIndent = 0;
+                                [attString addAttributes:@{NSParagraphStyleAttributeName : paragraphStyle} range:NSMakeRange(0, attString.length)];
+                                attributedDisplayText = [[NSAttributedString alloc] initWithAttributedString:attString];
+                            }
+                        }
+                    }
 
                     // Build the full emote string after the body message formatting
                     if ([msgtype isEqualToString:kMXMessageTypeEmote])

--- a/changelog.d/7288.bugfix
+++ b/changelog.d/7288.bugfix
@@ -1,0 +1,1 @@
+RTL replies sometimes don't get rendered


### PR DESCRIPTION
Issue in height calculation for RTL text when there is headIndent and firstlineheadIndent.

Signed-off-by: Shunmugaraj toshanmugaraj@gmail.com

### Pull Request Checklist

- [ x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ x] Accessibility has been taken into account.
* [ x] Pull request is based on the develop branch
- [ x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
