### PR TITLE
Fix a deadlock when updating the summary of a room that has a voice broadcast

### DIFF
--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -567,7 +567,8 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
             return [self session:session
                updateRoomSummary:summary
 withVoiceBroadcastInfoStateEvent:lastVoiceBroadcastInfoEvent
-  voiceBroadcastInfoStartedEvent:voiceBroadcastInfoStartedEvent roomState:roomState];
+  voiceBroadcastInfoStartedEvent:voiceBroadcastInfoStartedEvent
+                       roomState:roomState];
         }
     }
     
@@ -624,22 +625,8 @@ withVoiceBroadcastInfoStateEvent:lastVoiceBroadcastInfoEvent
     }
     else
     {
-        dispatch_group_t group = dispatch_group_create();
-        dispatch_group_enter(group);
-        
-        __block MXEvent *voiceBroadcastInfoStartedEvent;
-        
-        [session eventWithEventId:voiceBroadcastInfo.voiceBroadcastId inRoom:roomId success:^(MXEvent *resultEvent) {
-            voiceBroadcastInfoStartedEvent = resultEvent;
-            dispatch_group_leave(group);
-        } failure:^(NSError *error) {
-            MXLogErrorDetails(@"[EventFormatter] Fetch eventWithEventId with error = %@", error.description);
-            dispatch_group_leave(group);
-        }];
-        
-        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-        
-        return voiceBroadcastInfoStartedEvent;
+        // Search for the event only in the store to avoid network calls while updating the room summary (this a synchronous process and we cannot delay it).
+        return [mxSession.store eventWithEventId:voiceBroadcastInfo.voiceBroadcastId inRoom:roomId];
     }
 }
 

--- a/changelog.d/pr-7300.bugfix
+++ b/changelog.d/pr-7300.bugfix
@@ -1,0 +1,1 @@
+Fix a deadlock when updating the summary of a room that has a voice broadcast.


### PR DESCRIPTION
This PR is a hotfix fixing a deadlock happening when we try to update the summary of a room that has a voice broadcast.

To reproduce this issue in the current 1.9.16, simply clear the cache and a deadlock should occur if there is a voice broadcast in a room.