### PR TITLE
Reset Crypto SDK labs on logout

### DIFF
--- a/Config/AppConfiguration.swift
+++ b/Config/AppConfiguration.swift
@@ -24,6 +24,9 @@ class AppConfiguration: CommonConfiguration {
     override func setupSettings() {
         super.setupSettings()
         setupAppSettings()
+#if DEBUG
+        CryptoSDKConfiguration.shared.setup()
+#endif
     }
     
     private func setupAppSettings() {

--- a/Config/CommonConfiguration.swift
+++ b/Config/CommonConfiguration.swift
@@ -91,12 +91,6 @@ class CommonConfiguration: NSObject, Configurable {
         MXKeyProvider.sharedInstance().delegate = EncryptionKeyManager.shared
 
         sdkOptions.enableNewClientInformationFeature = RiotSettings.shared.enableClientInformationFeature
-        
-        #if DEBUG
-        if sdkOptions.isCryptoSDKAvailable {
-            sdkOptions.enableCryptoSDK = RiotSettings.shared.enableCryptoSDK
-        }
-        #endif
     }
     
     private func makeASCIIUserAgent() -> String? {

--- a/Config/CryptoSDKConfiguration.swift
+++ b/Config/CryptoSDKConfiguration.swift
@@ -1,0 +1,55 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+#if DEBUG
+
+/// Configuration for enabling / disabling Matrix Crypto SDK
+@objcMembers class CryptoSDKConfiguration: NSObject {
+    static let shared = CryptoSDKConfiguration()
+    
+    func setup() {
+        guard MXSDKOptions.sharedInstance().isCryptoSDKAvailable else {
+            return
+        }
+        
+        let isEnabled = RiotSettings.shared.enableCryptoSDK
+        MXSDKOptions.sharedInstance().enableCryptoSDK = isEnabled
+        
+        MXLog.debug("[CryptoSDKConfiguration] setup: Crypto SDK is \(isEnabled ? "enabled" : "disabled")")
+    }
+    
+    func enable() {
+        guard MXSDKOptions.sharedInstance().isCryptoSDKAvailable else {
+            return
+        }
+        
+        RiotSettings.shared.enableCryptoSDK = true
+        MXSDKOptions.sharedInstance().enableCryptoSDK = true
+        
+        MXLog.debug("[CryptoSDKConfiguration] enabling Crypto SDK")
+    }
+    
+    func disable() {
+        RiotSettings.shared.enableCryptoSDK = false
+        MXSDKOptions.sharedInstance().enableCryptoSDK = false
+        
+        MXLog.debug("[CryptoSDKConfiguration] disabling Crypto SDK")
+    }
+}
+
+#endif

--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -637,7 +637,7 @@
         }];
     }
     
-    [notificationCenter enableRule:rule isEnabled:YES];
+    [notificationCenter enableRule:rule isEnabled:YES completion:nil];
 }
 
 - (void)setNotificationCenterDidFailObserver:(id)anObserver

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2183,6 +2183,11 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     // Clear cache
     [self clearCache];
     
+    // Reset Crypto SDK configuration (labs flag for which crypto module to use)
+#if DEBUG
+    [CryptoSDKConfiguration.shared disable];
+#endif
+    
     // Reset key backup banner preferences
     [SecureBackupBannerPreferences.shared reset];
     

--- a/Riot/Modules/MatrixKit/Controllers/MXKNotificationSettingsViewController.m
+++ b/Riot/Modules/MatrixKit/Controllers/MXKNotificationSettingsViewController.m
@@ -193,7 +193,7 @@
         MXPushRule *pushRule = [_mxAccount.mxSession.notificationCenter ruleById:kMXNotificationCenterDisableAllNotificationsRuleID];
         if (pushRule)
         {
-            [_mxAccount.mxSession.notificationCenter enableRule:pushRule isEnabled:!areAllDisabled];
+            [_mxAccount.mxSession.notificationCenter enableRule:pushRule isEnabled:!areAllDisabled completion:nil];
         }
     }
 }

--- a/Riot/Modules/MatrixKit/Views/PushRule/MXKPushRuleTableViewCell.m
+++ b/Riot/Modules/MatrixKit/Views/PushRule/MXKPushRuleTableViewCell.m
@@ -163,7 +163,7 @@
     if (sender == _controlButton)
     {
         // Swap enable state
-        [_mxSession.notificationCenter enableRule:_mxPushRule isEnabled:!_mxPushRule.enabled];
+        [_mxSession.notificationCenter enableRule:_mxPushRule isEnabled:!_mxPushRule.enabled completion:nil];
     }
     else if (sender == _deleteButton)
     {

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -3400,8 +3400,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     [confirmationAlert addAction:[UIAlertAction actionWithTitle:[VectorL10n continue] style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
         MXStrongifyAndReturnIfNil(self);
         
-        RiotSettings.shared.enableCryptoSDK = isEnabled;
-        MXSDKOptions.sharedInstance.enableCryptoSDK = isEnabled;
+        [CryptoSDKConfiguration.shared enable];
         [[AppDelegate theDelegate] reloadMatrixSessions:YES];
     }]];
 

--- a/changelog.d/pr-7323.change
+++ b/changelog.d/pr-7323.change
@@ -1,0 +1,1 @@
+CryptoV2: Reset Crypto SDK on logout


### PR DESCRIPTION
We don't really have any mechanism to reset specific user defaults when the user logs out (e.g. all labs flags remain toggled after another user login). That may not be an issue for most settings, but logging out needs to reset crypto SDK setting. To make this a bit more consolidated add `CryptoSDKConfiguration` and disable from legacy app delegate.