### PR TITLE
Fix some crashes

### DIFF
--- a/Riot/Categories/MXBugReportRestClient+Riot.swift
+++ b/Riot/Categories/MXBugReportRestClient+Riot.swift
@@ -46,10 +46,10 @@ extension MXBugReportRestClient {
         // User info (TODO: handle multi-account and find a way to expose them in rageshake API)
         var userInfo = [String: String]()
         let mainAccount = MXKAccountManager.shared().accounts.first
-        if let userId = mainAccount?.mxSession.myUser.userId {
+        if let userId = mainAccount?.mxSession?.myUser?.userId {
             userInfo["user_id"] = userId
         }
-        if let deviceId = mainAccount?.mxSession.matrixRestClient.credentials.deviceId {
+        if let deviceId = mainAccount?.mxSession?.myDeviceId {
             userInfo["device_id"] = deviceId
         }
         

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -196,7 +196,7 @@ class AllChatsViewController: HomeViewController {
         searchController.isActive = false
 
         guard let spaceId = spaceId else {
-            self.dataSource?.currentSpace = nil
+            dataSource?.currentSpace = nil
             updateUI()
 
             return
@@ -207,7 +207,7 @@ class AllChatsViewController: HomeViewController {
             return
         }
         
-        self.dataSource.currentSpace = space
+        dataSource?.currentSpace = space
         updateUI()
         
         self.recentsTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
@@ -288,7 +288,7 @@ class AllChatsViewController: HomeViewController {
     
     @objc private func showSpaceSelectorAction(sender: AnyObject) {
         Analytics.shared.viewRoomTrigger = .roomList
-        let currentSpaceId = self.dataSource.currentSpace?.spaceId ?? SpaceSelectorConstants.homeSpaceId
+        let currentSpaceId = dataSource?.currentSpace?.spaceId ?? SpaceSelectorConstants.homeSpaceId
         let spaceSelectorBridgePresenter = SpaceSelectorBottomSheetCoordinatorBridgePresenter(session: self.mainSession, selectedSpaceId: currentSpaceId, showHomeSpace: true)
         spaceSelectorBridgePresenter.present(from: self, animated: true)
         spaceSelectorBridgePresenter.delegate = self
@@ -310,7 +310,7 @@ class AllChatsViewController: HomeViewController {
             return super.tableView(tableView, numberOfRowsInSection: section)
         }
         
-        return dataSource.tableView(tableView, numberOfRowsInSection: section)
+        return dataSource?.tableView(tableView, numberOfRowsInSection: section) ?? 0
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -318,6 +318,10 @@ class AllChatsViewController: HomeViewController {
             return super.tableView(tableView, cellForRowAt: indexPath)
         }
         
+        guard let dataSource = dataSource else {
+            MXLog.failure("Missing data source")
+            return UITableViewCell()
+        }
         return dataSource.tableView(tableView, cellForRowAt: indexPath)
     }
     
@@ -328,7 +332,7 @@ class AllChatsViewController: HomeViewController {
             return super.tableView(tableView, heightForRowAt: indexPath)
         }
         
-        return dataSource.cellHeight(at: indexPath)
+        return dataSource?.cellHeight(at: indexPath) ?? 0
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -583,7 +587,7 @@ class AllChatsViewController: HomeViewController {
     }
     
     private func showSpaceInvite() {
-        guard let session = mainSession, let spaceRoom = dataSource.currentSpace?.room else {
+        guard let session = mainSession, let spaceRoom = dataSource?.currentSpace?.room else {
             return
         }
         
@@ -595,7 +599,7 @@ class AllChatsViewController: HomeViewController {
     }
     
     private func showSpaceMembers() {
-        guard let session = mainSession, let spaceId = dataSource.currentSpace?.spaceId else {
+        guard let session = mainSession, let spaceId = dataSource?.currentSpace?.spaceId else {
             return
         }
         
@@ -609,7 +613,7 @@ class AllChatsViewController: HomeViewController {
     }
 
     private func showSpaceSettings() {
-        guard let session = mainSession, let spaceId = dataSource.currentSpace?.spaceId else {
+        guard let session = mainSession, let spaceId = dataSource?.currentSpace?.spaceId else {
             return
         }
         
@@ -630,7 +634,7 @@ class AllChatsViewController: HomeViewController {
     }
     
     private func showLeaveSpace() {
-        guard let session = mainSession, let spaceSummary = dataSource.currentSpace?.summary else {
+        guard let session = mainSession, let spaceSummary = dataSource?.currentSpace?.summary else {
             return
         }
         
@@ -714,11 +718,11 @@ extension AllChatsViewController: SpaceSelectorBottomSheetCoordinatorBridgePrese
 extension AllChatsViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         guard let searchText = searchController.searchBar.text, !searchText.isEmpty else {
-            self.dataSource.search(withPatterns: nil)
+            self.dataSource?.search(withPatterns: nil)
             return
         }
         
-        self.dataSource.search(withPatterns: [searchText])
+        self.dataSource?.search(withPatterns: [searchText])
     }
 }
 
@@ -754,7 +758,7 @@ extension AllChatsViewController: AllChatsEditActionProviderDelegate {
         case .startChat:
             startChat()
         case .createSpace:
-            showCreateSpace(parentSpaceId: dataSource.currentSpace?.spaceId)
+            showCreateSpace(parentSpaceId: dataSource?.currentSpace?.spaceId)
         }
     }
     

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinator.swift
@@ -25,7 +25,6 @@ final class KeyVerificationSelfVerifyWaitCoordinator: KeyVerificationSelfVerifyW
     
     // MARK: Private
     
-    private let session: MXSession
     private var keyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWaitViewModelType
     private let keyVerificationSelfVerifyWaitViewController: KeyVerificationSelfVerifyWaitViewController
     private let cancellable: Bool
@@ -40,9 +39,7 @@ final class KeyVerificationSelfVerifyWaitCoordinator: KeyVerificationSelfVerifyW
     // MARK: - Setup
     
     init(session: MXSession, isNewSignIn: Bool, cancellable: Bool) {
-        self.session = session
-        
-        let keyVerificationSelfVerifyWaitViewModel = KeyVerificationSelfVerifyWaitViewModel(session: self.session, isNewSignIn: isNewSignIn)
+        let keyVerificationSelfVerifyWaitViewModel = KeyVerificationSelfVerifyWaitViewModel(session: session, isNewSignIn: isNewSignIn)
         let keyVerificationSelfVerifyWaitViewController = KeyVerificationSelfVerifyWaitViewController.instantiate(with: keyVerificationSelfVerifyWaitViewModel, cancellable: cancellable)
         self.keyVerificationSelfVerifyWaitViewModel = keyVerificationSelfVerifyWaitViewModel
         self.keyVerificationSelfVerifyWaitViewController = keyVerificationSelfVerifyWaitViewController

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -2150,7 +2150,10 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
                 }
                 else
                 {
-                    failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendGeneric userInfo:nil]);
+                    if (failure)
+                    {
+                        failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendGeneric userInfo:nil]);
+                    }
                     MXLogWarning(@"[MXKRoomDataSource][%p] resendEventWithEventId: Warning - Unable to resend room message of type: %@", self, msgType);
                 }
             }
@@ -2177,7 +2180,10 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
             NSURL *localFileURL = [NSURL URLWithString:localFilePath];
             
             if (![NSFileManager.defaultManager fileExistsAtPath:localFilePath]) {
-                failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendInvalidLocalFilePath userInfo:nil]);
+                if (failure)
+                {
+                    failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendInvalidLocalFilePath userInfo:nil]);
+                }
                 MXLogWarning(@"[MXKRoomDataSource][%p] resendEventWithEventId: Warning - Unable to resend voice message, invalid file path.", self);
                 return;
             }
@@ -2247,7 +2253,10 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
                 }
                 else
                 {
-                    failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendGeneric userInfo:nil]);
+                    if (failure)
+                    {
+                        failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendGeneric userInfo:nil]);
+                    }
                     MXLogWarning(@"[MXKRoomDataSource][%p] resendEventWithEventId: Warning - Unable to resend room message of type: %@", self, msgType);
                 }
             }
