### PR TITLE
Fix crypto v2 config

### DIFF
--- a/Config/AppConfiguration.swift
+++ b/Config/AppConfiguration.swift
@@ -24,9 +24,6 @@ class AppConfiguration: CommonConfiguration {
     override func setupSettings() {
         super.setupSettings()
         setupAppSettings()
-#if DEBUG
-        CryptoSDKConfiguration.shared.setup()
-#endif
     }
     
     private func setupAppSettings() {

--- a/Config/CommonConfiguration.swift
+++ b/Config/CommonConfiguration.swift
@@ -91,6 +91,16 @@ class CommonConfiguration: NSObject, Configurable {
         MXKeyProvider.sharedInstance().delegate = EncryptionKeyManager.shared
 
         sdkOptions.enableNewClientInformationFeature = RiotSettings.shared.enableClientInformationFeature
+        
+        #if DEBUG
+        if sdkOptions.isCryptoSDKAvailable {
+            let isEnabled = RiotSettings.shared.enableCryptoSDK
+            MXLog.debug("[CryptoSDKConfiguration] Crypto SDK is \(isEnabled ? "enabled" : "disabled")")
+            sdkOptions.enableCryptoSDK = isEnabled
+        } else {
+            MXLog.debug("[CryptoSDKConfiguration] Crypto SDK is not available)")
+        }
+        #endif
     }
     
     private func makeASCIIUserAgent() -> String? {

--- a/Config/CryptoSDKConfiguration.swift
+++ b/Config/CryptoSDKConfiguration.swift
@@ -22,17 +22,6 @@ import Foundation
 @objcMembers class CryptoSDKConfiguration: NSObject {
     static let shared = CryptoSDKConfiguration()
     
-    func setup() {
-        guard MXSDKOptions.sharedInstance().isCryptoSDKAvailable else {
-            return
-        }
-        
-        let isEnabled = RiotSettings.shared.enableCryptoSDK
-        MXSDKOptions.sharedInstance().enableCryptoSDK = isEnabled
-        
-        MXLog.debug("[CryptoSDKConfiguration] setup: Crypto SDK is \(isEnabled ? "enabled" : "disabled")")
-    }
-    
     func enable() {
         guard MXSDKOptions.sharedInstance().isCryptoSDKAvailable else {
             return


### PR DESCRIPTION
Fix how crypto v2 config is setup, given that `AppConfiguration` does not belong to NSE target as is required by Crypto V2