### PR TITLE
Generate Crypto SDK store key

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -804,9 +804,9 @@ Tap the + to start adding people.";
 "settings_labs_enable_new_app_layout" = "New Application Layout";
 "settings_labs_enable_wysiwyg_composer" = "Try out the rich text editor";
 "settings_labs_enable_voice_broadcast" = "Voice broadcast";
-"settings_labs_enable_crypto_sdk" = "Enable new rust-based Crypto SDK";
-"settings_labs_confirm_crypto_sdk" = "This action cannot be undone";
-"settings_labs_disable_crypto_sdk" = "Crypto SDK is enabled. To disable please reinstall the app";
+"settings_labs_enable_crypto_sdk" = "End-to-end encryption 2.0";
+"settings_labs_confirm_crypto_sdk" = "This option will enable a new, faster and more reliable engine for end-to-end encryption written in Rust. Once enabled, you will need to log out to disable it. Do you wish to proceed?";
+"settings_labs_disable_crypto_sdk" = "End-to-end encryption 2.0 (log out to disable)";
 
 "settings_version" = "Version %@";
 "settings_olm_version" = "Olm Version %@";

--- a/Riot/Categories/MatrixSDKCrypto+LocalizedError.swift
+++ b/Riot/Categories/MatrixSDKCrypto+LocalizedError.swift
@@ -1,0 +1,31 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG
+
+import MatrixSDKCrypto
+
+extension CryptoStoreError: LocalizedError {
+    public var errorDescription: String? {
+        // We dont really care about the type of error here when showing to the user.
+        // Details about the error are tracked independently
+        return VectorL10n.e2eNeedLogInAgain
+    }
+}
+
+#endif

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -7571,7 +7571,7 @@ public class VectorL10n: NSObject {
   public static var settingsLabs: String { 
     return VectorL10n.tr("Vector", "settings_labs") 
   }
-  /// This action cannot be undone
+  /// This option will enable a new, faster and more reliable engine for end-to-end encryption written in Rust. Once enabled, you will need to log out to disable it. Do you wish to proceed?
   public static var settingsLabsConfirmCryptoSdk: String { 
     return VectorL10n.tr("Vector", "settings_labs_confirm_crypto_sdk") 
   }
@@ -7579,7 +7579,7 @@ public class VectorL10n: NSObject {
   public static var settingsLabsCreateConferenceWithJitsi: String { 
     return VectorL10n.tr("Vector", "settings_labs_create_conference_with_jitsi") 
   }
-  /// Crypto SDK is enabled. To disable please reinstall the app
+  /// End-to-end encryption 2.0 (log out to disable)
   public static var settingsLabsDisableCryptoSdk: String { 
     return VectorL10n.tr("Vector", "settings_labs_disable_crypto_sdk") 
   }
@@ -7595,7 +7595,7 @@ public class VectorL10n: NSObject {
   public static var settingsLabsEnableAutoReportDecryptionErrors: String { 
     return VectorL10n.tr("Vector", "settings_labs_enable_auto_report_decryption_errors") 
   }
-  /// Enable new rust-based Crypto SDK
+  /// End-to-end encryption 2.0
   public static var settingsLabsEnableCryptoSdk: String { 
     return VectorL10n.tr("Vector", "settings_labs_enable_crypto_sdk") 
   }

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -3386,7 +3386,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     MXWeakify(self);
     
     [currentAlert dismissViewControllerAnimated:NO completion:nil];
-    UIAlertController *confirmationAlert = [UIAlertController alertControllerWithTitle:nil
+    UIAlertController *confirmationAlert = [UIAlertController alertControllerWithTitle:VectorL10n.settingsLabsEnableCryptoSdk
                                                                              message:VectorL10n.settingsLabsConfirmCryptoSdk
                                                                       preferredStyle:UIAlertControllerStyleAlert];
 

--- a/changelog.d/pr-7310.change
+++ b/changelog.d/pr-7310.change
@@ -1,0 +1,1 @@
+CryptoV2: Generate Crypto SDK store key


### PR DESCRIPTION
Use the existing `EncryptionKeyManager` to generate new Crypto SDK store key used to encrypt the [sqlite store](https://github.com/matrix-org/matrix-ios-sdk/pull/1699).

Additionally change some of the copy for the Labs option to enable crypto v2