### PR TITLE
Enable Crypto SDK for production

### DIFF
--- a/Config/CommonConfiguration.swift
+++ b/Config/CommonConfiguration.swift
@@ -92,15 +92,14 @@ class CommonConfiguration: NSObject, Configurable {
 
         sdkOptions.enableNewClientInformationFeature = RiotSettings.shared.enableClientInformationFeature
         
-        #if DEBUG
         if sdkOptions.isCryptoSDKAvailable {
             let isEnabled = RiotSettings.shared.enableCryptoSDK
             MXLog.debug("[CryptoSDKConfiguration] Crypto SDK is \(isEnabled ? "enabled" : "disabled")")
             sdkOptions.enableCryptoSDK = isEnabled
+            sdkOptions.enableStartupProgress = isEnabled
         } else {
             MXLog.debug("[CryptoSDKConfiguration] Crypto SDK is not available)")
         }
-        #endif
     }
     
     private func makeASCIIUserAgent() -> String? {

--- a/Config/CryptoSDKConfiguration.swift
+++ b/Config/CryptoSDKConfiguration.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// Configuration for enabling / disabling Matrix Crypto SDK
 @objcMembers class CryptoSDKConfiguration: NSObject {
     static let shared = CryptoSDKConfiguration()
@@ -29,6 +27,7 @@ import Foundation
         
         RiotSettings.shared.enableCryptoSDK = true
         MXSDKOptions.sharedInstance().enableCryptoSDK = true
+        MXSDKOptions.sharedInstance().enableStartupProgress = true
         
         MXLog.debug("[CryptoSDKConfiguration] enabling Crypto SDK")
     }
@@ -36,9 +35,8 @@ import Foundation
     func disable() {
         RiotSettings.shared.enableCryptoSDK = false
         MXSDKOptions.sharedInstance().enableCryptoSDK = false
+        MXSDKOptions.sharedInstance().enableStartupProgress = false
         
         MXLog.debug("[CryptoSDKConfiguration] disabling Crypto SDK")
     }
 }
-
-#endif

--- a/Riot/Categories/MatrixSDKCrypto+LocalizedError.swift
+++ b/Riot/Categories/MatrixSDKCrypto+LocalizedError.swift
@@ -15,9 +15,6 @@
 //
 
 import Foundation
-
-#if DEBUG
-
 import MatrixSDKCrypto
 
 extension CryptoStoreError: LocalizedError {
@@ -27,5 +24,3 @@ extension CryptoStoreError: LocalizedError {
         return VectorL10n.e2eNeedLogInAgain
     }
 }
-
-#endif

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -192,11 +192,9 @@ final class RiotSettings: NSObject {
     @UserDefault(key: "enableVoiceBroadcast", defaultValue: false, storage: defaults)
     var enableVoiceBroadcast
     
-    #if DEBUG
     /// Flag indicating if we are using rust-based `MatrixCryptoSDK` instead of `MatrixSDK`'s internal crypto module
     @UserDefault(key: "enableCryptoSDK", defaultValue: false, storage: defaults)
     var enableCryptoSDK
-    #endif
 
     // MARK: Calls
     

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2184,9 +2184,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     [self clearCache];
     
     // Reset Crypto SDK configuration (labs flag for which crypto module to use)
-#if DEBUG
     [CryptoSDKConfiguration.shared disable];
-#endif
     
     // Reset key backup banner preferences
     [SecureBackupBannerPreferences.shared reset];

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -865,10 +865,12 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
             return
         }
 
