### PR TITLE
Implement MSC3912 to delete server side all the data of the deleted voice broadcast

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4303,12 +4303,9 @@ static CGSize kThreadListBarButtonItemImageSize;
                 [self startActivityIndicator];
                 
                 NSArray<NSString *>* relationTypes = nil;
-                // If it's a voice broadcast, delete the selected event and all related events (only if this feature is supported).
+                // If it's a voice broadcast, delete the selected event and all related events.
                 if (selectedEvent.eventType == MXEventTypeCustom && [selectedEvent.type isEqualToString:VoiceBroadcastSettings.voiceBroadcastInfoContentKeyType]) {
-                    // Check if the homeserver supports redaction with relations
-                    if (self.mainSession.store.supportedMatrixVersions.supportsRedactionWithRelations || self.mainSession.store.supportedMatrixVersions.supportsRedactionWithRelationsUnstable) {
-                        relationTypes = @[MXEventRelationTypeReference];
-                    }
+                    relationTypes = @[MXEventRelationTypeReference];
                 }
                 
                 MXWeakify(self);

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/Coordinator/VoiceBroadcastPlaybackCoordinator.swift
@@ -57,7 +57,8 @@ final class VoiceBroadcastPlaybackCoordinator: Coordinator, Presentable {
     }
     
     deinit {
-        viewModel.context.send(viewAction: .redact)
+        // If init has failed, our viewmodel will be nil.
+        viewModel?.context.send(viewAction: .redact)
     }
     
     // MARK: - Public

--- a/changelog.d/7283.feature
+++ b/changelog.d/7283.feature
@@ -1,0 +1,1 @@
+Voice Broadcast: When deleting a voice broadcast, all data is now deleted on server side (MSC3912 implementation).


### PR DESCRIPTION
Fixes #7283 

This PR is based on the [msc3912 implementation](https://github.com/matrix-org/matrix-ios-sdk/pull/1688) in matrix-ios-sdk 
