### PR TITLE
Show own location in map views

### DIFF
--- a/Riot/Modules/LocationSharing/LocationManager.swift
+++ b/Riot/Modules/LocationSharing/LocationManager.swift
@@ -226,3 +226,19 @@ extension LocationManager: CLLocationManagerDelegate {
         MXLog.error("[LocationManager] Did failed", context: error)
     }
 }
+
+extension CLLocationManager {
+    func isAuthorizedOrRequest() -> Bool {
+        switch authorizationStatus {
+        case .notDetermined:
+            requestWhenInUseAuthorization()
+            return false
+        case .restricted, .denied:
+            return false
+        case .authorizedAlways, .authorizedWhenInUse, .authorized:
+            return true
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/Riot/Modules/LocationSharing/LocationManager.swift
+++ b/Riot/Modules/LocationSharing/LocationManager.swift
@@ -228,7 +228,7 @@ extension LocationManager: CLLocationManagerDelegate {
 }
 
 extension CLLocationManager {
-    func isAuthorizedOrRequest() -> Bool {
+    func requestAuthorizationIfNeeded() -> Bool {
         switch authorizationStatus {
         case .notDetermined:
             requestWhenInUseAuthorization()

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerModels.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerModels.swift
@@ -42,6 +42,12 @@ struct LiveLocationSharingViewerViewState: BindableState {
     /// Live location list items
     var listItemsViewData: [LiveLocationListItemViewData]
 
+    var showsUserLocation = false
+    
+    var isCurrentUserShared: Bool {
+        listItemsViewData.contains { $0.isCurrentUser }
+    }
+    
     var showLoadingIndicator = false
     
     var shareButtonEnabled: Bool {
@@ -75,4 +81,5 @@ enum LiveLocationSharingViewerViewAction {
     case tapListItem(_ userId: String)
     case share(_ annotation: UserLocationAnnotation)
     case mapCreditsDidTap
+    case showUserLocation
 }

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
@@ -72,6 +72,8 @@ class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType
             completion?(.share(userLocationAnnotation.coordinate))
         case .mapCreditsDidTap:
             state.bindings.showMapCreditsSheet.toggle()
+        case .showUserLocation:
+            state.showsUserLocation.toggle()
         }
     }
     

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
@@ -15,6 +15,7 @@
 //
 
 import Combine
+import CoreLocation
 import Mapbox
 import SwiftUI
 
@@ -73,7 +74,7 @@ class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType
         case .mapCreditsDidTap:
             state.bindings.showMapCreditsSheet.toggle()
         case .showUserLocation:
-            state.showsUserLocation.toggle()
+            showsCurrentUserLocation()
         }
     }
     
@@ -229,6 +230,16 @@ class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType
                                                           message: VectorL10n.locationSharingLiveStopSharingError,
                                                           primaryButton: (VectorL10n.ok, nil))
             }
+        }
+    }
+    
+    private let locationManager = CLLocationManager()
+    
+    private func showsCurrentUserLocation() {
+        if locationManager.isAuthorizedOrRequest() {
+            state.showsUserLocation = true
+        } else {
+            state.errorSubject.send(.invalidLocationAuthorization)
         }
     }
 }

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/LiveLocationSharingViewerViewModel.swift
@@ -15,7 +15,6 @@
 //
 
 import Combine
-import CoreLocation
 import Mapbox
 import SwiftUI
 
@@ -233,10 +232,8 @@ class LiveLocationSharingViewerViewModel: LiveLocationSharingViewerViewModelType
         }
     }
     
