### PR TITLE
Ensure E2EE never tracks UnknownError

### DIFF
--- a/Riot/Modules/Analytics/DecryptionFailure.swift
+++ b/Riot/Modules/Analytics/DecryptionFailure.swift
@@ -16,12 +16,10 @@
 
 import AnalyticsEvents
 
-/// Failure reasons as defined in https://docs.google.com/document/d/1es7cTCeJEXXfRCTRgZerAM2Wg5ZerHjvlpfTW-gsOfI.
 @objc enum DecryptionFailureReason: Int {
     case unspecified
     case olmKeysNotSent
     case olmIndexError
-    case unexpected
     
     var errorName: AnalyticsEvent.Error.Name {
         switch self {
@@ -31,8 +29,6 @@ import AnalyticsEvents
             return .OlmKeysNotSentError
         case .olmIndexError:
             return .OlmIndexError
-        case .unexpected:
-            return .UnknownError
         }
     }
 }

--- a/Riot/Modules/Analytics/DecryptionFailureTracker.m
+++ b/Riot/Modules/Analytics/DecryptionFailureTracker.m
@@ -105,12 +105,9 @@ NSString *const kDecryptionFailureTrackerAnalyticsCategory = @"e2e.failure";
             reason = DecryptionFailureReasonOlmIndexError;
             break;
 
-        case MXDecryptingErrorEncryptionNotEnabledCode:
-        case MXDecryptingErrorUnableToDecryptCode:
-            reason = DecryptionFailureReasonUnexpected;
-            break;
-
         default:
+            // All other error codes will be tracked as `OlmUnspecifiedError` and will include `context` containing
+            // the actual error code and localized description
             reason = DecryptionFailureReasonUnspecified;
             break;
     }

--- a/Riot/Modules/Analytics/Helpers/MXCallHangupReason+Analytics.swift
+++ b/Riot/Modules/Analytics/Helpers/MXCallHangupReason+Analytics.swift
@@ -21,6 +21,9 @@ extension __MXCallHangupReason {
         switch self {
         case .userHangup:
             return .VoipUserHangup
+        case .userBusy:
+            // There is no dedicated analytics event for `userBusy` error
+            return .UnknownError
         case .inviteTimeout:
             return .VoipInviteTimeout
         case .iceFailed:
@@ -32,6 +35,9 @@ extension __MXCallHangupReason {
         case .unknownError:
             return .UnknownError
         default:
+            MXLog.failure("Unknown or unhandled hangup reason", context: [
+                "reason": rawValue
+            ])
             return .UnknownError
         }
     }

--- a/changelog.d/pr-7304.change
+++ b/changelog.d/pr-7304.change
@@ -1,0 +1,1 @@
+Analytics: Ensure E2EE never tracks UnknownError


### PR DESCRIPTION
We have been using `UnknownError` analytics event to track some types of E2EE errors. This error type is however used for other unrelated events as well (notably VOIP), which makes it impossible to distinguish the area of concern.

To solve this we will never use the generic `UnknownError` to track E2EE errors and instead only rely on the existing `OlmUnspecifiedError` (even if the "Olm" in the name is misleading). Further details about the error are always present in the `context` property