### PR TITLE
Refresh notification service on crypto change

### DIFF
--- a/changelog.d/pr-7332.change
+++ b/changelog.d/pr-7332.change
@@ -1,0 +1,1 @@
+CryptoV2: Refresh notification service on crypto change


### PR DESCRIPTION
CryptoSDK labs flag can be enabled after the notification service has been setup so we need to make sure that background sync service (which internally creates crypto module) is refreshed accordingly