### PR TITLE
Inform the user about decryption errors during a voice broadcast

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2225,6 +2225,7 @@ Tap the + to start adding people.";
 "voice_broadcast_connection_error_title" = "Connection error";
 "voice_broadcast_connection_error_message" = "Unfortunately we’re unable to start a recording right now. Please try again later.";
 "voice_broadcast_recorder_connection_error" = "Connection error - Recording paused";
+"voice_broadcast_playback_unable_to_decrypt" = "Unable to decrypt this voice broadcast.";
 
 // MARK: - Version check
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -9235,6 +9235,10 @@ public class VectorL10n: NSObject {
   public static var voiceBroadcastPlaybackLockScreenPlaceholder: String { 
     return VectorL10n.tr("Vector", "voice_broadcast_playback_lock_screen_placeholder") 
   }
+  /// Unable to decrypt this voice broadcast.
+  public static var voiceBroadcastPlaybackUnableToDecrypt: String { 
+    return VectorL10n.tr("Vector", "voice_broadcast_playback_unable_to_decrypt") 
+  }
   /// Connection error - Recording paused
   public static var voiceBroadcastRecorderConnectionError: String { 
     return VectorL10n.tr("Vector", "voice_broadcast_recorder_connection_error") 

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1053,8 +1053,13 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
                     else if ([event.decryptionError.domain isEqualToString:MXDecryptingErrorDomain]
                         && event.decryptionError.code == MXDecryptingErrorUnknownInboundSessionIdCode)
                     {
-                        // Make the unknown inbound session id error description more user friendly
-                        errorDescription = [VectorL10n noticeCryptoErrorUnknownInboundSessionId];
+                        // Hide the decryption error for event related to another one (like voicebroadcast chunks)
+                        if ([event.relatesTo.relationType isEqualToString:MXEventRelationTypeReference]) {
+                            displayText = nil;
+                        } else {
+                            // Make the unknown inbound session id error description more user friendly
+                            errorDescription = [VectorL10n noticeCryptoErrorUnknownInboundSessionId];
+                        }
                     }
                     else if ([event.decryptionError.domain isEqualToString:MXDecryptingErrorDomain]
                            && event.decryptionError.code == MXDecryptingErrorDuplicateMessageIndexCode)

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1053,8 +1053,17 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
                     else if ([event.decryptionError.domain isEqualToString:MXDecryptingErrorDomain]
                         && event.decryptionError.code == MXDecryptingErrorUnknownInboundSessionIdCode)
                     {
-                        // Hide the decryption error for event related to another one (like voicebroadcast chunks)
+                        // Hide the decryption error for VoiceBroadcast chunks
+                        BOOL isVoiceBroadcastChunk = NO;
                         if ([event.relatesTo.relationType isEqualToString:MXEventRelationTypeReference]) {
+                            MXEvent *startEvent = [mxSession.store eventWithEventId:event.relatesTo.eventId
+                                                                             inRoom:event.roomId];
+
+                            if (startEvent) {
+                                isVoiceBroadcastChunk = (startEvent.eventType == MXEventTypeCustom && [startEvent.type isEqualToString:VoiceBroadcastSettings.voiceBroadcastInfoContentKeyType]);
+                            }
+                        }
+                        if (isVoiceBroadcastChunk) {
                             displayText = nil;
                         } else {
                             // Make the unknown inbound session id error description more user friendly

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/View/VoiceBroadcastPlaybackDecryptionErrorView.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/View/VoiceBroadcastPlaybackDecryptionErrorView.swift
@@ -1,0 +1,47 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct VoiceBroadcastPlaybackDecryptionErrorView: View {
+    // MARK: - Properties
+    
+    // MARK: Private
+    
+    @Environment(\.theme) private var theme: ThemeSwiftUI
+    
+    // MARK: Public
+    
+    var body: some View {
+        ZStack {
+            HStack(spacing: 0) {
+                Image(uiImage: Asset.Images.errorIcon.image)
+                    .frame(width: 40, height: 40)
+                Text(VectorL10n.voiceBroadcastPlaybackUnableToDecrypt)
+                    .multilineTextAlignment(.center)
+                    .font(theme.fonts.caption1)
+                    .foregroundColor(theme.colors.alert)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct VoiceBroadcastPlaybackDecryptionErrorView_Previews: PreviewProvider {
+    static var previews: some View {
+        VoiceBroadcastPlaybackDecryptionErrorView()
+    }
+}

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/View/VoiceBroadcastPlaybackView.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/View/VoiceBroadcastPlaybackView.swift
@@ -91,7 +91,7 @@ struct VoiceBroadcastPlaybackView: View {
                         }
                     }
                 }.frame(maxWidth: .infinity, alignment: .leading)
-                
+                                
                 if viewModel.viewState.broadcastState != .stopped {
                     Label {
                         Text(VectorL10n.voiceBroadcastLive)
@@ -109,7 +109,12 @@ struct VoiceBroadcastPlaybackView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(EdgeInsets(top: 0.0, leading: 0.0, bottom: 4.0, trailing: 0.0))
             
-            if viewModel.viewState.playbackState == .error {
+            if viewModel.viewState.decryptionState.errorCount > 0 {
+                VoiceBroadcastPlaybackDecryptionErrorView()
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("decryptionErrorView")
+            }
+            else if viewModel.viewState.playbackState == .error {
                 VoiceBroadcastPlaybackErrorView()
             } else {
                 HStack (spacing: 34.0) {
@@ -156,8 +161,8 @@ struct VoiceBroadcastPlaybackView: View {
             }
             
             VoiceBroadcastSlider(value: $viewModel.progress,
-                       minValue: 0.0,
-                       maxValue: viewModel.viewState.playingState.duration) { didChange in
+                                 minValue: 0.0,
+                                 maxValue: viewModel.viewState.playingState.duration) { didChange in
                 viewModel.send(viewAction: .sliderChange(didChange: didChange))
             }
             

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/VoiceBroadcastPlaybackModels.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/VoiceBroadcastPlaybackModels.swift
@@ -48,12 +48,17 @@ struct VoiceBroadcastPlayingState {
     var canMoveBackward: Bool
 }
 
+struct VoiceBroadcastPlaybackDecryptionState {
+    var errorCount: Int
+}
+
 struct VoiceBroadcastPlaybackViewState: BindableState {
     var details: VoiceBroadcastPlaybackDetails
     var broadcastState: VoiceBroadcastInfoState
     var playbackState: VoiceBroadcastPlaybackState
     var playingState: VoiceBroadcastPlayingState
     var bindings: VoiceBroadcastPlaybackViewStateBindings
+    var decryptionState: VoiceBroadcastPlaybackDecryptionState
 }
 
 struct VoiceBroadcastPlaybackViewStateBindings {

--- a/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/VoiceBroadcastPlaybackScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/VoiceBroadcastPlayback/VoiceBroadcastPlaybackScreenState.swift
@@ -43,11 +43,12 @@ enum MockVoiceBroadcastPlaybackScreenState: MockScreenState, CaseIterable {
     var screenView: ([Any], AnyView) {
         
         let details = VoiceBroadcastPlaybackDetails(senderDisplayName: "Alice", avatarData: AvatarInput(mxContentUri: "", matrixItemId: "!fakeroomid:matrix.org", displayName: "The name of the room"))
-        let viewModel = MockVoiceBroadcastPlaybackViewModel(initialViewState: VoiceBroadcastPlaybackViewState(details: details, broadcastState: .started,  playbackState: .stopped, playingState: VoiceBroadcastPlayingState(duration: 10.0, isLive: true, canMoveForward: false, canMoveBackward: false), bindings: VoiceBroadcastPlaybackViewStateBindings(progress: 0)))
+        let viewModel = MockVoiceBroadcastPlaybackViewModel(initialViewState: VoiceBroadcastPlaybackViewState(details: details, broadcastState: .started,  playbackState: .stopped, playingState: VoiceBroadcastPlayingState(duration: 10.0, isLive: true, canMoveForward: false, canMoveBackward: false), bindings: VoiceBroadcastPlaybackViewStateBindings(progress: 0), decryptionState: VoiceBroadcastPlaybackDecryptionState(errorCount: 0)))
         
         return (
             [false, viewModel],
-            AnyView(VoiceBroadcastPlaybackView(viewModel: viewModel.context))
+            AnyView(VoiceBroadcastPlaybackView(viewModel: viewModel.context)
+                .environmentObject(AvatarViewModel.withMockedServices()))
         )
     }
 }

--- a/changelog.d/7189.change
+++ b/changelog.d/7189.change
@@ -1,0 +1,1 @@
+Voice Broadcast: Inform the user about decryption errors during a voice broadcast.

--- a/changelog.d/7189.change
+++ b/changelog.d/7189.change
@@ -1,1 +1,1 @@
-Voice Broadcast: Inform the user about decryption errors during a voice broadcast.
+Inform the user about decryption errors during a voice broadcast.


### PR DESCRIPTION
Fixes #7189 

If a decryption error occurs during a voice broadcast:
- don't display an entry for the encrypted chunk in the room
- pause the voice broadcast playback and show an error in the cell until there is a decryption error
![chunk_decryption_error](https://user-images.githubusercontent.com/4334885/214789003-33a27249-b9c3-4030-84a4-a62d11101020.jpeg)

