### PR TITLE
Track crypto SDK being enabled

### DIFF
--- a/Config/CommonConfiguration.swift
+++ b/Config/CommonConfiguration.swift
@@ -94,11 +94,11 @@ class CommonConfiguration: NSObject, Configurable {
         
         if sdkOptions.isCryptoSDKAvailable {
             let isEnabled = RiotSettings.shared.enableCryptoSDK
-            MXLog.debug("[CryptoSDKConfiguration] Crypto SDK is \(isEnabled ? "enabled" : "disabled")")
+            MXLog.debug("[CommonConfiguration] Crypto SDK is \(isEnabled ? "enabled" : "disabled")")
             sdkOptions.enableCryptoSDK = isEnabled
             sdkOptions.enableStartupProgress = isEnabled
         } else {
-            MXLog.debug("[CryptoSDKConfiguration] Crypto SDK is not available)")
+            MXLog.debug("[CommonConfiguration] Crypto SDK is not available)")
         }
     }
     

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -805,9 +805,9 @@ Tap the + to start adding people.";
 "settings_labs_enable_new_app_layout" = "New Application Layout";
 "settings_labs_enable_wysiwyg_composer" = "Try out the rich text editor";
 "settings_labs_enable_voice_broadcast" = "Voice broadcast";
-"settings_labs_enable_crypto_sdk" = "End-to-end encryption 2.0";
-"settings_labs_confirm_crypto_sdk" = "This option will enable a new, faster and more reliable engine for end-to-end encryption written in Rust. Once enabled, you will need to log out to disable it. Do you wish to proceed?";
-"settings_labs_disable_crypto_sdk" = "End-to-end encryption 2.0 (log out to disable)";
+"settings_labs_enable_crypto_sdk" = "Rust end-to-end encryption";
+"settings_labs_confirm_crypto_sdk" = "Please be advised that as this feature is still in its experimental stage, it may not function as expected and could potentially have unintended consequences. To revert the feature, simply log out and log back in. Use at your own discretion and with caution.";
+"settings_labs_disable_crypto_sdk" = "Rust end-to-end encryption (log out to disable)";
 
 "settings_version" = "Version %@";
 "settings_olm_version" = "Olm Version %@";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -7583,7 +7583,7 @@ public class VectorL10n: NSObject {
   public static var settingsLabs: String { 
     return VectorL10n.tr("Vector", "settings_labs") 
   }
-  /// This option will enable a new, faster and more reliable engine for end-to-end encryption written in Rust. Once enabled, you will need to log out to disable it. Do you wish to proceed?
+  /// Please be advised that as this feature is still in its experimental stage, it may not function as expected and could potentially have unintended consequences. To revert the feature, simply log out and log back in. Use at your own discretion and with caution.
   public static var settingsLabsConfirmCryptoSdk: String { 
     return VectorL10n.tr("Vector", "settings_labs_confirm_crypto_sdk") 
   }
@@ -7591,7 +7591,7 @@ public class VectorL10n: NSObject {
   public static var settingsLabsCreateConferenceWithJitsi: String { 
     return VectorL10n.tr("Vector", "settings_labs_create_conference_with_jitsi") 
   }
-  /// End-to-end encryption 2.0 (log out to disable)
+  /// Rust end-to-end encryption (log out to disable)
   public static var settingsLabsDisableCryptoSdk: String { 
     return VectorL10n.tr("Vector", "settings_labs_disable_crypto_sdk") 
   }
@@ -7607,7 +7607,7 @@ public class VectorL10n: NSObject {
   public static var settingsLabsEnableAutoReportDecryptionErrors: String { 
     return VectorL10n.tr("Vector", "settings_labs_enable_auto_report_decryption_errors") 
   }
-  /// End-to-end encryption 2.0
+  /// Rust end-to-end encryption
   public static var settingsLabsEnableCryptoSdk: String { 
     return VectorL10n.tr("Vector", "settings_labs_enable_crypto_sdk") 
   }

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -324,6 +324,11 @@ extension Analytics {
         viewRoomTrigger = .unknown
         capture(event: event)
     }
+    
+    func trackCryptoSDKEnabled() {
+        let event = AnalyticsEvent.CryptoSDKEnabled()
+        capture(event: event)
+    }
 }
 
 // MARK: - MXAnalyticsDelegate
@@ -391,5 +396,16 @@ extension Analytics: MXAnalyticsDelegate {
 
     func trackNonFatalIssue(_ issue: String, details: [String: Any]?) {
         monitoringClient.trackNonFatalIssue(issue, details: details)
+    }
+}
+
+/// iOS-specific analytics event triggered when users select the Crypto SDK labs option
+///
+/// Due to this event being iOS only, and temporary during gradual rollout of Crypto SDK,
+/// this event is not added into the shared analytics schema
+extension AnalyticsEvent {
+    struct CryptoSDKEnabled: AnalyticsEventProtocol {
+        let eventName = "CryptoSDKEnabled"
+        let properties: [String: Any] = [:]
     }
 }

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -2599,7 +2599,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
                 labelAndSwitchCell.mxkSwitch.on = isEnabled;
                 [labelAndSwitchCell.mxkSwitch setEnabled:!isEnabled];
                 labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
-                [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleEnableCryptoSDKFeature:) forControlEvents:UIControlEventTouchUpInside];
+                [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(enableCryptoSDKFeature:) forControlEvents:UIControlEventTouchUpInside];
                 
                 cell = labelAndSwitchCell;
             }
@@ -3375,16 +3375,14 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     RiotSettings.shared.enableVoiceBroadcast = sender.isOn;
 }
 
-- (void)toggleEnableCryptoSDKFeature:(UISwitch *)sender
+- (void)enableCryptoSDKFeature:(UISwitch *)sender
 {
-    BOOL isEnabled = sender.isOn;
-    MXWeakify(self);
-    
     [currentAlert dismissViewControllerAnimated:NO completion:nil];
     UIAlertController *confirmationAlert = [UIAlertController alertControllerWithTitle:VectorL10n.settingsLabsEnableCryptoSdk
                                                                              message:VectorL10n.settingsLabsConfirmCryptoSdk
                                                                       preferredStyle:UIAlertControllerStyleAlert];
 
+    MXWeakify(self);
     [confirmationAlert addAction:[UIAlertAction actionWithTitle:[VectorL10n cancel] style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         MXStrongifyAndReturnIfNil(self);
         self->currentAlert = nil;
@@ -3393,9 +3391,10 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     }]];
 
     [confirmationAlert addAction:[UIAlertAction actionWithTitle:[VectorL10n continue] style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
-        MXStrongifyAndReturnIfNil(self);
         
         [CryptoSDKConfiguration.shared enable];
+        [Analytics.shared trackCryptoSDKEnabled];
+        
         [[AppDelegate theDelegate] reloadMatrixSessions:YES];
     }]];
 


### PR DESCRIPTION
Add temporary and local-only analytics event that gets trigged when users select the Crypto SDK Labs option