### PR TITLE
Do not reset device keys if migrating to CryptoSDK

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
+++ b/Riot/Modules/MatrixKit/Models/Account/MXKAccount.m
@@ -947,9 +947,10 @@ static NSArray<NSNumber*> *initialSyncSilentErrorsHTTPStatusCodes;
 
         if (clearStore)
         {
-            // Force a reload of device keys at the next session start.
+            // Force a reload of device keys at the next session start, unless we are just about to migrate
+            // all data and device keys into CryptoSDK.
             // This will fix potential UISIs other peoples receive for our messages.
-            if ([mxSession.crypto isKindOfClass:[MXLegacyCrypto class]])
+            if ([mxSession.crypto isKindOfClass:[MXLegacyCrypto class]] && !MXSDKOptions.sharedInstance.enableCryptoSDK)
             {
                 [(MXLegacyCrypto *)mxSession.crypto resetDeviceKeys];
             }

--- a/changelog.d/pr-7369.change
+++ b/changelog.d/pr-7369.change
@@ -1,0 +1,1 @@
+Do not reset device keys if migrating to CryptoSDK


### PR DESCRIPTION
Legacy crypto does some kind of patchwork and resets device keys on session reload. In practice this means that we reset all tracked users, and when migrating to CryptoSDK we do not have any of the tracked users information.

To solve this we simply avoid resetting device keys when the `cryptoSDK` feature flag has just been enabled (note that the next time we are resetting session, crypto will no longer be the `MXLegacyCrypto` type)