### PR TITLE
Add option to find own location in map views

### DIFF
--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerModels.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerModels.swift
@@ -44,6 +44,8 @@ struct LiveLocationSharingViewerViewState: BindableState {
 
     var showLoadingIndicator = false
     
+    var isSharingOwnLocation: Bool
+    
     var shareButtonEnabled: Bool {
         !showLoadingIndicator
     }

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
@@ -42,7 +42,7 @@ class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType
     // MARK: - Setup
     
     init(mapStyleURL: URL, service: LiveLocationSharingViewerServiceProtocol) {
-        let viewState = LiveLocationSharingViewerViewState(mapStyleURL: mapStyleURL, annotations: [], highlightedAnnotation: nil, listItemsViewData: [])
+        let viewState = LiveLocationSharingViewerViewState(mapStyleURL: mapStyleURL, annotations: [], highlightedAnnotation: nil, listItemsViewData: [], isSharingOwnLocation: false)
         
         liveLocationSharingViewerService = service
         mapViewErrorAlertInfoBuilder = MapViewErrorAlertInfoBuilder()
@@ -198,6 +198,7 @@ class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType
         state.annotations = annotations
         state.highlightedAnnotation = highlightedAnnotation
         state.listItemsViewData = listViewItems
+        state.isSharingOwnLocation = annotations.first { liveLocationSharingViewerService.isCurrentUserId($0.userId) } != nil
     }
     
     private func highlighAnnotation(with userId: String) {

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
@@ -27,6 +27,7 @@ struct LiveLocationSharingViewer: View {
     @Environment(\.openURL) var openURL
     
     @State private var isBottomSheetExpanded = false
+    @State private var showsUserLocation = false
     
     var bottomSheetCollapsedHeight: CGFloat = 150.0
     
@@ -41,7 +42,7 @@ struct LiveLocationSharingViewer: View {
                                        annotations: viewModel.viewState.annotations,
                                        highlightedAnnotation: viewModel.viewState.highlightedAnnotation,
                                        userAvatarData: nil,
-                                       showsUserLocation: false,
+                                       showsUserLocation: showsUserLocation,
                                        userAnnotationCanShowCallout: true,
                                        userLocation: Binding.constant(nil),
                                        mapCenterCoordinate: Binding.constant(nil),
@@ -103,6 +104,16 @@ struct LiveLocationSharingViewer: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button(VectorL10n.close) {
                     viewModel.send(viewAction: .done)
+                }
+            }
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                if !viewModel.viewState.isSharingOwnLocation {
+                    Button {
+                        showsUserLocation = true
+                    } label: {
+                        // TODO: Replace icon
+                        Image(uiImage: Asset.Images.locationPinIcon.image)
+                    }
                 }
             }
         }

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/View/StaticLocationView.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/View/StaticLocationView.swift
@@ -27,6 +27,8 @@ struct StaticLocationView: View {
     
     @ObservedObject var viewModel: StaticLocationViewingViewModel.Context
     
+    @State private var showsUserLocation = false
+    
     // MARK: Views
     
     var body: some View {
@@ -36,7 +38,7 @@ struct StaticLocationView: View {
                                        annotations: [viewModel.viewState.sharedAnnotation],
                                        highlightedAnnotation: viewModel.viewState.sharedAnnotation,
                                        userAvatarData: viewModel.viewState.userAvatarData,
-                                       showsUserLocation: false,
+                                       showsUserLocation: showsUserLocation,
                                        userLocation: Binding.constant(nil),
                                        mapCenterCoordinate: Binding.constant(nil),
                                        errorSubject: viewModel.viewState.errorSubject)
@@ -53,6 +55,14 @@ struct StaticLocationView: View {
                     Text(VectorL10n.locationSharingTitle)
                         .font(.headline)
                         .foregroundColor(theme.colors.primaryContent)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showsUserLocation = true
+                    } label: {
+                        // TODO: Replace icon
+                        Image(uiImage: Asset.Images.locationPinIcon.image)
+                    }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/changelog.d/pr-7337.change
+++ b/changelog.d/pr-7337.change
@@ -1,0 +1,1 @@
+Add option to find own location in map views


### PR DESCRIPTION
This exposes the default "find my location" button in the map view dialog for static and live locations. When the user is currently live-sharing their own location, the button is hidden.

### Todo

I couldn't find a suitable existing icon for this so I reused one of the map marker icons for demonstration purposes. We'll probably need to make a new one.

It also currently only centers the map on the user location when clicking for the first time.

### Screenshots

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-04 at 21 50 16](https://user-images.githubusercontent.com/1137962/216789145-c7897319-94f1-441e-847e-1d58f9286dc9.png)
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-04 at 21 53 57](https://user-images.githubusercontent.com/1137962/216789148-3818458e-67e0-4905-945d-440cbd218e53.png)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