-    private let locationManager = CLLocationManager()
-    
     private func showsCurrentUserLocation() {
-        if locationManager.isAuthorizedOrRequest() {
+        if liveLocationSharingViewerService.requestAuthorizationIfNeeded() {
             state.showsUserLocation = true
         } else {
             state.errorSubject.send(.invalidLocationAuthorization)

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/LiveLocationSharingViewerServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/LiveLocationSharingViewerServiceProtocol.swift
@@ -33,4 +33,6 @@ protocol LiveLocationSharingViewerServiceProtocol {
     
     /// Stop current user location sharing
     func stopUserLiveLocationSharing(completion: @escaping (Result<Void, Error>) -> Void)
+    
+    func requestAuthorizationIfNeeded() -> Bool
 }

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/MatrixSDK/LiveLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/MatrixSDK/LiveLocationSharingViewerService.swift
@@ -19,11 +19,13 @@ import Foundation
 import MatrixSDK
 
 class LiveLocationSharingViewerService: LiveLocationSharingViewerServiceProtocol {
+    
     // MARK: - Properties
     
     private(set) var usersLiveLocation: [UserLiveLocation] = []
     private let roomId: String
     private var beaconInfoSummaryListener: Any?
+    private let locationManager = CLLocationManager()
     
     // MARK: Private
     
@@ -72,6 +74,10 @@ class LiveLocationSharingViewerService: LiveLocationSharingViewerServiceProtocol
                 completion(.failure(error))
             }
         }
+    }
+    
+    func requestAuthorizationIfNeeded() -> Bool {
+        locationManager.requestAuthorizationIfNeeded()
     }
     
     // MARK: - Private

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/Mock/MockLiveLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/Mock/MockLiveLocationSharingViewerService.swift
@@ -61,6 +61,10 @@ class MockLiveLocationSharingViewerService: LiveLocationSharingViewerServiceProt
     
     func stopUserLiveLocationSharing(completion: @escaping (Result<Void, Error>) -> Void) { }
     
+    func requestAuthorizationIfNeeded() -> Bool {
+        return true
+    }
+    
     // MARK: Private
     
     private func createFirstUserLiveLocation() -> UserLiveLocation {

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/Mock/MockLiveLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Service/Mock/MockLiveLocationSharingViewerService.swift
@@ -27,12 +27,17 @@ class MockLiveLocationSharingViewerService: LiveLocationSharingViewerServiceProt
     
     // MARK: Setup
     
-    init(generateRandomUsers: Bool = false) {
-        let firstUserLiveLocation = createFirstUserLiveLocation()
+    init(generateRandomUsers: Bool = false, currentUserSharingLocation: Bool = true) {
+        let firstUserLiveLocation: UserLiveLocation?
+        if currentUserSharingLocation {
+            firstUserLiveLocation = createFirstUserLiveLocation()
+        } else {
+            firstUserLiveLocation = nil
+        }
         
         let secondUserLiveLocation = createSecondUserLiveLocation()
         
-        var usersLiveLocation: [UserLiveLocation] = [firstUserLiveLocation, secondUserLiveLocation]
+        var usersLiveLocation: [UserLiveLocation] = [firstUserLiveLocation, secondUserLiveLocation].compactMap { $0 }
         
         if generateRandomUsers {
             for _ in 1...20 {

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Test/Unit/LiveLocationSharingViewerViewModelTests.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/Test/Unit/LiveLocationSharingViewerViewModelTests.swift
@@ -15,6 +15,7 @@
 //
 
 import Combine
+import CoreLocation
 import XCTest
 
 @testable import RiotSwiftUI
@@ -29,5 +30,18 @@ class LiveLocationSharingViewerViewModelTests: XCTestCase {
         service = MockLiveLocationSharingViewerService()
         viewModel = LiveLocationSharingViewerViewModel(mapStyleURL: BuildSettings.defaultTileServerMapStyleURL, service: service)
         context = viewModel.context
+    }
+    
+    func testIsUserBeingShared() {
+        XCTAssertTrue(context.viewState.isCurrentUserShared)
+    }
+    
+    func testToggleShowUserLocation() {
+        let service = MockLiveLocationSharingViewerService(currentUserSharingLocation: false)
+        let viewModel = LiveLocationSharingViewerViewModel(mapStyleURL: BuildSettings.defaultTileServerMapStyleURL, service: service)
+        XCTAssertFalse(viewModel.context.viewState.isCurrentUserShared)
+        XCTAssertFalse(viewModel.context.viewState.showsUserLocation)
+        viewModel.context.send(viewAction: .showUserLocation)
+        XCTAssertTrue(viewModel.context.viewState.showsUserLocation)
     }
 }

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
@@ -54,21 +54,14 @@ struct LiveLocationSharingViewer: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             if !viewModel.viewState.showMapLoadingError {
-                ZStack(alignment: .topTrailing) {
+                    
+                if !viewModel.viewState.isCurrentUserShared {
                     mapView
-                    if !viewModel.viewState.isCurrentUserShared {
-                        Button {
+                        .overlay(CenterToUserLocationButton(action: {
                             viewModel.send(viewAction: .showUserLocation)
-                        } label: {
-                            Image(uiImage: Asset.Images.locationCenterMapIcon.image)
-                                .foregroundColor(theme.colors.accent)
-                        }
-                        .padding(8.0)
-                        .background(theme.colors.background)
-                        .clipShape(Circle())
-                        .shadow(radius: 2.0)
-                        .offset(x: -11.0, y: 52)
-                    }
+                        }).offset(x: -11.0, y: 52), alignment: .topTrailing)
+                } else {
+                    mapView
                 }
                 
                 // Show map credits above collapsed bottom sheet height if bottom sheet is visible
@@ -195,5 +188,29 @@ struct LiveLocationSharingViewer_Previews: PreviewProvider {
             stateRenderer.screenGroup().theme(.light).preferredColorScheme(.light)
             stateRenderer.screenGroup().theme(.dark).preferredColorScheme(.dark)
         }
+    }
+}
+
+struct CenterToUserLocationButton: View {
+    
+    // MARK: Private
+    
+    @Environment(\.theme) private var theme: ThemeSwiftUI
+    
+    // MARK: Public
+    
+    var action: () -> Void
+    
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            Image(uiImage: Asset.Images.locationCenterMapIcon.image)
+                .foregroundColor(theme.colors.accent)
+        }
+        .padding(8.0)
+        .background(theme.colors.background)
+        .clipShape(Circle())
+        .shadow(radius: 2.0)
     }
 }

--- a/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/LiveLocationSharingViewer/View/LiveLocationSharingViewer.swift
@@ -34,23 +34,42 @@ struct LiveLocationSharingViewer: View {
     
     @ObservedObject var viewModel: LiveLocationSharingViewerViewModel.Context
     
+    var mapView: LocationSharingMapView {
+        LocationSharingMapView(tileServerMapURL: viewModel.viewState.mapStyleURL,
+                               annotations: viewModel.viewState.annotations,
+                               highlightedAnnotation: viewModel.viewState.highlightedAnnotation,
+                               userAvatarData: nil,
+                               showsUserLocation: viewModel.viewState.showsUserLocation,
+                               userAnnotationCanShowCallout: true,
+                               userLocation: Binding.constant(nil),
+                               mapCenterCoordinate: Binding.constant(nil),
+                               onCalloutTap: { annotation in
+                                   if let userLocationAnnotation = annotation as? UserLocationAnnotation {
+                                       viewModel.send(viewAction: .share(userLocationAnnotation))
+                                   }
+                               },
+                               errorSubject: viewModel.viewState.errorSubject)
+    }
+    
     var body: some View {
         ZStack(alignment: .bottom) {
             if !viewModel.viewState.showMapLoadingError {
-                LocationSharingMapView(tileServerMapURL: viewModel.viewState.mapStyleURL,
-                                       annotations: viewModel.viewState.annotations,
-                                       highlightedAnnotation: viewModel.viewState.highlightedAnnotation,
-                                       userAvatarData: nil,
-                                       showsUserLocation: false,
-                                       userAnnotationCanShowCallout: true,
-                                       userLocation: Binding.constant(nil),
-                                       mapCenterCoordinate: Binding.constant(nil),
-                                       onCalloutTap: { annotation in
-                                           if let userLocationAnnotation = annotation as? UserLocationAnnotation {
-                                               viewModel.send(viewAction: .share(userLocationAnnotation))
-                                           }
-                                       },
-                                       errorSubject: viewModel.viewState.errorSubject)
+                ZStack(alignment: .topTrailing) {
+                    mapView
+                    if !viewModel.viewState.isCurrentUserShared {
+                        Button {
+                            viewModel.send(viewAction: .showUserLocation)
+                        } label: {
+                            Image(uiImage: Asset.Images.locationCenterMapIcon.image)
+                                .foregroundColor(theme.colors.accent)
+                        }
+                        .padding(8.0)
+                        .background(theme.colors.background)
+                        .clipShape(Circle())
+                        .shadow(radius: 2.0)
+                        .offset(x: -11.0, y: 52)
+                    }
+                }
                 
                 // Show map credits above collapsed bottom sheet height if bottom sheet is visible
                 if viewModel.viewState.isBottomSheetVisible {

--- a/RiotSwiftUI/Modules/LocationSharing/MapError/MapViewErrorAlertInfoBuilder.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/MapError/MapViewErrorAlertInfoBuilder.swift
@@ -32,7 +32,7 @@ struct MapViewErrorAlertInfoBuilder {
         case .invalidLocationAuthorization:
             alertInfo = AlertInfo(id: .authorizationError,
                                   title: VectorL10n.locationSharingInvalidAuthorizationErrorTitle(AppInfo.current.displayName),
-                                  primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, primaryButtonCompletion),
+                                  primaryButton: (VectorL10n.locationSharingInvalidAuthorizationNotNow, {}),
                                   secondaryButton: (VectorL10n.locationSharingInvalidAuthorizationSettings, primaryButtonCompletion))
         default:
             alertInfo = nil

--- a/RiotSwiftUI/Modules/LocationSharing/MapView/View/LocationSharingMapView.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/MapView/View/LocationSharingMapView.swift
@@ -125,11 +125,14 @@ extension LocationSharingMapView {
                 return LocationAnnotationView(userLocationAnnotation: userLocationAnnotation)
             } else if let pinLocationAnnotation = annotation as? PinLocationAnnotation {
                 return LocationAnnotationView(pinLocationAnnotation: pinLocationAnnotation)
-            } else if annotation is MGLUserLocation, let currentUserAvatarData = locationSharingMapView.userAvatarData {
-                // Replace default current location annotation view with a UserLocationAnnotatonView when the map is center on user location
-                return LocationAnnotationView(avatarData: currentUserAvatarData)
+            } else if annotation is MGLUserLocation {
+                if let currentUserAvatarData = locationSharingMapView.userAvatarData {
+                    // Replace default current location annotation view with a UserLocationAnnotatonView when the map is center on user location
+                    return LocationAnnotationView(avatarData: currentUserAvatarData)
+                } else {
+                    return LocationAnnotationView(userPinLocationAnnotation: annotation)
+                }
             }
-
             return nil
         }
         

--- a/RiotSwiftUI/Modules/LocationSharing/MapView/View/LocationSharingMapView.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/MapView/View/LocationSharingMapView.swift
@@ -75,7 +75,7 @@ struct LocationSharingMapView: UIViewRepresentable {
         mapView.vc_removeAllAnnotations()
         mapView.addAnnotations(annotations)
         
-        if let highlightedAnnotation = highlightedAnnotation {
+        if let highlightedAnnotation = highlightedAnnotation, !showsUserLocation {
             mapView.setCenter(highlightedAnnotation.coordinate, zoomLevel: Constants.mapZoomLevel, animated: false)
         }
         

--- a/RiotSwiftUI/Modules/LocationSharing/MapView/View/UserLocationAnnotationView.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/MapView/View/UserLocationAnnotationView.swift
@@ -48,7 +48,11 @@ class LocationAnnotationView: MGLUserLocationAnnotationView {
         
         addUserMarkerView(with: userLocationAnnotation.avatarData)
     }
-    
+    convenience init(userPinLocationAnnotation: MGLAnnotation) {
+        self.init(annotation: userPinLocationAnnotation, reuseIdentifier: "userPinLocation")
+        
+        addPinView()
+    }
     convenience init(pinLocationAnnotation: PinLocationAnnotation) {
         // TODO: Use a reuseIdentifier
         self.init(annotation: pinLocationAnnotation, reuseIdentifier: nil)
@@ -72,6 +76,16 @@ class LocationAnnotationView: MGLUserLocationAnnotationView {
         }
         
         addMarkerView(avatarMarkerView)
+    }
+    
+    private func addPinView() {
+        guard let pinView = UIHostingController(rootView: Image(uiImage: Asset.Images.locationMarkerIcon.image)
+            .resizable()
+            .foregroundColor(theme.colors.accent)).view else {
+            return
+        }
+        
+        addMarkerView(pinView)
     }
     
     private func addPinMarkerView() {

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Coordinator/StaticLocationViewingCoordinator.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Coordinator/StaticLocationViewingCoordinator.swift
@@ -53,7 +53,8 @@ final class StaticLocationViewingCoordinator: Coordinator, Presentable {
             mapStyleURL: parameters.session.vc_homeserverConfiguration().tileServer.mapStyleURL,
             avatarData: parameters.avatarData,
             location: parameters.location,
-            coordinateType: parameters.coordinateType
+            coordinateType: parameters.coordinateType,
+            service: StaticLocationSharingViewerService()
         )
         let view = StaticLocationView(viewModel: viewModel.context)
             .environmentObject(AvatarViewModel(avatarService: AvatarService(mediaManager: parameters.mediaManager)))

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/MockStaticLocationViewingScreenState.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/MockStaticLocationViewingScreenState.swift
@@ -46,7 +46,8 @@ enum MockStaticLocationViewingScreenState: MockScreenState, CaseIterable {
         let viewModel = StaticLocationViewingViewModel(mapStyleURL: mapStyleURL,
                                                        avatarData: AvatarInput(mxContentUri: "", matrixItemId: "alice:matrix.org", displayName: "Alice"),
                                                        location: location,
-                                                       coordinateType: coordinateType)
+                                                       coordinateType: coordinateType,
+                                                       service: MockStaticLocationSharingViewerService())
         
         return ([viewModel],
                 AnyView(StaticLocationView(viewModel: viewModel.context)

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Service/MatrixSDK/StaticLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Service/MatrixSDK/StaticLocationSharingViewerService.swift
@@ -1,0 +1,32 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CoreLocation
+import Foundation
+
+class StaticLocationSharingViewerService: StaticLocationSharingViewerServiceProtocol {
+    
+    // MARK: Private
+    
+    private let locationManager = CLLocationManager()
+    
+    // MARK: Public
+    
+    func requestAuthorizationIfNeeded() -> Bool {
+        locationManager.requestAuthorizationIfNeeded()
+    }
+}
+

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Service/Mock/MockStaticLocationSharingViewerService.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Service/Mock/MockStaticLocationSharingViewerService.swift
@@ -1,0 +1,25 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+class MockStaticLocationSharingViewerService: StaticLocationSharingViewerServiceProtocol {
+    
+    func requestAuthorizationIfNeeded() -> Bool {
+        return true
+    }
+    
+}

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Service/StaticLocationSharingViewerServiceProtocol.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Service/StaticLocationSharingViewerServiceProtocol.swift
@@ -1,0 +1,22 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol StaticLocationSharingViewerServiceProtocol {
+    
+    func requestAuthorizationIfNeeded() -> Bool
+}

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingModels.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingModels.swift
@@ -23,6 +23,7 @@ import Foundation
 enum StaticLocationViewingViewAction {
     case close
     case share
+    case showUserLocation
 }
 
 enum StaticLocationViewingViewModelResult {
@@ -41,6 +42,8 @@ struct StaticLocationViewingViewState: BindableState {
     
     /// Shared annotation to display existing location
     let sharedAnnotation: LocationAnnotation
+    
+    var showsUserLocation = false
     
     var showLoadingIndicator = false
     

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
@@ -64,7 +64,7 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
         case .share:
             completion?(.share(state.sharedAnnotation.coordinate))
         case .showUserLocation:
-            state.showsUserLocation.toggle()
+            showsCurrentUserLocation()
         }
     }
     
@@ -90,5 +90,15 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
         }
         
         state.bindings.alertInfo = alertInfo
+    }
+    
+    private let locationManager = CLLocationManager()
+    
+    private func showsCurrentUserLocation() {
+        if locationManager.isAuthorizedOrRequest() {
+            state.showsUserLocation = true
+        } else {
+            state.errorSubject.send(.invalidLocationAuthorization)
+        }
     }
 }

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
@@ -63,6 +63,8 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
             completion?(.close)
         case .share:
             completion?(.share(state.sharedAnnotation.coordinate))
+        case .showUserLocation:
+            state.showsUserLocation.toggle()
         }
     }
     

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
@@ -95,7 +95,7 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
     private let locationManager = CLLocationManager()
     
     private func showsCurrentUserLocation() {
-        if locationManager.isAuthorizedOrRequest() {
+        if locationManager.requestAuthorizationIfNeeded() {
             state.showsUserLocation = true
         } else {
             state.errorSubject.send(.invalidLocationAuthorization)

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/StaticLocationViewingViewModel.swift
@@ -24,6 +24,7 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
 
     // MARK: Private
     
+    private var staticLocationSharingViewerService: StaticLocationSharingViewerServiceProtocol
     private var mapViewErrorAlertInfoBuilder: MapViewErrorAlertInfoBuilder
 
     // MARK: Public
@@ -32,7 +33,10 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
     
     // MARK: - Setup
     
-    init(mapStyleURL: URL, avatarData: AvatarInputProtocol, location: CLLocationCoordinate2D, coordinateType: LocationSharingCoordinateType) {
+    init(mapStyleURL: URL, avatarData: AvatarInputProtocol, location: CLLocationCoordinate2D, coordinateType: LocationSharingCoordinateType, service: StaticLocationSharingViewerServiceProtocol) {
+        
+        staticLocationSharingViewerService = service
+        
         let sharedAnnotation: LocationAnnotation
         switch coordinateType {
         case .user:
@@ -92,10 +96,8 @@ class StaticLocationViewingViewModel: StaticLocationViewingViewModelType, Static
         state.bindings.alertInfo = alertInfo
     }
     
-    private let locationManager = CLLocationManager()
-    
     private func showsCurrentUserLocation() {
-        if locationManager.requestAuthorizationIfNeeded() {
+        if staticLocationSharingViewerService.requestAuthorizationIfNeeded() {
             state.showsUserLocation = true
         } else {
             state.errorSubject.send(.invalidLocationAuthorization)

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Test/Unit/StaticLocationViewingViewModelTests.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Test/Unit/StaticLocationViewingViewModelTests.swift
@@ -90,6 +90,7 @@ class StaticLocationViewingViewModelTests: XCTestCase {
         StaticLocationViewingViewModel(mapStyleURL: URL(string: "http://empty.com")!,
                                        avatarData: AvatarInput(mxContentUri: "", matrixItemId: "", displayName: ""),
                                        location: CLLocationCoordinate2D(latitude: 51.4932641, longitude: -0.257096),
-                                       coordinateType: .user)
+                                       coordinateType: .user,
+                                       service: MockStaticLocationSharingViewerService())
     }
 }

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Test/Unit/StaticLocationViewingViewModelTests.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/Test/Unit/StaticLocationViewingViewModelTests.swift
@@ -79,6 +79,13 @@ class StaticLocationViewingViewModelTests: XCTestCase {
         waitForExpectations(timeout: 3)
     }
     
+    func testToggleShowUserLocation() {
+        let viewModel = buildViewModel()
+        XCTAssertFalse(viewModel.context.viewState.showsUserLocation)
+        viewModel.context.send(viewAction: .showUserLocation)
+        XCTAssertTrue(viewModel.context.viewState.showsUserLocation)
+    }
+    
     private func buildViewModel() -> StaticLocationViewingViewModel {
         StaticLocationViewingViewModel(mapStyleURL: URL(string: "http://empty.com")!,
                                        avatarData: AvatarInput(mxContentUri: "", matrixItemId: "", displayName: ""),

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/View/StaticLocationView.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/View/StaticLocationView.swift
@@ -26,21 +26,38 @@ struct StaticLocationView: View {
     // MARK: Public
     
     @ObservedObject var viewModel: StaticLocationViewingViewModel.Context
-    
+    @State private var showsUserLocation: Bool = false
     // MARK: Views
+    
+    var mapView: LocationSharingMapView {
+        LocationSharingMapView(tileServerMapURL: viewModel.viewState.mapStyleURL,
+                               annotations: [viewModel.viewState.sharedAnnotation],
+                               highlightedAnnotation: viewModel.viewState.sharedAnnotation,
+                               userAvatarData: nil,
+                               showsUserLocation: viewModel.viewState.showsUserLocation,
+                               userLocation: Binding.constant(nil),
+                               mapCenterCoordinate: Binding.constant(nil),
+                               errorSubject: viewModel.viewState.errorSubject)
+    }
     
     var body: some View {
         NavigationView {
-            ZStack(alignment: .bottom) {
-                LocationSharingMapView(tileServerMapURL: viewModel.viewState.mapStyleURL,
-                                       annotations: [viewModel.viewState.sharedAnnotation],
-                                       highlightedAnnotation: viewModel.viewState.sharedAnnotation,
-                                       userAvatarData: viewModel.viewState.userAvatarData,
-                                       showsUserLocation: false,
-                                       userLocation: Binding.constant(nil),
-                                       mapCenterCoordinate: Binding.constant(nil),
-                                       errorSubject: viewModel.viewState.errorSubject)
-                MapCreditsView()
+            ZStack(alignment: .topTrailing) {
+                ZStack(alignment: .bottom) {
+                    mapView
+                    MapCreditsView()
+                }
+                Button {
+                    viewModel.send(viewAction: .showUserLocation)
+                } label: {
+                    Image(uiImage: Asset.Images.locationCenterMapIcon.image)
+                        .foregroundColor(theme.colors.accent)
+                }
+                .padding(8.0)
+                .background(theme.colors.background)
+                .clipShape(Circle())
+                .shadow(radius: 2.0)
+                .offset(x: -11.0, y: 52)
             }
             .ignoresSafeArea(.all, edges: [.bottom])
             .toolbar {

--- a/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/View/StaticLocationView.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StaticLocationSharingViewer/View/StaticLocationView.swift
@@ -26,7 +26,7 @@ struct StaticLocationView: View {
     // MARK: Public
     
     @ObservedObject var viewModel: StaticLocationViewingViewModel.Context
-    @State private var showsUserLocation: Bool = false
+    
     // MARK: Views
     
     var mapView: LocationSharingMapView {
@@ -42,23 +42,13 @@ struct StaticLocationView: View {
     
     var body: some View {
         NavigationView {
-            ZStack(alignment: .topTrailing) {
-                ZStack(alignment: .bottom) {
-                    mapView
-                    MapCreditsView()
-                }
-                Button {
-                    viewModel.send(viewAction: .showUserLocation)
-                } label: {
-                    Image(uiImage: Asset.Images.locationCenterMapIcon.image)
-                        .foregroundColor(theme.colors.accent)
-                }
-                .padding(8.0)
-                .background(theme.colors.background)
-                .clipShape(Circle())
-                .shadow(radius: 2.0)
-                .offset(x: -11.0, y: 52)
+            ZStack(alignment: .bottom) {
+                mapView
+                MapCreditsView()
             }
+            .overlay(CenterToUserLocationButton(action: {
+                viewModel.send(viewAction: .showUserLocation)
+            }).offset(x: -11.0, y: 52), alignment: .topTrailing)
             .ignoresSafeArea(.all, edges: [.bottom])
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/changelog.d/pr-7361.change
+++ b/changelog.d/pr-7361.change
@@ -1,0 +1,1 @@
+Map Views: Show own location in map views


### PR DESCRIPTION
The expanded map view contains a control to display / center on the user’s own location.
The button is hidden when the user is currently sharing their own live location in the same room.
The button is always shown for static location shares, even if it was from the current user.