@@ -2259,13 +2268,19 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
         }
         else
         {
-            failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendInvalidMessageType userInfo:nil]);
+            if (failure)
+            {
+                failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendInvalidMessageType userInfo:nil]);
+            }
             MXLogWarning(@"[MXKRoomDataSource][%p] resendEventWithEventId: Warning - Unable to resend room message of type: %@", self, msgType);
         }
     }
     else
     {
-        failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendInvalidMessageType userInfo:nil]);
+        if (failure)
+        {
+            failure([NSError errorWithDomain:MXKRoomDataSourceErrorDomain code:MXKRoomDataSourceErrorResendInvalidMessageType userInfo:nil]);
+        }
         MXLogWarning(@"[MXKRoomDataSource][%p] MXKRoomDataSource: Warning - Only resend of MXEventTypeRoomMessage is allowed. Event.type: %@", self, event.type);
     }
 }

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/Service/MatrixSDK/MXRoomNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/Service/MatrixSDK/MXRoomNotificationSettingsService.swift
@@ -30,6 +30,10 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
     
     private var observers: [ObjectIdentifier] = []
     
+    private var notificationCenter: MXNotificationCenter? {
+        room.mxSession?.notificationCenter
+    }
+    
     // MARK: Public
     
     var notificationState: RoomNotificationState {
@@ -166,7 +170,7 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
         }
         handleFailureCallback(completion)
         
