### PR TITLE
Automatic poll rules sync (PSG-1135)

### DIFF
--- a/Config/AppConfiguration.swift
+++ b/Config/AppConfiguration.swift
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-import Combine
 import Foundation
 
 /// AppConfiguration is CommonConfiguration plus configurations dedicated to the app
@@ -55,17 +54,12 @@ class AppConfiguration: CommonConfiguration {
     
     // MARK: - Per matrix session settings
     
-    private var pushRulesUpdater: PushRulesUpdater?
-    
     override func setupSettings(for matrixSession: MXSession) {
         super.setupSettings(for: matrixSession)
         setupWidgetReadReceipts(for: matrixSession)
-        setupPushRuleSync(for: matrixSession)
     }
-}
-
-private extension AppConfiguration {
-    func setupWidgetReadReceipts(for matrixSession: MXSession) {
+  
+    private func setupWidgetReadReceipts(for matrixSession: MXSession) {
         var acknowledgableEventTypes = matrixSession.acknowledgableEventTypes ?? []
         acknowledgableEventTypes.append(kWidgetMatrixEventTypeString)
         acknowledgableEventTypes.append(kWidgetModularEventTypeString)
@@ -73,16 +67,4 @@ private extension AppConfiguration {
         matrixSession.acknowledgableEventTypes = acknowledgableEventTypes
     }
     
-    func setupPushRuleSync(for matrixSession: MXSession) {
-        let sessionIsReady = NotificationCenter.default.publisher(for: .mxSessionStateDidChange)
-            .first { _ in
-                matrixSession.state >= .running
-            }
-            .eraseOutput()
-        
-        let applicationDidBecomeActive = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification).eraseOutput()
-        let needsRulesCheck = Publishers.CombineLatest(sessionIsReady, applicationDidBecomeActive).eraseOutput()
-        
-        pushRulesUpdater = .init(notificationSettingsService: MXNotificationSettingsService(session: matrixSession), needsCheck: needsRulesCheck)
-    }
 }

--- a/Config/AppConfiguration.swift
+++ b/Config/AppConfiguration.swift
@@ -81,7 +81,7 @@ private extension AppConfiguration {
             .eraseOutput()
         
         let applicationDidBecomeActive = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification).eraseOutput()
-        let needsRulesCheck = Publishers.Merge(sessionIsReady, applicationDidBecomeActive).eraseToAnyPublisher()
+        let needsRulesCheck = Publishers.CombineLatest(sessionIsReady, applicationDidBecomeActive).eraseOutput()
         
         pushRulesUpdater = .init(notificationSettingsService: MXNotificationSettingsService(session: matrixSession), needsCheck: needsRulesCheck)
     }

--- a/Riot/Categories/Publisher+Riot.swift
+++ b/Riot/Categories/Publisher+Riot.swift
@@ -33,4 +33,10 @@ extension Publisher {
             Just($0).delay(for: .seconds(spacingDelay), scheduler: scheduler)
         }
     }
+    
+    func eraseOutput() -> AnyPublisher<Void, Failure> {
+        self
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
 }

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -80,12 +80,7 @@ private extension PushRulesUpdater {
 }
 
 private extension NotificationPushRuleType {
-    func hasSameContentOf(_ otherRule: NotificationPushRuleType) -> Bool {
-        guard let ruleId = pushRuleId else {
-            return false
-        }
-        
-        let notificationOption = NotificationIndex.index(when: enabled)
-        return otherRule.matches(standardActions: ruleId.standardActions(for: notificationOption))
+    func hasSameContentOf(_ otherRule: NotificationPushRuleType) -> Bool? {
+        enabled == otherRule.enabled && ruleActions == otherRule.ruleActions
     }
 }

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -44,12 +44,12 @@ private extension PushRulesUpdater {
         let relatedRules = rule.syncedRules(in: rules)
         
         for relatedRule in relatedRules {
-            guard relatedRule == rule else {
-                MXLog.debug("*** mismatch not found. rule: \(relatedRule.ruleId)")
+            guard MXPushRule.haveSameContent(relatedRule, rule) == false else {
+                MXLog.debug("*** mismatch -> rule: \(relatedRule.ruleId)")
                 continue
             }
             
-            MXLog.debug("*** mismatch found. rule: \(relatedRule.ruleId)")
+            MXLog.debug("*** OK -> rule: \(relatedRule.ruleId)")
         }
     }
 }
@@ -66,5 +66,29 @@ private extension MXPushRule {
             }
             return ruleId.syncedRules.contains(someRuleId)
         }
