### PR TITLE
Fallback for poll ended event (PSG-1156)

### DIFF
--- a/Riot/Modules/MatrixKit/Models/MXKAppSettings.m
+++ b/Riot/Modules/MatrixKit/Models/MXKAppSettings.m
@@ -199,7 +199,9 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
             kMXEventTypeStringCallHangup,
             kMXEventTypeStringSticker,
             kMXEventTypeStringPollStart,
-            kMXEventTypeStringPollStartMSC3381
+            kMXEventTypeStringPollStartMSC3381,
+            kMXEventTypeStringPollEnd,
+            kMXEventTypeStringPollEndMSC3381
         ].mutableCopy;
         
         _messageDetailsAllowSharing = YES;

--- a/Riot/Modules/MatrixKit/Models/Room/MXKSendReplyEventStringLocalizer.swift
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKSendReplyEventStringLocalizer.swift
@@ -49,7 +49,7 @@ class MXKSendReplyEventStringLocalizer: NSObject, MXSendReplyEventStringLocalize
         VectorL10n.messageReplyToMessageToReplyToPrefix
     }
     
-    func replyToEndedPoll() -> String {
+    func endedPollMessage() -> String {
         VectorL10n.pollTimelineReplyEndedPoll
     }
 }

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1900,7 +1900,7 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
                 repliedEventContent = [MXEventContentPollStart modelFromJSON:repliedEvent.content].question;
             }
             if (!repliedEventContent && repliedEvent.eventType == MXEventTypePollEnd) {
-                repliedEventContent = MXSendReplyEventDefaultStringLocalizer.new.replyToEndedPoll;
+                repliedEventContent = MXSendReplyEventDefaultStringLocalizer.new.endedPollMessage;
             }
         }
 

--- a/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/Poll/PollBaseBubbleCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/Poll/PollBaseBubbleCell.swift
@@ -50,7 +50,7 @@ class PollBaseBubbleCell: PollPlainCell {
             return
         }
         
-        self.addBubbleBackgroundView( messageBubbleBackgroundView, to: pollView)
+        self.addBubbleBackgroundView(messageBubbleBackgroundView, to: pollView)
         messageBubbleBackgroundView.backgroundColor = self.bubbleBackgroundColor
     }
     

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollProvider.swift
@@ -15,6 +15,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 @objcMembers
 class TimelinePollProvider: NSObject {
@@ -45,7 +46,7 @@ class TimelinePollProvider: NSObject {
         
         let parameters = TimelinePollCoordinatorParameters(session: session, room: room, pollEvent: event)
         guard let coordinator = try? TimelinePollCoordinator(parameters: parameters) else {
-            return nil
+            return messageViewController(for: event)
         }
         
         coordinatorsForEventIdentifiers[event.eventId] = coordinator
@@ -60,5 +61,16 @@ class TimelinePollProvider: NSObject {
     
     func reset() {
         coordinatorsForEventIdentifiers.removeAll()
+    }
+}
+
+private extension TimelinePollProvider {
+    func messageViewController(for event: MXEvent) -> UIViewController? {
+        switch event.eventType {
+        case .pollEnd:
+            return VectorHostingController(rootView: TimelinePollMessageView(message: VectorL10n.pollTimelineReplyEndedPoll))
+        default:
+            return nil
+        }
     }
 }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollMessageView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollMessageView.swift
@@ -1,0 +1,45 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+/// A view for showing polls' related messages whenever there aren't enough information to show a full poll in the timeline.
+struct TimelinePollMessageView: View {
+    @Environment(\.theme) private var theme
+    private let imageSize: CGFloat = 16
+    
+    let message: String
+    
+    var body: some View {
+        HStack {
+            Image(uiImage: Asset.Images.pollHistory.image)
+                .resizable()
+                .frame(width: imageSize, height: imageSize)
+            
+            Text(message)
+                .font(.system(size: 15))
+                .foregroundColor(theme.colors.primaryContent)
+        }
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct TimelinePollMessageView_Previews: PreviewProvider {
+    static var previews: some View {
+        TimelinePollMessageView(message: VectorL10n.pollTimelineReplyEndedPoll)
+    }
+}

--- a/changelog.d/pr-7353.change
+++ b/changelog.d/pr-7353.change
@@ -1,0 +1,1 @@
+Polls: add fallback text for poll ended events.


### PR DESCRIPTION
### Description

This PR:
- Adds a fallback text for m.poll.end events. These fallbacks are useful for receivers when the associated m.poll.start event is unavailable. (see screenshots below)
- Fixes a bug that prevented to see the last "poll ended" event in the room list

### Dependency
https://github.com/matrix-org/matrix-ios-sdk/pull/1713

### Result
| Plain | Bubble |
|---|---|
|![normal](https://user-images.githubusercontent.com/19324622/217592574-b5e183e3-7a45-437d-b3da-8c065f349009.png)| ![bubble](https://user-images.githubusercontent.com/19324622/217592817-8322a1b8-4274-442e-9785-8cf76505921b.png)
|