### PR TITLE
Fix Space Switcher avatars

### DIFF
--- a/RiotSwiftUI/Modules/Common/Avatar/View/AvatarImage.swift
+++ b/RiotSwiftUI/Modules/Common/Avatar/View/AvatarImage.swift
@@ -26,9 +26,11 @@ struct AvatarImage: View {
     var displayName: String?
     var size: AvatarSize
     
+    @State private var avatar: AvatarViewState = .empty
+    
     var body: some View {
         Group {
-            switch viewModel.viewState {
+            switch avatar {
             case .empty:
                 ProgressView()
             case .placeholder(let firstCharacter, let colorIndex):
@@ -42,13 +44,16 @@ struct AvatarImage: View {
         .frame(maxWidth: CGFloat(size.rawValue), maxHeight: CGFloat(size.rawValue))
         .clipShape(Circle())
         .onAppear {
-            viewModel.loadAvatar(
-                mxContentUri: mxContentUri,
-                matrixItemId: matrixItemId,
-                displayName: displayName,
-                colorCount: theme.colors.namesAndAvatars.count,
-                avatarSize: size
-            )
+            avatar = viewModel.placeholderAvatar(matrixItemId: matrixItemId,
+                                                 displayName: displayName,
+                                                 colorCount: theme.colors.namesAndAvatars.count)
+            viewModel.loadAvatar(mxContentUri: mxContentUri,
+                                 matrixItemId: matrixItemId,
+                                 displayName: displayName,
+                                 colorCount: theme.colors.namesAndAvatars.count,
+                                 avatarSize: size ) { newState in
+                avatar = newState
+            }
         }
     }
 }

--- a/changelog.d/7305.bugfix
+++ b/changelog.d/7305.bugfix
@@ -1,0 +1,1 @@
+Space Switcher: Fix a bug where the avatars would all be the same.


### PR DESCRIPTION
Fixes #7305. The view model is now injected at a top level and shared across multiple avatars so no longer works with the state being held within the model. As this is a lightweight component it seems reasonable to me to move it to an `@State` variable within the view itself.

Note: Also fixes the same bug in user suggestions and possibly elsewhere in SwiftUI.

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 14 - 2023-01-26 at 12 02 13](https://user-images.githubusercontent.com/6060466/214830583-a40d1c04-e485-4781-9d56-9e0c94458ec3.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-26 at 11 56 40](https://user-images.githubusercontent.com/6060466/214830596-2edc9af2-b432-4256-95ab-4742ebb71b48.png) |
