### PR TITLE
Fix some voice message issues (#7325, #7217)

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioPlayer.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioPlayer.swift
@@ -53,7 +53,7 @@ class VoiceMessageAudioPlayer: NSObject {
             return false
         }
         
-        return (audioPlayer.rate > 0)
+        return audioPlayer.currentItem != nil && (audioPlayer.rate > 0)
     }
     
     var duration: TimeInterval {
@@ -118,6 +118,13 @@ class VoiceMessageAudioPlayer: NSObject {
         }
     }
     
+    func reloadContentIfNeeded() {
+        if let url, let audioPlayer, audioPlayer.currentItem == nil {
+            self.url = nil
+            loadContentFromURL(url)
+        }
+    }
+    
     func removeAllPlayerItems() {
         audioPlayer?.removeAllItems()
     }
@@ -129,6 +136,8 @@ class VoiceMessageAudioPlayer: NSObject {
     
     func play() {
         isStopped = false
+        
+        reloadContentIfNeeded()
         
         do {
             try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioRecorder.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioRecorder.swift
@@ -73,15 +73,18 @@ class VoiceMessageAudioRecorder: NSObject, AVAudioRecorderDelegate {
         }
     }
 
-    func stopRecording() {
+    func stopRecording(releaseAudioSession: Bool = true) {
         audioRecorder?.stop()
-        do {
-            try AVAudioSession.sharedInstance().setActive(false)
-        } catch {
-            delegateContainer.notifyDelegatesWithBlock { delegate in
-                (delegate as? VoiceMessageAudioRecorderDelegate)?.audioRecorder(self, didFailWithError: VoiceMessageAudioRecorderError.genericError) }
+        
+        if releaseAudioSession {
+            MXLog.debug("[VoiceMessageAudioRecorder] stopRecording() - releasing audio session")
+            do {
+                try AVAudioSession.sharedInstance().setActive(false)
+            } catch {
+                delegateContainer.notifyDelegatesWithBlock { delegate in
+                    (delegate as? VoiceMessageAudioRecorderDelegate)?.audioRecorder(self, didFailWithError: VoiceMessageAudioRecorderError.genericError) }
+            }
         }
-
     }
     
     func peakPowerForChannelNumber(_ channelNumber: Int) -> Float {

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
@@ -191,7 +191,9 @@ import MediaPlayer
                 continue
             }
             
-            audioRecorder.stopRecording()
+            // We should release the audio session only if we want to pause all services
+            let shouldReleaseAudioSession = (service == nil)
+            audioRecorder.stopRecording(releaseAudioSession: shouldReleaseAudioSession)
         }
         
         guard let audioPlayersEnumerator = audioPlayers.objectEnumerator() else {

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessagePlaybackController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessagePlaybackController.swift
@@ -144,6 +144,8 @@ class VoiceMessagePlaybackController: VoiceMessageAudioPlayerDelegate, VoiceMess
         audioPlayer.seekToTime(0.0) { [weak self] _ in
             guard let self = self else { return }
             self.state = .stopped
+            // Reload its content if necessary, otherwise the seek won't work
+            self.audioPlayer?.reloadContentIfNeeded()
         }
     }
     

--- a/changelog.d/7217.bugfix
+++ b/changelog.d/7217.bugfix
@@ -1,0 +1,1 @@
+A voice message is now replayable.

--- a/changelog.d/7325.bugfix
+++ b/changelog.d/7325.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where a voice message recording was failing.


### PR DESCRIPTION
Fix #7325: prevent setting the audio session to inactive during recording
Fix #7217: ensure that an audio player has its content loaded when it reaches the end to allow seek and replay.