-        let devices = mainSession.crypto.devices(forUser: mainSession.myUserId).values
-        let userHasOneUnverifiedDevice = devices.contains(where: {!$0.trustLevel.isCrossSigningVerified})
-        if userHasOneUnverifiedDevice {
-            presentReviewUnverifiedSessionsAlert(with: session)
+        if let userId = mainSession.myUserId, let crypto = mainSession.crypto {
+            let devices = crypto.devices(forUser: userId).values
+            let userHasOneUnverifiedDevice = devices.contains(where: {!$0.trustLevel.isCrossSigningVerified})
+            if userHasOneUnverifiedDevice {
+                presentReviewUnverifiedSessionsAlert(with: session)
+            }
         }
     }
     

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -588,12 +588,10 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     if (BuildSettings.settingsScreenShowLabSettings)
     {
         Section *sectionLabs = [Section sectionWithTag:SECTION_TAG_LABS];
-        #if DEBUG
         if (MXSDKOptions.sharedInstance.isCryptoSDKAvailable)
         {
             [sectionLabs addRowWithTag:LABS_ENABLE_CRYPTO_SDK];
         }
-        #endif
         
         [sectionLabs addRowWithTag:LABS_ENABLE_RINGING_FOR_GROUP_CALLS_INDEX];
         [sectionLabs addRowWithTag:LABS_ENABLE_THREADS_INDEX];
@@ -2593,7 +2591,6 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         }
         else
         {
-        #if DEBUG
             if (row == LABS_ENABLE_CRYPTO_SDK)
             {
                 MXKTableViewCellWithLabelAndSwitch *labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
@@ -2606,7 +2603,6 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
                 
                 cell = labelAndSwitchCell;
             }
-        #endif
         }
     }
     else if (section == SECTION_TAG_SECURITY)
@@ -3379,7 +3375,6 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     RiotSettings.shared.enableVoiceBroadcast = sender.isOn;
 }
 
-#if DEBUG
 - (void)toggleEnableCryptoSDKFeature:(UISwitch *)sender
 {
     BOOL isEnabled = sender.isOn;
@@ -3407,7 +3402,6 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     [self presentViewController:confirmationAlert animated:YES completion:nil];
     currentAlert = confirmationAlert;
 }
-#endif
 
 - (void)togglePinRoomsWithMissedNotif:(UISwitch *)sender
 {

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -41,9 +41,7 @@ class NotificationService: UNNotificationServiceExtension {
     private var ongoingVoIPPushRequests: [String: Bool] = [:]
     
     private var userAccount: MXKAccount?
-    #if DEBUG
     private var isCryptoSDKEnabled = false
-    #endif
     
     /// Best attempt contents. Will be updated incrementally, if something fails during the process, this best attempt content will be showed as notification. Keys are eventId's
     private var bestAttemptContents: [String: UNMutableNotificationContent] = [:]
@@ -201,6 +199,7 @@ class NotificationService: UNNotificationServiceExtension {
                 if hasChangedCryptoSDK() || NotificationService.backgroundSyncService?.credentials != userAccount.mxCredentials {
                     MXLog.debug("[NotificationService] setup: MXBackgroundSyncService init: BEFORE")
                     self.logMemory()
+                    
                     NotificationService.backgroundSyncService = MXBackgroundSyncService(withCredentials: userAccount.mxCredentials, persistTokenDataHandler: { persistTokenDataHandler in
                         MXKAccountManager.shared().readAndWriteCredentials(persistTokenDataHandler)
                     }, unauthenticatedHandler: { error, softLogout, refreshTokenAuth, completion in
@@ -220,14 +219,11 @@ class NotificationService: UNNotificationServiceExtension {
     /// Determine whether we have switched from using crypto v1 to v2 or vice versa which will require
     /// rebuilding `MXBackgroundSyncService`
     private func hasChangedCryptoSDK() -> Bool {
-        #if DEBUG
-        if isCryptoSDKEnabled != RiotSettings.shared.enableCryptoSDK {
-            isCryptoSDKEnabled = RiotSettings.shared.enableCryptoSDK
-            return true
+        guard isCryptoSDKEnabled != RiotSettings.shared.enableCryptoSDK else {
+            return false
         }
-        #endif
-        
-        return false
+        isCryptoSDKEnabled = RiotSettings.shared.enableCryptoSDK
+        return true
     }
     
     /// Attempts to preprocess payload and attach room display name to the best attempt content

--- a/changelog.d/pr-7333.change
+++ b/changelog.d/pr-7333.change
@@ -1,0 +1,1 @@
+CryptoV2: Enable Crypto SDK for production


### PR DESCRIPTION
Remove all `DEBUG` compiler flags to enable CryptoSDK for production. Additionally ensure that `enableStartupProgress` is enabled only when `cryptoSDK` is enabled (at least for now)

Corresponding [SDK change](https://github.com/matrix-org/matrix-ios-sdk/pull/1708)