-        room.mxSession.notificationCenter.addRoomRule(
+        notificationCenter?.addRoomRule(
             room.roomId,
             notify: false,
             sound: false,
@@ -184,7 +188,7 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
         }
         handleFailureCallback(completion)
         
-        room.mxSession.notificationCenter.addOverrideRule(
+        notificationCenter?.addOverrideRule(
             withId: roomId,
             conditions: [["kind": "event_match", "key": "room_id", "pattern": roomId]],
             notify: false,
@@ -196,11 +200,11 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
     private func removePushRule(rule: MXPushRule, completion: @escaping Completion) {
         handleUpdateCallback(completion) { [weak self] in
             guard let self = self else { return true }
-            return self.room.mxSession.notificationCenter.rule(byId: rule.ruleId) == nil
+            return self.notificationCenter?.rule(byId: rule.ruleId) == nil
         }
         handleFailureCallback(completion)
         
-        room.mxSession.notificationCenter.removeRule(rule)
+        notificationCenter?.removeRule(rule)
     }
     
     private func enablePushRule(rule: MXPushRule, completion: @escaping Completion) {
@@ -210,7 +214,7 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
         }
         handleFailureCallback(completion)
         
-        room.mxSession.notificationCenter.enableRule(rule, isEnabled: true)
+        notificationCenter?.enableRule(rule, isEnabled: true)
     }
     
     private func handleUpdateCallback(_ completion: @escaping Completion, releaseCheck: @escaping () -> Bool) {
@@ -283,14 +287,14 @@ private extension MXRoom {
     }
     
     var overridePushRule: MXPushRule? {
-        guard let overrideRules = mxSession.notificationCenter.rules.global.override else {
+        guard let overrideRules = mxSession?.notificationCenter?.rules?.global?.override else {
             return nil
         }
         return getRoomRule(from: overrideRules)
     }
     
     var roomPushRule: MXPushRule? {
-        guard let roomRules = mxSession.notificationCenter.rules.global.room else {
+        guard let roomRules = mxSession?.notificationCenter?.rules?.global?.room else {
             return nil
         }
         return getRoomRule(from: roomRules)


### PR DESCRIPTION
Resolves https://github.com/matrix-org/element-ios-rageshakes/issues/23067

Fix a bunch of unrelated crashes as reported by Sentry and Xcode. Most of them are caused by accessing obj-c properties from Swift when exposed as implicitely unwrapped optional, which is one of the greatest evils of the objc-Swift interoperability, far more unstable than just using pure objective-c.