### PR TITLE
Detect and handle the lost of connectivity with the homeserver while recording a voice broadcast

### DIFF
--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -100,14 +100,8 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
 
             if AppDelegate.theDelegate().isOffline {
                 self.splitViewCoordinator?.showAppStateIndicator(with: VectorL10n.networkOfflineTitle, icon: UIImage(systemName: "wifi.slash"))
-                
-                // Pause voice broadcast recording without sending pending events.
-                VoiceBroadcastRecorderProvider.shared.pauseRecordingOnError()
             } else {
-                self.splitViewCoordinator?.hideAppStateIndicator()
-                
-                // Send pause voice broadcast event.
-                VoiceBroadcastRecorderProvider.shared.pauseRecording()
+                self.splitViewCoordinator?.hideAppStateIndicator()                
             }
         }
         

--- a/changelog.d/7285.change
+++ b/changelog.d/7285.change
@@ -1,0 +1,1 @@
+Voice Broadcast: handle the lost of connectivity with the homeserver while recording.


### PR DESCRIPTION
Fixes #7285 

While recording a voice broadcast, we now pause it if the session state changes to .homeserverNotReachable instead of just relying on network connectivity because a device might be considered online, but it's always possible that the home server is unreachable.

The easiest way to test this PR is to shutdown the local homeserver while recording a voice broadcast.