### PR TITLE
"Mark as unread" dot appears on rooms that are actually unread, not marked as such

### DIFF
--- a/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
+++ b/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
@@ -92,12 +92,17 @@
         self.lastEventDecriptionLabelTrailingConstraint.constant = self.unsentImageView.hidden ? 10 : 30;
 
         // Notify unreads and bing
-        if (roomCellData.hasUnread)
+        if (roomCellData.isRoomMarkedAsUnread)
         {
-
+            self.missedNotifAndUnreadBadgeBgView.hidden = NO;
+            self.missedNotifAndUnreadBadgeBgView.backgroundColor = ThemeService.shared.theme.tintColor;
+            self.missedNotifAndUnreadBadgeBgViewWidthConstraint.constant = 20;
+        }
+        else if (roomCellData.hasUnread)
+        {
+            self.missedNotifAndUnreadIndicator.hidden = NO;
             if (0 < roomCellData.notificationCount)
             {
-                self.missedNotifAndUnreadIndicator.hidden = NO;
                 self.missedNotifAndUnreadIndicator.backgroundColor = roomCellData.highlightCount ? ThemeService.shared.theme.noticeColor : ThemeService.shared.theme.noticeSecondaryColor;
 
                 self.missedNotifAndUnreadBadgeBgView.hidden = NO;
@@ -110,9 +115,7 @@
             }
             else
             {
-                self.missedNotifAndUnreadBadgeBgView.hidden = NO;
-                self.missedNotifAndUnreadBadgeBgView.backgroundColor = ThemeService.shared.theme.tintColor;
-                self.missedNotifAndUnreadBadgeBgViewWidthConstraint.constant = 20;
+                self.missedNotifAndUnreadIndicator.backgroundColor = ThemeService.shared.theme.unreadRoomIndentColor;
             }
 
             // Use bold font for the room title

--- a/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -63,8 +63,12 @@
 
 - (BOOL)hasUnread
 {
-    bool isRoomUnread = [[self mxSession] isRoomMarkedAsUnread:roomSummary.roomId];
-    return (roomSummary.localUnreadEventCount != 0 || isRoomUnread);
+    return (roomSummary.localUnreadEventCount != 0);
+}
+
+- (BOOL)isRoomMarkedAsUnread
+{
+    return [[self mxSession] isRoomMarkedAsUnread:roomSummary.roomId];;
 }
 
 - (NSString *)roomIdentifier

--- a/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellDataStoring.h
+++ b/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellDataStoring.h
@@ -50,6 +50,7 @@
 @property (nonatomic, readonly) NSString *lastEventDate;
 
 @property (nonatomic, readonly) BOOL hasUnread;
+@property (nonatomic, readonly) BOOL isRoomMarkedAsUnread;
 @property (nonatomic, readonly) NSUInteger notificationCount;
 @property (nonatomic, readonly) NSUInteger highlightCount;
 @property (nonatomic, readonly) NSString *notificationCountStringValue;

--- a/changelog.d/7530.bugfix
+++ b/changelog.d/7530.bugfix
@@ -1,0 +1,1 @@
+The green dot for unread rooms was also showing for silent rooms

--- a/changelog.d/7530.bugfix
+++ b/changelog.d/7530.bugfix
@@ -1,1 +1,1 @@
-The green dot for unread rooms was also showing for silent rooms
+Fixes #7350 - Fix green dot only to appear for marked action


### PR DESCRIPTION
fix green dot appearing also for silent rooms
![test](https://user-images.githubusercontent.com/20090282/217569412-091f3416-571a-42ad-82a6-21f82bc0838b.gif)