+    }
+    
+    static func haveSameContent(_ firstRule: MXPushRule, _ secondRule: MXPushRule) -> Bool {
+        guard
+            firstRule.enabled == secondRule.enabled,
+            let firstActions = firstRule.mxActions,
+            let secondActions = secondRule.mxActions,
+            firstActions.count == secondActions.count
+        else {
+            return false
+        }
+        
+        return firstActions.indices.allSatisfy { index in
+            let action1 = firstActions[index]
+            let action2 = secondActions[index]
+            #warning("compare  @property (nonatomic) NSDictionary *parameters")
+            return action1.actionType == action2.actionType
+        }
+    }
+}
+
+private extension MXPushRule {
+    var mxActions: [MXPushRuleAction]? {
+        actions as? [MXPushRuleAction]
     }
 }

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -39,7 +39,6 @@ final class PushRulesUpdater {
 
 private extension PushRulesUpdater {
     func syncRulesIfNeeded() {
-        print("*** check started: \(rules.count)")
         for rule in rules {
             syncRelatedRulesIfNeeded(for: rule)
         }
@@ -54,11 +53,9 @@ private extension PushRulesUpdater {
         
         for relatedRule in relatedRules {
             guard rule.hasSameContentOf(relatedRule) == false else {
-                print("*** OK -> rule: \(relatedRule.ruleId)")
                 continue
             }
             
-            print("*** mismatch -> rule: \(relatedRule.ruleId)")
             sync(relatedRuleId: relatedRule.ruleId, with: rule)
         }
     }

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -46,7 +46,7 @@ private extension PushRulesUpdater {
     }
     
     func syncRelatedRulesIfNeeded(for rule: NotificationPushRuleType) {
-        guard let ruleId = NotificationPushRuleId(rawValue: rule.ruleId) else {
+        guard let ruleId = rule.pushRuleId else {
             return
         }
         
@@ -67,7 +67,7 @@ private extension PushRulesUpdater {
         let notificationOption = NotificationIndex.index(when: rule.enabled)
         
         guard
-            let ruleId = NotificationPushRuleId(rawValue: rule.ruleId),
+            let ruleId = rule.pushRuleId,
             let expectedActions = ruleId.standardActions(for: notificationOption).actions
         else {
             return
@@ -81,7 +81,7 @@ private extension PushRulesUpdater {
 
 private extension NotificationPushRuleType {
     func hasSameContentOf(_ otherRule: NotificationPushRuleType) -> Bool {
-        guard let ruleId = NotificationPushRuleId(rawValue: ruleId) else {
+        guard let ruleId = pushRuleId else {
             return false
         }
         

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -1,0 +1,70 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+
+final class PushRulesUpdater {
+    private var cancellables: Set<AnyCancellable> = .init()
+    private var rules: [MXPushRule] = []
+    
+    init(checkSignal: AnyPublisher<Void, Never>, rulesProvider: AnyPublisher<[MXPushRule], Never>) {
+        rulesProvider
+            .weakAssign(to: \.rules, on: self)
+            .store(in: &cancellables)
+        
+        checkSignal
+            .sink { [weak self] _ in
+                self?.updateRulesIfNeeded()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+private extension PushRulesUpdater {
+    func updateRulesIfNeeded() {
+        for rule in rules {
+            syncRelatedRulesIfNeeded(for: rule)
+        }
+    }
+    
+    func syncRelatedRulesIfNeeded(for rule: MXPushRule) {
+        let relatedRules = rule.syncedRules(in: rules)
+        
+        for relatedRule in relatedRules {
+            guard relatedRule == rule else {
+                MXLog.debug("*** mismatch not found. rule: \(relatedRule.ruleId)")
+                continue
+            }
+            
+            MXLog.debug("*** mismatch found. rule: \(relatedRule.ruleId)")
+        }
+    }
+}
+
+private extension MXPushRule {
+    func syncedRules(in rules: [MXPushRule]) -> [MXPushRule] {
+        guard let ruleId = NotificationPushRuleId(rawValue: ruleId) else {
+            return []
+        }
+        
+        return rules.filter {
+            guard let someRuleId = NotificationPushRuleId(rawValue: $0.ruleId) else {
+                return false
+            }
+            return ruleId.syncedRules.contains(someRuleId)
+        }
+    }
+}

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -20,55 +20,36 @@ final class PushRulesUpdater {
     private var cancellables: Set<AnyCancellable> = .init()
     private var rules: [NotificationPushRuleType] = []
     private let notificationSettingsService: NotificationSettingsServiceType
-    private let didCompleteUpdateSubject: PassthroughSubject<Void, Never> = .init()
-    
-    var didCompleteUpdate: AnyPublisher<Void, Never> {
-        didCompleteUpdateSubject.eraseToAnyPublisher()
-    }
-    
-    init(notificationSettingsService: NotificationSettingsServiceType, needsCheck: AnyPublisher<Void, Never>) {
+
+    init(notificationSettingsService: NotificationSettingsServiceType) {
         self.notificationSettingsService = notificationSettingsService
         
         notificationSettingsService
             .rulesPublisher
             .weakAssign(to: \.rules, on: self)
             .store(in: &cancellables)
-        
-        needsCheck
-            .sink { [weak self] _ in
-                self?.syncRulesIfNeeded()
-            }
-            .store(in: &cancellables)
     }
-}
-
-private extension PushRulesUpdater {
-    func syncRulesIfNeeded() {
-        Task {
-            await withTaskGroup(of: Void.self) { [rules, notificationSettingsService] group in
-                for rule in rules {
-                    guard let ruleId = rule.pushRuleId else {
+    
+    func syncRulesIfNeeded() async {
+        await withTaskGroup(of: Void.self) { [rules, notificationSettingsService] group in
+            for rule in rules {
+                guard let ruleId = rule.pushRuleId else {
+                    continue
+                }
+                
+                let relatedRules = ruleId.syncedRules(in: rules)
+                
+                for relatedRule in relatedRules {
+                    guard rule.hasSameContentOf(relatedRule) == false else {
                         continue
                     }
                     
-                    let relatedRules = ruleId.syncedRules(in: rules)
-                    
-                    for relatedRule in relatedRules {
-                        guard rule.hasSameContentOf(relatedRule) == false else {
-                            continue
-                        }
-                        
-                        group.addTask {
-                            try? await notificationSettingsService.updatePushRuleActions(for: relatedRule.ruleId,
-                                                                                         enabled: rule.enabled,
-                                                                                         actions: rule.ruleActions)
-                        }
+                    group.addTask {
+                        try? await notificationSettingsService.updatePushRuleActions(for: relatedRule.ruleId,
+                                                                                     enabled: rule.enabled,
+                                                                                     actions: rule.ruleActions)
                     }
                 }
-            }
-            
-            await MainActor.run { [weak self] in
-                self?.didCompleteUpdateSubject.send(())
             }
         }
     }

--- a/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
+++ b/Riot/Managers/PushRulesUpdater/PushRulesUpdater.swift
@@ -64,17 +64,8 @@ private extension PushRulesUpdater {
     }
     
     func sync(relatedRuleId: String, with rule: NotificationPushRuleType) {
-        let notificationOption = NotificationIndex.index(when: rule.enabled)
-        
-        guard
-            let ruleId = rule.pushRuleId,
-            let expectedActions = ruleId.standardActions(for: notificationOption).actions
-        else {
-            return
-        }
-        
         Task {
-            try? await notificationSettingsService.updatePushRuleActions(for: relatedRuleId, enabled: rule.enabled, actions: expectedActions)
+            try? await notificationSettingsService.updatePushRuleActions(for: relatedRuleId, enabled: rule.enabled, actions: rule.ruleActions)
         }
     }
 }

--- a/Riot/Modules/Application/AppCoordinator.swift
+++ b/Riot/Modules/Application/AppCoordinator.swift
@@ -273,7 +273,6 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
             }
         
         sessionReady
-            .print("*** ready")
             .sink { [weak self] session in
                 let applicationDidBecomeActive = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification).eraseOutput()
                 let needsCheckPublisher = applicationDidBecomeActive.merge(with: Just(())).eraseToAnyPublisher()
@@ -288,7 +287,6 @@ final class AppCoordinator: NSObject, AppCoordinatorType {
             .filter { $0.state == .closed }
         
         sessionClosed
-            .print("*** closed")
             .sink { [weak self] _ in
                 self?.pushRulesUpdater = nil
             }

--- a/RiotSwiftUI/Modules/Settings/Notifications/Model/MatrixSDK/MXNotificationPushRule.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Model/MatrixSDK/MXNotificationPushRule.swift
@@ -41,6 +41,10 @@ extension MXPushRule: NotificationPushRuleType {
         return false
     }
     
+    var ruleActions: NotificationActions? {
+        .init(notify: notify, highlight: highlight, sound: sound)
+    }
+    
     private func getAction(actionType: MXPushRuleActionType, tweakType: String? = nil) -> MXPushRuleAction? {
         guard let actions = actions as? [MXPushRuleAction] else {
             return nil

--- a/RiotSwiftUI/Modules/Settings/Notifications/Model/Mock/MockNotificationPushRule.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Model/Mock/MockNotificationPushRule.swift
@@ -19,9 +19,9 @@ import Foundation
 struct MockNotificationPushRule: NotificationPushRuleType {
     var ruleId: String!
     var enabled: Bool
-    var actions: NotificationActions? = NotificationStandardActions.notifyDefaultSound.actions
+    var ruleActions: NotificationActions? = NotificationStandardActions.notifyDefaultSound.actions
     
     func matches(standardActions: NotificationStandardActions?) -> Bool {
-        standardActions?.actions == actions
+        standardActions?.actions == ruleActions
     }
 }

--- a/RiotSwiftUI/Modules/Settings/Notifications/Model/Mock/MockNotificationPushRule.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Model/Mock/MockNotificationPushRule.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-struct MockNotificationPushRule: NotificationPushRuleType {
+struct MockNotificationPushRule: NotificationPushRuleType, Equatable {
     var ruleId: String!
     var enabled: Bool
     var ruleActions: NotificationActions? = NotificationStandardActions.notifyDefaultSound.actions

--- a/RiotSwiftUI/Modules/Settings/Notifications/Model/NotificationPushRuleType.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Model/NotificationPushRuleType.swift
@@ -21,3 +21,9 @@ protocol NotificationPushRuleType {
     var enabled: Bool { get }
     func matches(standardActions: NotificationStandardActions?) -> Bool
 }
+
+extension NotificationPushRuleType {
+    var pushRuleId: NotificationPushRuleId? {
+        ruleId.flatMap(NotificationPushRuleId.init(rawValue:))
+    }
+}

--- a/RiotSwiftUI/Modules/Settings/Notifications/Model/NotificationPushRuleType.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Model/NotificationPushRuleType.swift
@@ -19,6 +19,8 @@ import Foundation
 protocol NotificationPushRuleType {
     var ruleId: String! { get }
     var enabled: Bool { get }
+    var ruleActions: NotificationActions? { get }
+    
     func matches(standardActions: NotificationStandardActions?) -> Bool
 }
 

--- a/RiotSwiftUI/Modules/Settings/Notifications/Service/MatrixSDK/MXNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Service/MatrixSDK/MXNotificationSettingsService.swift
@@ -89,10 +89,10 @@ class MXNotificationSettingsService: NotificationSettingsServiceType {
         
         // Updating the actions before enabling the rule allows the homeserver to triggers just one sync update
         try await session.notificationCenter.updatePushRuleActions(ruleId,
-                                                         kind: rule.kind,
-                                                         notify: actions.notify,
-                                                         soundName: actions.sound,
-                                                         highlight: actions.highlight)
+                                                                   kind: rule.kind,
+                                                                   notify: actions.notify,
+                                                                   soundName: actions.sound,
+                                                                   highlight: actions.highlight)
         
         try await session.notificationCenter.enableRule(pushRule: rule, isEnabled: enabled)
     }

--- a/RiotSwiftUI/Modules/Settings/Notifications/Service/MatrixSDK/MXNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Service/MatrixSDK/MXNotificationSettingsService.swift
@@ -38,14 +38,14 @@ class MXNotificationSettingsService: NotificationSettingsServiceType {
         let rulesUpdated = NotificationCenter.default.publisher(for: NSNotification.Name(rawValue: kMXNotificationCenterDidUpdateRules))
         
         // Set initial value of the content rules
-        if let contentRules = session.notificationCenter.rules.global.content as? [MXPushRule] {
+        if let contentRules = session.notificationCenter.rules?.global.content as? [MXPushRule] {
             self.contentRules = contentRules
         }
         
         // Observe future updates to content rules
         rulesUpdated
             .compactMap { [weak self] _ in
-                self?.session.notificationCenter.rules.global.content as? [MXPushRule]
+                self?.session.notificationCenter.rules?.global.content as? [MXPushRule]
             }
             .assign(to: &$contentRules)
         

--- a/RiotSwiftUI/Modules/Settings/Notifications/Service/Mock/MockNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Service/Mock/MockNotificationSettingsService.swift
@@ -49,6 +49,6 @@ class MockNotificationSettingsService: NotificationSettingsServiceType, Observab
             return
         }
         
-        rules[ruleIndex] = MockNotificationPushRule(ruleId: ruleId, enabled: enabled, actions: actions)
+        rules[ruleIndex] = MockNotificationPushRule(ruleId: ruleId, enabled: enabled, ruleActions: actions)
     }
 }

--- a/RiotSwiftUI/Modules/Settings/Notifications/ViewModel/NotificationSettingsViewModel.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/ViewModel/NotificationSettingsViewModel.swift
@@ -294,7 +294,7 @@ private extension NotificationSettingsViewModel {
     }
 }
 
-private extension NotificationPushRuleId {
+extension NotificationPushRuleId {
     func syncedRules(in rules: [NotificationPushRuleType]) -> [NotificationPushRuleType] {
         rules.filter {
             guard let ruleId = NotificationPushRuleId(rawValue: $0.ruleId) else {

--- a/RiotSwiftUI/Modules/Settings/Notifications/ViewModel/NotificationSettingsViewModel.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/ViewModel/NotificationSettingsViewModel.swift
@@ -218,7 +218,7 @@ private extension NotificationSettingsViewModel {
         
         for rule in newRules {
             guard
-                let ruleId = NotificationPushRuleId(rawValue: rule.ruleId),
+                let ruleId = rule.pushRuleId,
                 ruleIds.contains(ruleId)
             else {
                 continue
@@ -248,7 +248,7 @@ private extension NotificationSettingsViewModel {
     /// - Parameter rule: The push rule type to check.
     /// - Returns: Wether it should be displayed as checked or not checked.
     func defaultIsChecked(rule: NotificationPushRuleType) -> Bool {
-        guard let ruleId = NotificationPushRuleId(rawValue: rule.ruleId) else {
+        guard let ruleId = rule.pushRuleId else {
             return false
         }
         
@@ -264,7 +264,7 @@ private extension NotificationSettingsViewModel {
     }
     
     func isChecked(rule: NotificationPushRuleType, syncedRules: [NotificationPushRuleType]) -> Bool {
-        guard let ruleId = NotificationPushRuleId(rawValue: rule.ruleId) else {
+        guard let ruleId = rule.pushRuleId else {
             return false
         }
         
@@ -280,7 +280,7 @@ private extension NotificationSettingsViewModel {
     }
     
     func isOutOfSync(rule: NotificationPushRuleType, syncedRules: [NotificationPushRuleType]) -> Bool {
-        guard let ruleId = NotificationPushRuleId(rawValue: rule.ruleId) else {
+        guard let ruleId = rule.pushRuleId else {
             return false
         }
         
@@ -297,7 +297,7 @@ private extension NotificationSettingsViewModel {
 extension NotificationPushRuleId {
     func syncedRules(in rules: [NotificationPushRuleType]) -> [NotificationPushRuleType] {
         rules.filter {
-            guard let ruleId = NotificationPushRuleId(rawValue: $0.ruleId) else {
+            guard let ruleId = $0.pushRuleId else {
                 return false
             }
             return syncedRules.contains(ruleId)

--- a/RiotTests/PushRulesUpdaterTests.swift
+++ b/RiotTests/PushRulesUpdaterTests.swift
@@ -42,12 +42,13 @@ final class PushRulesUpdaterTests: XCTestCase {
         
         needsCheckPublisher.send(())
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertEqual(self.notificationService.rules[targetRuleIndex].ruleActions, NotificationStandardActions.notifyDefaultSound.actions)
             XCTAssertTrue(self.notificationService.rules[targetRuleIndex].enabled)
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 1.0)
+        
+        waitForExpectations(timeout: 2.0)
     }
     
     func testAffectedRulesAreUpdated() throws {
@@ -59,7 +60,7 @@ final class PushRulesUpdaterTests: XCTestCase {
         
         needsCheckPublisher.send(())
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             for rule in self.notificationService.rules {
                 guard let id = rule.pushRuleId else {
                     continue
@@ -74,7 +75,7 @@ final class PushRulesUpdaterTests: XCTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 2.0)
     }
     
     func testAffectedOneToOneRulesAreUpdated() throws {
@@ -86,7 +87,7 @@ final class PushRulesUpdaterTests: XCTestCase {
         
         needsCheckPublisher.send(())
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             for rule in self.notificationService.rules {
                 guard let id = rule.pushRuleId else {
                     continue
@@ -101,7 +102,7 @@ final class PushRulesUpdaterTests: XCTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 2.0)
     }
 }
 

--- a/RiotTests/PushRulesUpdaterTests.swift
+++ b/RiotTests/PushRulesUpdaterTests.swift
@@ -1,0 +1,34 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+import XCTest
+@testable import Element
+
+final class PushRulesUpdaterTests: XCTestCase {
+    private var notificationService: MockNotificationSettingsService!
+    private var pushRulesUpdater: PushRulesUpdater!
+    private var needsCheckPublisher: PassthroughSubject<Void, Never> = .init()
+
+    override func setUpWithError() throws {
+        notificationService = .init()
+        pushRulesUpdater = .init(notificationSettingsService: notificationService, needsCheck: needsCheckPublisher.eraseOutput())
+    }
+
+    func testExample() throws {
+        
+    }
+}

--- a/changelog.d/pr-7335.change
+++ b/changelog.d/pr-7335.change
@@ -1,0 +1,1 @@
+Polls: add automatic synchronization logic for poll push rules.


### PR DESCRIPTION
### Description

This PR adds logic to update poll push rules when don't match the ones of normal messages (see the table below).
The check is triggered the first time the matrix session is ready and when the app enters the foreground.

![table](https://user-images.githubusercontent.com/19324622/216375133-65d61157-9d75-458f-a79c-d9df74283ba1.png)

### Result

![poc](https://user-images.githubusercontent.com/19324622/216375497-e249680b-026d-453e-b407-1ee86971de2f.gif)