### PR TITLE
Automatically starts scanning the QR code if we have not received a QR code

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1574,7 +1574,6 @@ Tap the + to start adding people.";
 "device_verification_self_verify_open_on_other_device_information" = "You need to verify this session in order to read your secure message history.\n\nOpen Element on one of your other devices and follow the instructions.";
 "device_verification_self_verify_wait_recover_secrets_without_passphrase" = "Use Security Key";
 "device_verification_self_verify_wait_recover_secrets_with_passphrase" = "Use Security Phrase or Key";
-"device_verification_self_verify_wait_recover_secrets_additional_information" = "If you can't access an existing session";
 "device_verification_self_verify_wait_recover_secrets_additional_help" = "Can't access an existing %@ session?";
 "device_verification_self_verify_wait_recover_secrets_checking_availability" = "Checking for other verification capabilities ...";
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1529,9 +1529,6 @@ Tap the + to start adding people.";
 "device_verification_cancelled" = "The other party cancelled the verification.";
 "device_verification_cancelled_by_me" = "The verification has been cancelled. Reason: %@";
 "device_verification_error_cannot_load_device" = "Cannot load session information.";
-"device_verification_scan_qr_code_title" = "Scan QR code";
-"device_verification_scan_qr_code_information" = "Point your camera at the QR code displayed on your other device to verify this session";
-
 
 // MARK: Incoming
 "device_verification_incoming_title" = "Incoming Verification Request";
@@ -1573,9 +1570,12 @@ Tap the + to start adding people.";
 "device_verification_self_verify_wait_new_sign_in_title" = "Verify this login";
 "device_verification_self_verify_wait_information" = "Verify this session from one of your other sessions, granting it access to encrypted messages.\n\nUse the latest %@ on your other devices:";
 "device_verification_self_verify_wait_additional_information" = "This works with %@ and other cross-signing capable Matrix clients.";
+"device_verification_self_verify_open_on_other_device_title" = "Open %@ on your other device";
+"device_verification_self_verify_open_on_other_device_information" = "You need to verify this session in order to read your secure message history.\n\nOpen Element on one of your other devices and follow the instructions.";
 "device_verification_self_verify_wait_recover_secrets_without_passphrase" = "Use Security Key";
 "device_verification_self_verify_wait_recover_secrets_with_passphrase" = "Use Security Phrase or Key";
 "device_verification_self_verify_wait_recover_secrets_additional_information" = "If you can't access an existing session";
+"device_verification_self_verify_wait_recover_secrets_additional_help" = "Can't access an existing Element session?";
 "device_verification_self_verify_wait_recover_secrets_checking_availability" = "Checking for other verification capabilities ...";
 
 // MARK: Verify
@@ -1750,6 +1750,12 @@ Tap the + to start adding people.";
 
 "key_verification_verify_qr_code_scan_other_code_success_title" = "Code validated!";
 "key_verification_verify_qr_code_scan_other_code_success_message" = "QR code has been successfully validated.";
+
+"key_verification_scan_qr_code_title" = "Scan QR code";
+"key_verification_scan_qr_code_information_other_user" = "Point your camera at the QR code displayed on their device to verify their session";
+"key_verification_scan_qr_code_information_other_device" = "Point your camera at the QR code displayed on your other device to verify this session";
+"key_verification_scan_qr_code_information_other_session" = "Point your camera at the QR code displayed on your other device to verify your session";
+"key_verification_scan_qr_code_information_new_session" = "Point your camera at the QR code displayed on your other device to verify your new session";
 
 // MARK: Scan confirmation
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1575,7 +1575,7 @@ Tap the + to start adding people.";
 "device_verification_self_verify_wait_recover_secrets_without_passphrase" = "Use Security Key";
 "device_verification_self_verify_wait_recover_secrets_with_passphrase" = "Use Security Phrase or Key";
 "device_verification_self_verify_wait_recover_secrets_additional_information" = "If you can't access an existing session";
-"device_verification_self_verify_wait_recover_secrets_additional_help" = "Can't access an existing Element session?";
+"device_verification_self_verify_wait_recover_secrets_additional_help" = "Can't access an existing %@ session?";
 "device_verification_self_verify_wait_recover_secrets_checking_availability" = "Checking for other verification capabilities ...";
 
 // MARK: Verify

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1529,6 +1529,9 @@ Tap the + to start adding people.";
 "device_verification_cancelled" = "The other party cancelled the verification.";
 "device_verification_cancelled_by_me" = "The verification has been cancelled. Reason: %@";
 "device_verification_error_cannot_load_device" = "Cannot load session information.";
+"device_verification_scan_qr_code_title" = "Scan QR code";
+"device_verification_scan_qr_code_information" = "Point your camera at the QR code displayed on your other device to verify this session";
+
 
 // MARK: Incoming
 "device_verification_incoming_title" = "Incoming Verification Request";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1851,14 +1851,6 @@ public class VectorL10n: NSObject {
   public static var deviceVerificationIncomingTitle: String { 
     return VectorL10n.tr("Vector", "device_verification_incoming_title") 
   }
-  /// Point your camera at the QR code displayed on your other device to verify this session
-  public static var deviceVerificationScanQrCodeInformation: String { 
-    return VectorL10n.tr("Vector", "device_verification_scan_qr_code_information") 
-  }
-  /// Scan QR code
-  public static var deviceVerificationScanQrCodeTitle: String { 
-    return VectorL10n.tr("Vector", "device_verification_scan_qr_code_title") 
-  }
   /// Compare the unique emoji, ensuring they appear in the same order.
   public static var deviceVerificationSecurityAdviceEmoji: String { 
     return VectorL10n.tr("Vector", "device_verification_security_advice_emoji") 
@@ -1878,6 +1870,14 @@ public class VectorL10n: NSObject {
   /// Verify
   public static var deviceVerificationSelfVerifyAlertValidateAction: String { 
     return VectorL10n.tr("Vector", "device_verification_self_verify_alert_validate_action") 
+  }
+  /// You need to verify this session in order to read your secure message history.\n\nOpen Element on one of your other devices and follow the instructions.
+  public static var deviceVerificationSelfVerifyOpenOnOtherDeviceInformation: String { 
+    return VectorL10n.tr("Vector", "device_verification_self_verify_open_on_other_device_information") 
+  }
+  /// Open %@ on your other device
+  public static func deviceVerificationSelfVerifyOpenOnOtherDeviceTitle(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "device_verification_self_verify_open_on_other_device_title", p1)
   }
   /// Use this session to verify your new one, granting it access to encrypted messages.
   public static var deviceVerificationSelfVerifyStartInformation: String { 
@@ -1902,6 +1902,10 @@ public class VectorL10n: NSObject {
   /// Verify this login
   public static var deviceVerificationSelfVerifyWaitNewSignInTitle: String { 
     return VectorL10n.tr("Vector", "device_verification_self_verify_wait_new_sign_in_title") 
+  }
+  /// Can't access an existing Element session?
+  public static var deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp: String { 
+    return VectorL10n.tr("Vector", "device_verification_self_verify_wait_recover_secrets_additional_help") 
   }
   /// If you can't access an existing session
   public static var deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalInformation: String { 
@@ -2994,6 +2998,26 @@ public class VectorL10n: NSObject {
   /// Waiting for %@…
   public static func keyVerificationScanConfirmationScanningUserWaitingOther(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "key_verification_scan_confirmation_scanning_user_waiting_other", p1)
+  }
+  /// Point your camera at the QR code displayed on your other device to verify your new session
+  public static var keyVerificationScanQrCodeInformationNewSession: String { 
+    return VectorL10n.tr("Vector", "key_verification_scan_qr_code_information_new_session") 
+  }
+  /// Point your camera at the QR code displayed on your other device to verify this session
+  public static var keyVerificationScanQrCodeInformationOtherDevice: String { 
+    return VectorL10n.tr("Vector", "key_verification_scan_qr_code_information_other_device") 
+  }
+  /// Point your camera at the QR code displayed on your other device to verify your session
+  public static var keyVerificationScanQrCodeInformationOtherSession: String { 
+    return VectorL10n.tr("Vector", "key_verification_scan_qr_code_information_other_session") 
+  }
+  /// Point your camera at the QR code displayed on their device to verify their session
+  public static var keyVerificationScanQrCodeInformationOtherUser: String { 
+    return VectorL10n.tr("Vector", "key_verification_scan_qr_code_information_other_user") 
+  }
+  /// Scan QR code
+  public static var keyVerificationScanQrCodeTitle: String { 
+    return VectorL10n.tr("Vector", "key_verification_scan_qr_code_title") 
   }
   /// Other users may not trust it.
   public static var keyVerificationSelfVerifyCurrentSessionAlertMessage: String { 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1851,6 +1851,14 @@ public class VectorL10n: NSObject {
   public static var deviceVerificationIncomingTitle: String { 
     return VectorL10n.tr("Vector", "device_verification_incoming_title") 
   }
+  /// Point your camera at the QR code displayed on your other device to verify this session
+  public static var deviceVerificationScanQrCodeInformation: String { 
+    return VectorL10n.tr("Vector", "device_verification_scan_qr_code_information") 
+  }
+  /// Scan QR code
+  public static var deviceVerificationScanQrCodeTitle: String { 
+    return VectorL10n.tr("Vector", "device_verification_scan_qr_code_title") 
+  }
   /// Compare the unique emoji, ensuring they appear in the same order.
   public static var deviceVerificationSecurityAdviceEmoji: String { 
     return VectorL10n.tr("Vector", "device_verification_security_advice_emoji") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1907,10 +1907,6 @@ public class VectorL10n: NSObject {
   public static func deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "device_verification_self_verify_wait_recover_secrets_additional_help", p1)
   }
-  /// If you can't access an existing session
-  public static var deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalInformation: String { 
-    return VectorL10n.tr("Vector", "device_verification_self_verify_wait_recover_secrets_additional_information") 
-  }
   /// Checking for other verification capabilities ...
   public static var deviceVerificationSelfVerifyWaitRecoverSecretsCheckingAvailability: String { 
     return VectorL10n.tr("Vector", "device_verification_self_verify_wait_recover_secrets_checking_availability") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1903,9 +1903,9 @@ public class VectorL10n: NSObject {
   public static var deviceVerificationSelfVerifyWaitNewSignInTitle: String { 
     return VectorL10n.tr("Vector", "device_verification_self_verify_wait_new_sign_in_title") 
   }
-  /// Can't access an existing Element session?
-  public static var deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp: String { 
-    return VectorL10n.tr("Vector", "device_verification_self_verify_wait_recover_secrets_additional_help") 
+  /// Can't access an existing %@ session?
+  public static func deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "device_verification_self_verify_wait_recover_secrets_additional_help", p1)
   }
   /// If you can't access an existing session
   public static var deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalInformation: String { 

--- a/Riot/Modules/KeyVerification/Common/ScanConfirmation/KeyVerificationScanConfirmationViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Common/ScanConfirmation/KeyVerificationScanConfirmationViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="V8j-Lb-PgC">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="V8j-Lb-PgC">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,38 +11,38 @@
         <!--Key Verification Scan Confirmation View Controller-->
         <scene sceneID="mt5-wz-YKA">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="V8j-Lb-PgC" customClass="KeyVerificationScanConfirmationViewController" customModule="Riot" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="V8j-Lb-PgC" customClass="KeyVerificationScanConfirmationViewController" customModule="Element" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EL9-GA-lwo">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9U2-KL-ZVA">
-                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="848"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="36d-db-nP0">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="376.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="392"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A5W-J0-Sfd">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="376.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="392"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FO8-rD-Y21">
-                                                        <rect key="frame" x="20" y="40" width="374" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <rect key="frame" x="20" y="40" width="374" height="33.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="key_verification_success_shield" translatesAutoresizingMaskIntoConstraints="NO" id="Uad-3w-cQ4">
-                                                        <rect key="frame" x="147" y="88" width="120" height="120"/>
+                                                        <rect key="frame" x="147" y="103.5" width="120" height="120"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="120" id="3RB-i8-S1k"/>
                                                             <constraint firstAttribute="width" secondItem="Uad-3w-cQ4" secondAttribute="height" multiplier="1:1" id="vrj-Sp-Wpu"/>
                                                         </constraints>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="t0L-ns-MGv">
-                                                        <rect key="frame" x="20" y="238" width="374" height="118.5"/>
+                                                        <rect key="frame" x="20" y="253.5" width="374" height="118.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Waiting..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hwq-X6-Gl2">
-                                                                <rect key="frame" x="151.5" y="0.0" width="71.5" height="20.5"/>
+                                                                <rect key="frame" x="151.5" y="0.0" width="71" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.43921568630000002" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -61,7 +59,7 @@
                                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8Ou-Xh-0rC">
                                                                         <rect key="frame" x="0.0" y="48" width="374" height="40"/>
                                                                         <subviews>
-                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kBt-2D-25V" customClass="RoundedButton" customModule="Riot" customModuleProvider="target">
+                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kBt-2D-25V" customClass="RoundedButton" customModule="Element" customModuleProvider="target">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="182" height="40"/>
                                                                                 <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
                                                                                 <state key="normal" title="No">
@@ -71,7 +69,7 @@
                                                                                     <action selector="rejectButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="qCV-Oh-YAG"/>
                                                                                 </connections>
                                                                             </button>
-                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="03A-fe-h3s" customClass="RoundedButton" customModule="Riot" customModuleProvider="target">
+                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="03A-fe-h3s" customClass="RoundedButton" customModule="Element" customModuleProvider="target">
                                                                                 <rect key="frame" x="192" y="0.0" width="182" height="40"/>
                                                                                 <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
                                                                                 <state key="normal" title="Yes">
@@ -142,6 +140,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="bFg-jh-JZB"/>
                         <color key="backgroundColor" red="0.94509803921568625" green="0.96078431372549022" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="9U2-KL-ZVA" secondAttribute="bottom" id="7Cb-nY-CsO"/>
@@ -149,7 +148,6 @@
                             <constraint firstItem="bFg-jh-JZB" firstAttribute="trailing" secondItem="9U2-KL-ZVA" secondAttribute="trailing" id="sbD-ek-vGJ"/>
                             <constraint firstItem="bFg-jh-JZB" firstAttribute="top" secondItem="9U2-KL-ZVA" secondAttribute="top" id="wTB-V6-IHV"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="bFg-jh-JZB"/>
                     </view>
                     <connections>
                         <outlet property="confirmButton" destination="03A-fe-h3s" id="lDk-ec-qrl"/>

--- a/Riot/Modules/KeyVerification/Common/ScanConfirmation/KeyVerificationScanConfirmationViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/ScanConfirmation/KeyVerificationScanConfirmationViewController.swift
@@ -173,7 +173,6 @@ final class KeyVerificationScanConfirmationViewController: UIViewController {
             }
         }
         
-        self.title = viewData.verificationKind.verificationTitle
         self.titleLabel.text = title
         self.waitingLabel.text = waitingInfo
         self.scannedInformationLabel.text = scannedInfo

--- a/Riot/Modules/KeyVerification/Common/Verified/KeyVerificationVerifiedViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Common/Verified/KeyVerificationVerifiedViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dBQ-CG-VDL">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dBQ-CG-VDL">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,41 +11,41 @@
         <!--Key Verification Verified View Controller-->
         <scene sceneID="EyC-m5-6uM">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="dBQ-CG-VDL" customClass="KeyVerificationVerifiedViewController" customModule="Riot" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="dBQ-CG-VDL" customClass="KeyVerificationVerifiedViewController" customModule="Element" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ht4-fu-3rS">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jOh-c7-uod">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c4q-B8-hPy">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="345"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="358"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fNE-v3-2lx">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="345"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="358"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verified!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Nw-CZ-lKr">
-                                                        <rect key="frame" x="20" y="60" width="335" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                        <rect key="frame" x="20" y="60" width="335" height="33.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You've successfully verified this device." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sql-oR-dMk">
-                                                        <rect key="frame" x="20" y="103" width="335" height="18"/>
+                                                        <rect key="frame" x="20" y="116" width="335" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="key_verification_success_shield" translatesAutoresizingMaskIntoConstraints="NO" id="ie2-LW-ek2">
-                                                        <rect key="frame" x="127.5" y="141" width="120" height="120"/>
+                                                        <rect key="frame" x="127.5" y="154" width="120" height="120"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="ie2-LW-ek2" secondAttribute="height" multiplier="1:1" id="Re6-8V-peU"/>
                                                             <constraint firstAttribute="width" constant="120" id="qg0-4Z-ffM"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4i8-Se-1Ae" customClass="RoundedButton" customModule="Riot" customModuleProvider="target">
-                                                        <rect key="frame" x="20" y="281" width="335" height="44"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4i8-Se-1Ae" customClass="RoundedButton" customModule="Element" customModuleProvider="target">
+                                                        <rect key="frame" x="20" y="294" width="335" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="XNP-zj-OmI"/>
                                                         </constraints>
@@ -98,6 +96,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6ex-OQ-2sZ"/>
                         <color key="backgroundColor" red="0.94509803921568625" green="0.96078431372549022" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="jOh-c7-uod" secondAttribute="trailing" id="7K8-MG-xLT"/>
@@ -107,7 +106,6 @@
                             <constraint firstItem="jOh-c7-uod" firstAttribute="trailing" secondItem="6ex-OQ-2sZ" secondAttribute="trailing" id="jVN-Fr-MKN"/>
                             <constraint firstItem="jOh-c7-uod" firstAttribute="top" secondItem="6ex-OQ-2sZ" secondAttribute="top" id="s7K-jf-P1z"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6ex-OQ-2sZ"/>
                     </view>
                     <connections>
                         <outlet property="doneButton" destination="4i8-Se-1Ae" id="K4a-4m-cU2"/>

--- a/Riot/Modules/KeyVerification/Common/Verified/KeyVerificationVerifiedViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verified/KeyVerificationVerifiedViewController.swift
@@ -97,7 +97,6 @@ final class KeyVerificationVerifiedViewController: UIViewController {
             informationText = VectorL10n.keyVerificationVerifiedUserInformation
         }
         
-        self.title = self.verificationKind.verificationTitle
         self.titleLabel.text =  bodyTitle
         self.informationLabel.text = informationText
 

--- a/Riot/Modules/KeyVerification/Common/Verify/SAS/KeyVerificationVerifyBySASViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Common/Verify/SAS/KeyVerificationVerifyBySASViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="V8j-Lb-PgC">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="V8j-Lb-PgC">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,37 +11,34 @@
         <!--Key Verification Verify BySAS View Controller-->
         <scene sceneID="mt5-wz-YKA">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="V8j-Lb-PgC" customClass="KeyVerificationVerifyBySASViewController" customModule="Riot" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="V8j-Lb-PgC" customClass="KeyVerificationVerifyBySASViewController" customModule="Element" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EL9-GA-lwo">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9U2-KL-ZVA">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e7g-um-WO4">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="502"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="490.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="voD-3Q-ryt">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="502"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="490.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Compare emoji" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="he8-pl-xE9">
-                                                        <rect key="frame" x="20" y="35" width="335" height="61"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="61" id="Nam-ca-50k"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                        <rect key="frame" x="20" y="30" width="335" height="33.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="For maximum security, we recommend you do this in person or use another trusted means of communication." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxI-mu-qng">
-                                                        <rect key="frame" x="20" y="115" width="335" height="54"/>
+                                                        <rect key="frame" x="20" y="103.5" width="335" height="54"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3152 3307 8179" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RD6-ue-X5c">
-                                                        <rect key="frame" x="37.5" y="264.5" width="300" height="29"/>
+                                                        <rect key="frame" x="37.5" y="253" width="300" height="29"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="300" id="6Q5-M2-ifj"/>
                                                         </constraints>
@@ -52,7 +47,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="34i-3X-YvQ">
-                                                        <rect key="frame" x="27.5" y="189" width="320" height="180"/>
+                                                        <rect key="frame" x="27.5" y="177.5" width="320" height="180"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="180" id="kpT-ty-CDI"/>
@@ -65,7 +60,7 @@
                                                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                         </collectionViewFlowLayout>
                                                         <cells>
-                                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VerifyEmojiCollectionViewCell" id="iG2-Pq-pYr" customClass="VerifyEmojiCollectionViewCell" customModule="Riot" customModuleProvider="target">
+                                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VerifyEmojiCollectionViewCell" id="iG2-Pq-pYr" customClass="VerifyEmojiCollectionViewCell" customModule="Element" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
@@ -105,9 +100,9 @@
                                                         </connections>
                                                     </collectionView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="6xJ-uL-C85">
-                                                        <rect key="frame" x="20" y="389" width="335" height="44"/>
+                                                        <rect key="frame" x="20" y="377.5" width="335" height="44"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zsb-KY-oCN" customClass="RoundedButton" customModule="Riot" customModuleProvider="target">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zsb-KY-oCN" customClass="RoundedButton" customModule="Element" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="0.0" width="162.5" height="44"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
@@ -118,7 +113,7 @@
                                                                     <action selector="cancelButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="1NK-nX-rMW"/>
                                                                 </connections>
                                                             </button>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FvW-07-g2Q" customClass="RoundedButton" customModule="Riot" customModuleProvider="target">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FvW-07-g2Q" customClass="RoundedButton" customModule="Element" customModuleProvider="target">
                                                                 <rect key="frame" x="172.5" y="0.0" width="162.5" height="44"/>
                                                                 <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
                                                                 <state key="normal" title="They match">
@@ -146,7 +141,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="For ultimate security, use another trusted means of communication or do this in person." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDW-77-nwN">
-                                                        <rect key="frame" x="20" y="453" width="335" height="29"/>
+                                                        <rect key="frame" x="20" y="441.5" width="335" height="29"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -162,7 +157,7 @@
                                                     <constraint firstItem="he8-pl-xE9" firstAttribute="leading" secondItem="bxI-mu-qng" secondAttribute="leading" id="Q9n-7p-gHl"/>
                                                     <constraint firstItem="he8-pl-xE9" firstAttribute="leading" secondItem="voD-3Q-ryt" secondAttribute="leading" constant="20" id="QSg-yz-aaB"/>
                                                     <constraint firstItem="6yX-xD-4X5" firstAttribute="centerX" secondItem="voD-3Q-ryt" secondAttribute="centerX" id="Rg4-jV-Nht"/>
-                                                    <constraint firstItem="bxI-mu-qng" firstAttribute="top" secondItem="he8-pl-xE9" secondAttribute="top" constant="80" id="UL4-x0-oFT"/>
+                                                    <constraint firstItem="bxI-mu-qng" firstAttribute="top" secondItem="he8-pl-xE9" secondAttribute="bottom" constant="40" id="UL4-x0-oFT"/>
                                                     <constraint firstItem="gDW-77-nwN" firstAttribute="leading" secondItem="voD-3Q-ryt" secondAttribute="leading" constant="20" id="YAC-Wy-mPL"/>
                                                     <constraint firstItem="he8-pl-xE9" firstAttribute="centerX" secondItem="voD-3Q-ryt" secondAttribute="centerX" id="ZP8-mV-RBh"/>
                                                     <constraint firstItem="he8-pl-xE9" firstAttribute="trailing" secondItem="bxI-mu-qng" secondAttribute="trailing" id="Zeg-U8-uis"/>
@@ -171,7 +166,7 @@
                                                     <constraint firstItem="RD6-ue-X5c" firstAttribute="centerX" secondItem="34i-3X-YvQ" secondAttribute="centerX" id="lBM-R8-C6b"/>
                                                     <constraint firstItem="34i-3X-YvQ" firstAttribute="top" secondItem="bxI-mu-qng" secondAttribute="bottom" constant="20" id="r7A-9g-Mmb"/>
                                                     <constraint firstAttribute="bottom" secondItem="gDW-77-nwN" secondAttribute="bottom" constant="20" id="rpv-yg-1jT"/>
-                                                    <constraint firstItem="he8-pl-xE9" firstAttribute="top" secondItem="voD-3Q-ryt" secondAttribute="top" constant="35" id="s3k-Io-834"/>
+                                                    <constraint firstItem="he8-pl-xE9" firstAttribute="top" secondItem="voD-3Q-ryt" secondAttribute="top" constant="30" id="s3k-Io-834"/>
                                                     <constraint firstItem="gDW-77-nwN" firstAttribute="top" secondItem="6xJ-uL-C85" secondAttribute="bottom" constant="20" id="wL6-tr-pO2"/>
                                                     <constraint firstItem="34i-3X-YvQ" firstAttribute="centerX" secondItem="voD-3Q-ryt" secondAttribute="centerX" id="ydb-Fs-K0a"/>
                                                 </constraints>
@@ -201,6 +196,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="bFg-jh-JZB"/>
                         <color key="backgroundColor" red="0.94509803920000002" green="0.96078431369999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="9U2-KL-ZVA" secondAttribute="bottom" id="7Cb-nY-CsO"/>
@@ -208,7 +204,6 @@
                             <constraint firstItem="bFg-jh-JZB" firstAttribute="trailing" secondItem="9U2-KL-ZVA" secondAttribute="trailing" id="sbD-ek-vGJ"/>
                             <constraint firstItem="bFg-jh-JZB" firstAttribute="top" secondItem="9U2-KL-ZVA" secondAttribute="top" id="wTB-V6-IHV"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="bFg-jh-JZB"/>
                     </view>
                     <connections>
                         <outlet property="additionalInformationLabel" destination="gDW-77-nwN" id="leX-Mb-wlj"/>

--- a/Riot/Modules/KeyVerification/Common/Verify/SAS/KeyVerificationVerifyBySASViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/SAS/KeyVerificationVerifyBySASViewController.swift
@@ -145,7 +145,6 @@ final class KeyVerificationVerifyBySASViewController: UIViewController {
             adviceText = VectorL10n.deviceVerificationSecurityAdviceNumber
         }
 
-        self.title = self.viewModel.verificationKind.verificationTitle
         self.titleLabel.text = instructionText
         self.informationLabel.text = adviceText
         self.waitingPartnerLabel.text = VectorL10n.deviceVerificationVerifyWaitPartner

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.storyboard
@@ -20,23 +20,17 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fyB-h5-5v2">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="443"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="498.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D7P-C8-cqw">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="113"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="168.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="lPc-YT-wnY">
-                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="113"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="168.5"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J1F-ba-sZ7">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="52"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="254" text="Verify by scanning" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VsP-5V-z35">
-                                                                        <rect key="frame" x="20" y="20" width="288" height="30"/>
-                                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
-                                                                        <nil key="textColor"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1PP-lU-Ags" customClass="CloseButton" customModule="Element" customModuleProvider="target">
                                                                         <rect key="frame" x="318" y="13" width="44" height="44"/>
                                                                         <constraints>
@@ -52,20 +46,16 @@
                                                                 </subviews>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="bottom" secondItem="VsP-5V-z35" secondAttribute="bottom" id="A4U-o4-Q6E"/>
-                                                                    <constraint firstItem="VsP-5V-z35" firstAttribute="centerY" secondItem="1PP-lU-Ags" secondAttribute="centerY" id="F8E-af-0ee"/>
-                                                                    <constraint firstItem="VsP-5V-z35" firstAttribute="leading" secondItem="J1F-ba-sZ7" secondAttribute="leading" constant="20" id="gIh-y4-VEc"/>
                                                                     <constraint firstAttribute="height" priority="250" id="guf-gx-dH4"/>
-                                                                    <constraint firstItem="1PP-lU-Ags" firstAttribute="leading" secondItem="VsP-5V-z35" secondAttribute="trailing" constant="10" id="lfn-WB-Ilq"/>
                                                                     <constraint firstItem="1PP-lU-Ags" firstAttribute="top" secondItem="J1F-ba-sZ7" secondAttribute="top" constant="13" id="swy-iI-xCv"/>
                                                                     <constraint firstAttribute="trailing" secondItem="1PP-lU-Ags" secondAttribute="trailing" constant="13" id="xNP-5O-bnD"/>
                                                                 </constraints>
                                                             </view>
-                                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JWN-4v-RUi">
-                                                                <rect key="frame" x="0.0" y="50" width="375" height="20"/>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JWN-4v-RUi">
+                                                                <rect key="frame" x="0.0" y="52" width="375" height="53.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="751" text="Scan QR Code" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Vv-12-J2A">
-                                                                        <rect key="frame" x="20" y="20" width="335" height="0.0"/>
+                                                                        <rect key="frame" x="20" y="20" width="335" height="33.5"/>
                                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -81,7 +71,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLA-sa-fBw">
-                                                                <rect key="frame" x="0.0" y="50" width="375" height="63"/>
+                                                                <rect key="frame" x="0.0" y="105.5" width="375" height="63"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="751" text="Scan the code to securely verify each other." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y2w-7m-BE3">
                                                                         <rect key="frame" x="20" y="20" width="335" height="18"/>
@@ -116,7 +106,7 @@
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bQd-8A-8hf">
-                                                <rect key="frame" x="0.0" y="113" width="375" height="330"/>
+                                                <rect key="frame" x="0.0" y="168.5" width="375" height="330"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vrz-UO-PDk">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
@@ -292,6 +282,7 @@
                     <connections>
                         <outlet property="cannotScanButton" destination="bRZ-4Z-DEJ" id="O51-k2-JJY"/>
                         <outlet property="closeButton" destination="1PP-lU-Ags" id="cwn-nr-esg"/>
+                        <outlet property="closeButtonContainer" destination="J1F-ba-sZ7" id="OQp-Vr-iv8"/>
                         <outlet property="codeImageView" destination="NFT-6Y-5rt" id="0FH-o1-GBM"/>
                         <outlet property="informationLabel" destination="y2w-7m-BE3" id="uXB-RC-Ppc"/>
                         <outlet property="qrCodeContainerView" destination="vrz-UO-PDk" id="64E-48-YIv"/>
@@ -299,10 +290,8 @@
                         <outlet property="qrCodeScannerContainerView" destination="NG7-qS-njl" id="xmO-wT-3X5"/>
                         <outlet property="scanButtonContainerView" destination="s4G-bW-EGe" id="TL4-jJ-EDC"/>
                         <outlet property="scanCodeButton" destination="a4h-x5-COe" id="8Cl-iJ-be8"/>
-                        <outlet property="scanTitleLabel" destination="4Vv-12-J2A" id="C9X-QH-zC8"/>
-                        <outlet property="scanTitleView" destination="JWN-4v-RUi" id="7jz-CL-Zf1"/>
-                        <outlet property="titleLabel" destination="VsP-5V-z35" id="t5i-0x-a7m"/>
-                        <outlet property="titleView" destination="J1F-ba-sZ7" id="zVT-Mg-8di"/>
+                        <outlet property="titleLabel" destination="4Vv-12-J2A" id="HZc-SV-hcP"/>
+                        <outlet property="titleView" destination="JWN-4v-RUi" id="p4S-wd-mnh"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uyZ-jd-xN3" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.storyboard
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fyB-h5-5v2">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="806"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="443"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D7P-C8-cqw">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="113"/>
@@ -61,6 +61,25 @@
                                                                     <constraint firstAttribute="trailing" secondItem="1PP-lU-Ags" secondAttribute="trailing" constant="13" id="xNP-5O-bnD"/>
                                                                 </constraints>
                                                             </view>
+                                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JWN-4v-RUi">
+                                                                <rect key="frame" x="0.0" y="50" width="375" height="20"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="751" text="Scan QR Code" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Vv-12-J2A">
+                                                                        <rect key="frame" x="20" y="20" width="335" height="0.0"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstItem="4Vv-12-J2A" firstAttribute="leading" secondItem="JWN-4v-RUi" secondAttribute="leading" constant="20" id="4Bf-hJ-6wD"/>
+                                                                    <constraint firstAttribute="height" priority="750" id="Elw-li-szT"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="4Vv-12-J2A" secondAttribute="bottom" id="j1X-c8-tCi"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="4Vv-12-J2A" secondAttribute="trailing" constant="20" id="sAb-CX-1dL"/>
+                                                                    <constraint firstItem="4Vv-12-J2A" firstAttribute="top" secondItem="JWN-4v-RUi" secondAttribute="top" constant="20" id="wPc-io-mBg"/>
+                                                                </constraints>
+                                                            </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLA-sa-fBw">
                                                                 <rect key="frame" x="0.0" y="50" width="375" height="63"/>
                                                                 <subviews>
@@ -97,7 +116,7 @@
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bQd-8A-8hf">
-                                                <rect key="frame" x="0.0" y="113" width="375" height="693"/>
+                                                <rect key="frame" x="0.0" y="113" width="375" height="330"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vrz-UO-PDk">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
@@ -117,11 +136,11 @@
                                                             <constraint firstItem="NFT-6Y-5rt" firstAttribute="top" secondItem="vrz-UO-PDk" secondAttribute="top" id="Sfi-ob-xej"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NG7-qS-njl">
-                                                        <rect key="frame" x="0.0" y="200" width="375" height="363"/>
+                                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NG7-qS-njl">
+                                                        <rect key="frame" x="0.0" y="200" width="375" height="28"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yMt-yE-2HC">
-                                                                <rect key="frame" x="18" y="6" width="40" height="40"/>
+                                                                <rect key="frame" x="185.5" y="6" width="40" height="40"/>
                                                                 <color key="backgroundColor" red="0.050980392156862744" green="0.74117647058823533" blue="0.54509803921568623" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="40" id="aE1-Fg-abK"/>
@@ -129,28 +148,28 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IUM-L7-fqo">
-                                                                <rect key="frame" x="317" y="6" width="40" height="40"/>
+                                                                <rect key="frame" x="149.5" y="6" width="40" height="40"/>
                                                                 <color key="backgroundColor" red="0.050980392159999999" green="0.74117647060000003" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="IUM-L7-fqo" secondAttribute="height" id="i5Y-Jl-e2K"/>
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xt1-wB-5jN">
-                                                                <rect key="frame" x="18" y="305" width="40" height="40"/>
+                                                                <rect key="frame" x="185.5" y="-30" width="40" height="40"/>
                                                                 <color key="backgroundColor" red="0.050980392159999999" green="0.74117647060000003" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="Xt1-wB-5jN" secondAttribute="height" id="ChW-li-1yx"/>
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="niQ-mw-RBU">
-                                                                <rect key="frame" x="317" y="305" width="40" height="40"/>
+                                                                <rect key="frame" x="149.5" y="-30" width="40" height="40"/>
                                                                 <color key="backgroundColor" red="0.050980392159999999" green="0.74117647060000003" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="niQ-mw-RBU" secondAttribute="height" id="qac-f3-yEf"/>
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f4V-Zd-iYY">
-                                                                <rect key="frame" x="20" y="8" width="335" height="335"/>
+                                                                <rect key="frame" x="187.5" y="8" width="0.0" height="0.0"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="f4V-Zd-iYY" secondAttribute="height" id="p2W-BD-0pf"/>
@@ -184,7 +203,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4G-bW-EGe">
-                                                        <rect key="frame" x="0.0" y="563" width="375" height="55"/>
+                                                        <rect key="frame" x="0.0" y="200" width="375" height="55"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a4h-x5-COe">
                                                                 <rect key="frame" x="20" y="0.0" width="335" height="50"/>
@@ -211,7 +230,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n73-GU-j8x">
-                                                        <rect key="frame" x="0.0" y="618" width="375" height="75"/>
+                                                        <rect key="frame" x="0.0" y="255" width="375" height="75"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bRZ-4Z-DEJ">
                                                                 <rect key="frame" x="20" y="5" width="335" height="50"/>
@@ -280,6 +299,8 @@
                         <outlet property="qrCodeScannerContainerView" destination="NG7-qS-njl" id="xmO-wT-3X5"/>
                         <outlet property="scanButtonContainerView" destination="s4G-bW-EGe" id="TL4-jJ-EDC"/>
                         <outlet property="scanCodeButton" destination="a4h-x5-COe" id="8Cl-iJ-be8"/>
+                        <outlet property="scanTitleLabel" destination="4Vv-12-J2A" id="C9X-QH-zC8"/>
+                        <outlet property="scanTitleView" destination="JWN-4v-RUi" id="7jz-CL-Zf1"/>
                         <outlet property="titleLabel" destination="VsP-5V-z35" id="t5i-0x-a7m"/>
                         <outlet property="titleView" destination="J1F-ba-sZ7" id="zVT-Mg-8di"/>
                     </connections>

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="F9j-7h-dzQ">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="F9j-7h-dzQ">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,16 +11,16 @@
         <!--Key Verification Verify By Scanning View Controller-->
         <scene sceneID="aq0-GT-wx2">
             <objects>
-                <viewController id="F9j-7h-dzQ" customClass="KeyVerificationVerifyByScanningViewController" customModule="Riot" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="F9j-7h-dzQ" customClass="KeyVerificationVerifyByScanningViewController" customModule="Element" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="WNg-GS-gGF">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edw-lO-NVl">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fyB-h5-5v2">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="443"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="806"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D7P-C8-cqw">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="113"/>
@@ -39,7 +37,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1PP-lU-Ags" customClass="CloseButton" customModule="Riot" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1PP-lU-Ags" customClass="CloseButton" customModule="Element" customModuleProvider="target">
                                                                         <rect key="frame" x="318" y="13" width="44" height="44"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="44" id="Hfb-fa-cN0"/>
@@ -99,7 +97,7 @@
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bQd-8A-8hf">
-                                                <rect key="frame" x="0.0" y="113" width="375" height="330"/>
+                                                <rect key="frame" x="0.0" y="113" width="375" height="693"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vrz-UO-PDk">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
@@ -119,10 +117,76 @@
                                                             <constraint firstItem="NFT-6Y-5rt" firstAttribute="top" secondItem="vrz-UO-PDk" secondAttribute="top" id="Sfi-ob-xej"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4G-bW-EGe">
-                                                        <rect key="frame" x="0.0" y="200" width="375" height="55"/>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NG7-qS-njl">
+                                                        <rect key="frame" x="0.0" y="200" width="375" height="363"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a4h-x5-COe">
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yMt-yE-2HC">
+                                                                <rect key="frame" x="18" y="6" width="40" height="40"/>
+                                                                <color key="backgroundColor" red="0.050980392156862744" green="0.74117647058823533" blue="0.54509803921568623" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="40" id="aE1-Fg-abK"/>
+                                                                    <constraint firstAttribute="width" secondItem="yMt-yE-2HC" secondAttribute="height" id="xf4-KK-C59"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IUM-L7-fqo">
+                                                                <rect key="frame" x="317" y="6" width="40" height="40"/>
+                                                                <color key="backgroundColor" red="0.050980392159999999" green="0.74117647060000003" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="IUM-L7-fqo" secondAttribute="height" id="i5Y-Jl-e2K"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xt1-wB-5jN">
+                                                                <rect key="frame" x="18" y="305" width="40" height="40"/>
+                                                                <color key="backgroundColor" red="0.050980392159999999" green="0.74117647060000003" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="Xt1-wB-5jN" secondAttribute="height" id="ChW-li-1yx"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="niQ-mw-RBU">
+                                                                <rect key="frame" x="317" y="305" width="40" height="40"/>
+                                                                <color key="backgroundColor" red="0.050980392159999999" green="0.74117647060000003" blue="0.5450980392" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="niQ-mw-RBU" secondAttribute="height" id="qac-f3-yEf"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f4V-Zd-iYY">
+                                                                <rect key="frame" x="20" y="8" width="335" height="335"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="f4V-Zd-iYY" secondAttribute="height" id="p2W-BD-0pf"/>
+                                                                    <constraint firstAttribute="width" priority="750" constant="335" id="pQr-eX-6lg"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstItem="IUM-L7-fqo" firstAttribute="width" secondItem="yMt-yE-2HC" secondAttribute="width" id="0qx-12-Oqf"/>
+                                                            <constraint firstItem="Xt1-wB-5jN" firstAttribute="width" secondItem="Xt1-wB-5jN" secondAttribute="height" id="16F-6k-5hE"/>
+                                                            <constraint firstItem="IUM-L7-fqo" firstAttribute="trailing" secondItem="f4V-Zd-iYY" secondAttribute="trailing" constant="2" id="2rc-Na-oKh"/>
+                                                            <constraint firstAttribute="bottom" secondItem="f4V-Zd-iYY" secondAttribute="bottom" constant="20" id="7vU-Kd-aUH"/>
+                                                            <constraint firstItem="niQ-mw-RBU" firstAttribute="bottom" secondItem="f4V-Zd-iYY" secondAttribute="bottom" constant="2" id="90A-GI-ydv"/>
+                                                            <constraint firstItem="Xt1-wB-5jN" firstAttribute="leading" secondItem="f4V-Zd-iYY" secondAttribute="leading" constant="-2" id="ARQ-GC-TtD"/>
+                                                            <constraint firstItem="Xt1-wB-5jN" firstAttribute="bottom" secondItem="f4V-Zd-iYY" secondAttribute="bottom" constant="2" id="BaR-VQ-xl5"/>
+                                                            <constraint firstItem="niQ-mw-RBU" firstAttribute="width" secondItem="niQ-mw-RBU" secondAttribute="height" id="C0X-CO-gMw"/>
+                                                            <constraint firstItem="yMt-yE-2HC" firstAttribute="top" secondItem="f4V-Zd-iYY" secondAttribute="top" constant="-2" id="Dht-S4-RFd"/>
+                                                            <constraint firstItem="f4V-Zd-iYY" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="NG7-qS-njl" secondAttribute="leading" constant="20" id="EfI-5E-z6t"/>
+                                                            <constraint firstItem="Xt1-wB-5jN" firstAttribute="width" secondItem="Xt1-wB-5jN" secondAttribute="height" id="Gcw-x9-kpj"/>
+                                                            <constraint firstItem="yMt-yE-2HC" firstAttribute="leading" secondItem="f4V-Zd-iYY" secondAttribute="leading" constant="-2" id="GeY-lp-P1D"/>
+                                                            <constraint firstItem="IUM-L7-fqo" firstAttribute="width" secondItem="IUM-L7-fqo" secondAttribute="height" id="NRf-2R-0sY"/>
+                                                            <constraint firstItem="niQ-mw-RBU" firstAttribute="trailing" secondItem="f4V-Zd-iYY" secondAttribute="trailing" constant="2" id="U76-gQ-ZZ7"/>
+                                                            <constraint firstItem="f4V-Zd-iYY" firstAttribute="top" secondItem="NG7-qS-njl" secondAttribute="top" constant="8" id="YGv-cp-Sgf"/>
+                                                            <constraint firstItem="niQ-mw-RBU" firstAttribute="width" secondItem="niQ-mw-RBU" secondAttribute="height" id="a0V-il-D07"/>
+                                                            <constraint firstItem="IUM-L7-fqo" firstAttribute="top" secondItem="f4V-Zd-iYY" secondAttribute="top" constant="-2" id="aBA-ut-3yd"/>
+                                                            <constraint firstItem="niQ-mw-RBU" firstAttribute="width" secondItem="niQ-mw-RBU" secondAttribute="height" id="czv-1W-Pza"/>
+                                                            <constraint firstItem="niQ-mw-RBU" firstAttribute="width" secondItem="yMt-yE-2HC" secondAttribute="width" id="ecw-A3-4fu"/>
+                                                            <constraint firstItem="f4V-Zd-iYY" firstAttribute="centerX" secondItem="NG7-qS-njl" secondAttribute="centerX" id="eh4-6M-8Js"/>
+                                                            <constraint firstItem="Xt1-wB-5jN" firstAttribute="width" secondItem="yMt-yE-2HC" secondAttribute="width" id="ujK-gu-UAL"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4G-bW-EGe">
+                                                        <rect key="frame" x="0.0" y="563" width="375" height="55"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a4h-x5-COe">
                                                                 <rect key="frame" x="20" y="0.0" width="335" height="50"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
@@ -147,9 +211,9 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n73-GU-j8x">
-                                                        <rect key="frame" x="0.0" y="255" width="375" height="75"/>
+                                                        <rect key="frame" x="0.0" y="618" width="375" height="75"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bRZ-4Z-DEJ">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bRZ-4Z-DEJ">
                                                                 <rect key="frame" x="20" y="5" width="335" height="50"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
@@ -174,9 +238,6 @@
                                                         </constraints>
                                                     </view>
                                                 </subviews>
-                                                <constraints>
-                                                    <constraint firstItem="vrz-UO-PDk" firstAttribute="width" secondItem="bQd-8A-8hf" secondAttribute="width" id="N3C-LY-d1y"/>
-                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -200,6 +261,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="8yo-Sy-Oxb"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="edw-lO-NVl" secondAttribute="bottom" id="9bx-Fp-MtP"/>
@@ -207,14 +269,15 @@
                             <constraint firstItem="edw-lO-NVl" firstAttribute="trailing" secondItem="8yo-Sy-Oxb" secondAttribute="trailing" id="Wzg-67-vjz"/>
                             <constraint firstItem="edw-lO-NVl" firstAttribute="top" secondItem="8yo-Sy-Oxb" secondAttribute="top" id="sAk-S7-Gts"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="8yo-Sy-Oxb"/>
                     </view>
                     <connections>
                         <outlet property="cannotScanButton" destination="bRZ-4Z-DEJ" id="O51-k2-JJY"/>
                         <outlet property="closeButton" destination="1PP-lU-Ags" id="cwn-nr-esg"/>
                         <outlet property="codeImageView" destination="NFT-6Y-5rt" id="0FH-o1-GBM"/>
                         <outlet property="informationLabel" destination="y2w-7m-BE3" id="uXB-RC-Ppc"/>
-                        <outlet property="qrCodeContainerView" destination="vrz-UO-PDk" id="mMS-rd-ESe"/>
+                        <outlet property="qrCodeContainerView" destination="vrz-UO-PDk" id="64E-48-YIv"/>
+                        <outlet property="qrCodeReaderContainerView" destination="f4V-Zd-iYY" id="fg8-0P-GG3"/>
+                        <outlet property="qrCodeScannerContainerView" destination="NG7-qS-njl" id="xmO-wT-3X5"/>
                         <outlet property="scanButtonContainerView" destination="s4G-bW-EGe" id="TL4-jJ-EDC"/>
                         <outlet property="scanCodeButton" destination="a4h-x5-COe" id="8Cl-iJ-be8"/>
                         <outlet property="titleLabel" destination="VsP-5V-z35" id="t5i-0x-a7m"/>

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
@@ -36,6 +36,9 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var informationLabel: UILabel!
     
+    @IBOutlet private weak var scanTitleView: UIView!
+    @IBOutlet private weak var scanTitleLabel: UILabel!
+    
     @IBOutlet private weak var codeImageView: UIImageView!
     
     @IBOutlet private weak var scanCodeButton: UIButton!
@@ -201,17 +204,24 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
     private func renderLoadedWithoutQRCodeData(viewData: KeyVerificationVerifyByScanningViewData) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         
-        self.title = viewData.verificationKind.verificationTitle
-        self.titleLabel.text = VectorL10n.authenticationQrLoginStartTitle
+        // We don't have a QR code to display
         self.qrCodeContainerView.isHidden = true
+        // We will display a QR code scanner view, so no need to display the scan button
         self.scanButtonContainerView.isHidden = true
-        
+                
         if viewData.showScanAction == false {
+            self.title = viewData.verificationKind.verificationTitle
+            self.titleLabel.text = viewData.verificationKind.verificationTitle
             // Update the copy if QR code scanning is not possible at all
             self.informationLabel.text = VectorL10n.keyVerificationVerifyQrCodeEmojiInformation
             self.cannotScanButton.setTitle(VectorL10n.keyVerificationVerifyQrCodeStartEmojiAction, for: .normal)
         } else {
-            self.informationLabel.text = VectorL10n.authenticationQrLoginStartSubtitle
+            // For this case, we don't want a navtitle
+            self.title = nil
+            self.titleView.isHidden = true
+            self.scanTitleLabel.text = VectorL10n.deviceVerificationScanQrCodeTitle
+            self.scanTitleView.isHidden = false
+            self.informationLabel.text = VectorL10n.deviceVerificationScanQrCodeInformation
             
             addQRCodeReaderView()
         }
@@ -219,10 +229,7 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
     
     private func renderLoaded(viewData: KeyVerificationVerifyByScanningViewData) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
-        
-        self.qrCodeContainerView.isHidden = false
-        self.scanButtonContainerView.isHidden = false
-        
+    
         let hideQRCodeImage: Bool
         
         if let qrCodePayloadData = viewData.qrCodeData {
@@ -256,8 +263,6 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
             self.scanCodeButton.isHidden = false
             self.informationLabel.text = informationText
         }
-        
-        removeQRCodeReaderView()
     }
     
     private func render(error: Error) {

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
@@ -27,8 +27,6 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
     
     // MARK: Outlets
 
-    @IBOutlet private weak var scrollView: UIScrollView!
-    
     @IBOutlet private weak var closeButton: UIButton!
     
     @IBOutlet private weak var titleView: UIView!
@@ -36,8 +34,7 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var informationLabel: UILabel!
     
-    @IBOutlet private weak var scanTitleView: UIView!
-    @IBOutlet private weak var scanTitleLabel: UILabel!
+    @IBOutlet private weak var closeButtonContainer: UIView!
     
     @IBOutlet private weak var codeImageView: UIImageView!
     
@@ -141,12 +138,10 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         let cancelBarButtonItem = MXKBarButtonItem(title: VectorL10n.cancel, style: .plain) { [weak self] in
             self?.cancelButtonAction()
         }
-        
-        self.titleView.isHidden = self.navigationController != nil
-        
+                
         self.navigationItem.rightBarButtonItem = cancelBarButtonItem
+        self.closeButtonContainer.isHidden = self.navigationController != nil
         
-        self.title = VectorL10n.keyVerificationVerifyQrCodeTitle
         self.titleLabel.text = VectorL10n.keyVerificationVerifyQrCodeTitle
         self.informationLabel.text = VectorL10n.keyVerificationVerifyQrCodeInformation
         
@@ -161,7 +156,7 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         switch viewState {
         case .loading:
             self.renderLoading()
-        case .loaded(viewData: let viewData) where viewData.qrCodeData == nil:
+        case .loaded(viewData: let viewData) where viewData.qrCodeData == nil && viewData.showScanAction:
             self.renderLoadedWithoutQRCodeData(viewData: viewData)
         case .loaded(viewData: let viewData):
             self.renderLoaded(viewData: viewData)
@@ -209,22 +204,22 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         // We will display a QR code scanner view, so no need to display the scan button
         self.scanButtonContainerView.isHidden = true
                 
-        if viewData.showScanAction == false {
-            self.title = viewData.verificationKind.verificationTitle
-            self.titleLabel.text = viewData.verificationKind.verificationTitle
-            // Update the copy if QR code scanning is not possible at all
-            self.informationLabel.text = VectorL10n.keyVerificationVerifyQrCodeEmojiInformation
-            self.cannotScanButton.setTitle(VectorL10n.keyVerificationVerifyQrCodeStartEmojiAction, for: .normal)
-        } else {
-            // For this case, we don't want a navtitle
-            self.title = nil
-            self.titleView.isHidden = true
-            self.scanTitleLabel.text = VectorL10n.deviceVerificationScanQrCodeTitle
-            self.scanTitleView.isHidden = false
-            self.informationLabel.text = VectorL10n.deviceVerificationScanQrCodeInformation
-            
-            addQRCodeReaderView()
+        self.titleLabel.text = VectorL10n.keyVerificationScanQrCodeTitle
+        
+        let informationText: String
+        switch viewData.verificationKind {
+        case .user:
+            informationText = VectorL10n.keyVerificationScanQrCodeInformationOtherUser
+        case .newSession:
+            informationText = VectorL10n.keyVerificationScanQrCodeInformationNewSession
+        case .otherSession:
+            informationText = VectorL10n.keyVerificationScanQrCodeInformationOtherSession
+        default:
+            informationText = VectorL10n.keyVerificationScanQrCodeInformationOtherDevice
         }
+        self.informationLabel.text = informationText
+        
+        addQRCodeReaderView()
     }
     
     private func renderLoaded(viewData: KeyVerificationVerifyByScanningViewData) {
@@ -239,7 +234,6 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
             hideQRCodeImage = true
         }
         
-        self.title = viewData.verificationKind.verificationTitle
         self.titleLabel.text = viewData.verificationKind.verificationTitle
         self.qrCodeContainerView.isHidden = hideQRCodeImage
         self.scanButtonContainerView.isHidden = !viewData.showScanAction

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
@@ -149,8 +149,9 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         
         // Hide until we have the type of the verification request
         self.scanCodeButton.isHidden = true
-
         self.cannotScanButton.setTitle(VectorL10n.keyVerificationVerifyQrCodeCannotScanAction, for: .normal)
+
+        removeQRCodeReaderView()
     }
 
     private func render(viewState: KeyVerificationVerifyByScanningViewState) {
@@ -176,6 +177,27 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         self.activityPresenter.presentActivityIndicator(on: self.view, animated: true)
     }
     
+    private func addQRCodeReaderView() {
+        if self.qrCodeReaderView == nil {
+            // configure QRCodeReaderView
+            let qrCodeReaderView = QRCodeReaderView()
+            qrCodeReaderView.didFoundData = { [weak self] data in
+                self?.viewModel.process(viewAction: .scannedCode(payloadData: data))
+            }
+            self.qrCodeReaderView = qrCodeReaderView
+            self.qrCodeReaderContainerView.vc_addSubViewMatchingParent(qrCodeReaderView)
+        }
+        self.qrCodeScannerContainerView.isHidden = false
+    }
+    
+    private func removeQRCodeReaderView() {
+        if let qrCodeReaderView {
+            qrCodeReaderView.removeFromSuperview()
+            self.qrCodeReaderView = nil
+        }
+        self.qrCodeScannerContainerView.isHidden = true
+    }
+    
     private func renderLoadedWithoutQRCodeData(viewData: KeyVerificationVerifyByScanningViewData) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         
@@ -183,7 +205,6 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         self.titleLabel.text = VectorL10n.authenticationQrLoginStartTitle
         self.qrCodeContainerView.isHidden = true
         self.scanButtonContainerView.isHidden = true
-        self.qrCodeScannerContainerView.isHidden = false
         
         if viewData.showScanAction == false {
             // Update the copy if QR code scanning is not possible at all
@@ -192,15 +213,7 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         } else {
             self.informationLabel.text = VectorL10n.authenticationQrLoginStartSubtitle
             
-            if self.qrCodeReaderView == nil {
-                // configure QRCodeReaderView
-                let qrCodeReaderView = QRCodeReaderView()
-                qrCodeReaderView.didFoundData = { [weak self] data in
-                    self?.viewModel.process(viewAction: .scannedCode(payloadData: data))
-                }
-                self.qrCodeReaderView = qrCodeReaderView
-                self.qrCodeReaderContainerView.vc_addSubViewMatchingParent(qrCodeReaderView)
-            }
+            addQRCodeReaderView()
         }
     }
     
@@ -209,7 +222,6 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         
         self.qrCodeContainerView.isHidden = false
         self.scanButtonContainerView.isHidden = false
-        qrCodeScannerContainerView.isHidden = true
         
         let hideQRCodeImage: Bool
         
@@ -245,10 +257,7 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
             self.informationLabel.text = informationText
         }
         
-        if let qrCodeReaderView {
-            qrCodeReaderView.removeFromSuperview()
-            self.qrCodeReaderView = nil
-        }
+        removeQRCodeReaderView()
     }
     
     private func render(error: Error) {

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewModel.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewModel.swift
@@ -77,7 +77,7 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
     
     private func loadData() {
         
-        let qrCodePlayloadData: Data?
+        let qrCodePayloadData: Data?
         let canShowScanAction: Bool
         
         self.qrCodeTransaction = self.keyVerificationManager.qrCodeTransaction(withTransactionId: self.keyVerificationRequest.requestId)
@@ -85,19 +85,19 @@ final class KeyVerificationVerifyByScanningViewModel: KeyVerificationVerifyBySca
         if let supportedVerificationMethods = self.keyVerificationRequest.myMethods {
             
             if let qrCodeData = self.qrCodeTransaction?.qrCodeData {
-                qrCodePlayloadData = self.qrCodeDataCoder.encode(qrCodeData)
+                qrCodePayloadData = self.qrCodeDataCoder.encode(qrCodeData)
             } else {
-                qrCodePlayloadData = nil
+                qrCodePayloadData = nil
             }
             
             canShowScanAction = self.canShowScanAction(from: supportedVerificationMethods)
         } else {
-            qrCodePlayloadData = nil
+            qrCodePayloadData = nil
             canShowScanAction = false
         }
         
         let viewData = KeyVerificationVerifyByScanningViewData(verificationKind: self.verificationKind,
-                                                               qrCodeData: qrCodePlayloadData,
+                                                               qrCodeData: qrCodePayloadData,
                                                                showScanAction: canShowScanAction)
         
         self.update(viewState: .loaded(viewData: viewData))

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="79A-qb-tmk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="79A-qb-tmk">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +11,7 @@
         <!--Key Verification Self Verify Wait View Controller-->
         <scene sceneID="a9K-1U-7Nm">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="79A-qb-tmk" customClass="KeyVerificationSelfVerifyWaitViewController" customModule="Riot" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="79A-qb-tmk" customClass="KeyVerificationSelfVerifyWaitViewController" customModule="Element" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tAM-kt-f0s">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -20,22 +20,28 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tIM-sl-gwE">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="518.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="562"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IlB-Ch-LEo">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="518.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="562"/>
                                                 <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Element on your other device" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-RJ-1qU">
+                                                        <rect key="frame" x="20" y="20" width="335" height="67"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d5Y-pj-XsI">
-                                                        <rect key="frame" x="20" y="20" width="335" height="84"/>
-                                                        <string key="text">Verify this session from one of your others sessions, granting it access to encrypted messages.
+                                                        <rect key="frame" x="20" y="117" width="335" height="84"/>
+                                                        <string key="text">You need to verify this session in order to read your secure message history. 
 
-Use the latest Riot on your other devices:</string>
+Open Element on one of your other devices and follow the instructions.</string>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ANK-XS-dY7">
-                                                        <rect key="frame" x="27.5" y="144" width="320" height="48"/>
+                                                        <rect key="frame" x="27.5" y="241" width="320" height="48"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="3at-ql-vhb">
                                                                 <rect key="frame" x="0.0" y="0.0" width="160" height="48"/>
@@ -66,14 +72,8 @@ Use the latest Riot on your other devices:</string>
                                                             <constraint firstAttribute="width" constant="320" id="TyM-5Y-YSw"/>
                                                         </constraints>
                                                     </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This works with Element and other cross-signing capable Matrix clients." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LnW-1H-Ltq">
-                                                        <rect key="frame" x="20" y="232" width="335" height="33.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="8oJ-o6-DLK">
-                                                        <rect key="frame" x="20" y="285.5" width="335" height="233"/>
+                                                        <rect key="frame" x="20" y="329" width="335" height="233"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dXT-cL-ukJ">
                                                                 <rect key="frame" x="0.0" y="0.0" width="335" height="114.5"/>
@@ -102,8 +102,14 @@ Use the latest Riot on your other devices:</string>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nf8-Ye-b9r">
                                                                 <rect key="frame" x="0.0" y="114.5" width="335" height="118.5"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OEt-k0-vgM" customClass="RoundedButton" customModule="Riot" customModuleProvider="target">
-                                                                        <rect key="frame" x="0.0" y="10" width="335" height="44"/>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you can't accessing an existing session" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ou-cM-K9C">
+                                                                        <rect key="frame" x="20" y="10" width="295" height="24.5"/>
+                                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
+                                                                        <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OEt-k0-vgM" customClass="RoundedButton" customModule="Element" customModuleProvider="target">
+                                                                        <rect key="frame" x="0.0" y="44.5" width="335" height="44"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="44" id="7ws-Nc-I7y"/>
                                                                         </constraints>
@@ -115,19 +121,13 @@ Use the latest Riot on your other devices:</string>
                                                                             <action selector="recoverSecretsButtonAction:" destination="79A-qb-tmk" eventType="touchUpInside" id="FY5-tR-dyT"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you can't accessing an existing session" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ou-cM-K9C">
-                                                                        <rect key="frame" x="20" y="64" width="295" height="24.5"/>
-                                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
-                                                                        <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
                                                                 </subviews>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="trailing" secondItem="4Ou-cM-K9C" secondAttribute="trailing" constant="20" id="6a1-gA-Cev"/>
-                                                                    <constraint firstAttribute="bottom" secondItem="4Ou-cM-K9C" secondAttribute="bottom" constant="30" id="X1c-Yc-qLh"/>
-                                                                    <constraint firstItem="4Ou-cM-K9C" firstAttribute="top" secondItem="OEt-k0-vgM" secondAttribute="bottom" constant="10" id="Y5b-Bf-IYu"/>
-                                                                    <constraint firstItem="OEt-k0-vgM" firstAttribute="top" secondItem="nf8-Ye-b9r" secondAttribute="top" constant="10" id="fvJ-vZ-MMa"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="OEt-k0-vgM" secondAttribute="bottom" constant="30" id="LgI-8r-jEC"/>
+                                                                    <constraint firstItem="4Ou-cM-K9C" firstAttribute="top" secondItem="nf8-Ye-b9r" secondAttribute="top" constant="10" id="Y5b-Bf-IYu"/>
+                                                                    <constraint firstItem="OEt-k0-vgM" firstAttribute="top" secondItem="4Ou-cM-K9C" secondAttribute="bottom" constant="10" id="fvJ-vZ-MMa"/>
                                                                     <constraint firstItem="OEt-k0-vgM" firstAttribute="leading" secondItem="nf8-Ye-b9r" secondAttribute="leading" id="loc-cf-E6p"/>
                                                                     <constraint firstItem="4Ou-cM-K9C" firstAttribute="leading" secondItem="nf8-Ye-b9r" secondAttribute="leading" constant="20" id="o3E-Q9-7h1"/>
                                                                     <constraint firstAttribute="trailing" secondItem="OEt-k0-vgM" secondAttribute="trailing" id="yQK-YS-7Yr"/>
@@ -145,16 +145,16 @@ Use the latest Riot on your other devices:</string>
                                                     <constraint firstAttribute="height" priority="250" id="72E-My-WHK"/>
                                                     <constraint firstItem="ANK-XS-dY7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="IlB-Ch-LEo" secondAttribute="leading" id="9BR-a1-3By"/>
                                                     <constraint firstAttribute="bottom" secondItem="8oJ-o6-DLK" secondAttribute="bottom" id="CB2-Nd-n2g"/>
-                                                    <constraint firstItem="LnW-1H-Ltq" firstAttribute="top" secondItem="ANK-XS-dY7" secondAttribute="bottom" constant="40" id="Mph-SR-U7u"/>
-                                                    <constraint firstAttribute="trailing" secondItem="LnW-1H-Ltq" secondAttribute="trailing" constant="20" id="NZH-JW-JVA"/>
                                                     <constraint firstItem="d5Y-pj-XsI" firstAttribute="leading" secondItem="IlB-Ch-LEo" secondAttribute="leading" constant="20" id="Okc-DX-xdE"/>
-                                                    <constraint firstItem="d5Y-pj-XsI" firstAttribute="top" secondItem="IlB-Ch-LEo" secondAttribute="top" constant="20" id="Pkt-ox-zZs"/>
+                                                    <constraint firstItem="d5Y-pj-XsI" firstAttribute="top" secondItem="aOD-RJ-1qU" secondAttribute="bottom" constant="30" id="Pkt-ox-zZs"/>
                                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ANK-XS-dY7" secondAttribute="trailing" id="RQI-kF-Z1h"/>
                                                     <constraint firstItem="8oJ-o6-DLK" firstAttribute="leading" secondItem="IlB-Ch-LEo" secondAttribute="leading" constant="20" id="RtP-rm-bjH"/>
-                                                    <constraint firstItem="LnW-1H-Ltq" firstAttribute="leading" secondItem="IlB-Ch-LEo" secondAttribute="leading" constant="20" id="VOi-rz-Qf1"/>
+                                                    <constraint firstAttribute="trailing" secondItem="aOD-RJ-1qU" secondAttribute="trailing" constant="20" id="ST6-T5-XSg"/>
+                                                    <constraint firstItem="aOD-RJ-1qU" firstAttribute="leading" secondItem="IlB-Ch-LEo" secondAttribute="leading" constant="20" id="e2Y-ak-D86"/>
+                                                    <constraint firstItem="aOD-RJ-1qU" firstAttribute="top" secondItem="IlB-Ch-LEo" secondAttribute="top" constant="20" id="fDO-Bh-1Gn"/>
                                                     <constraint firstItem="ANK-XS-dY7" firstAttribute="top" secondItem="d5Y-pj-XsI" secondAttribute="bottom" constant="40" id="gnp-AK-DYa"/>
                                                     <constraint firstItem="ANK-XS-dY7" firstAttribute="centerX" secondItem="IlB-Ch-LEo" secondAttribute="centerX" id="nEo-IT-GtP"/>
-                                                    <constraint firstItem="8oJ-o6-DLK" firstAttribute="top" secondItem="LnW-1H-Ltq" secondAttribute="bottom" constant="20" id="tLd-x1-rOB"/>
+                                                    <constraint firstItem="8oJ-o6-DLK" firstAttribute="top" secondItem="ANK-XS-dY7" secondAttribute="bottom" constant="40" id="tLd-x1-rOB"/>
                                                     <constraint firstAttribute="trailing" secondItem="8oJ-o6-DLK" secondAttribute="trailing" constant="20" id="vev-7p-7ua"/>
                                                 </constraints>
                                             </view>
@@ -178,6 +178,7 @@ Use the latest Riot on your other devices:</string>
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="GnW-bb-rsL"/>
                         <color key="backgroundColor" red="0.94509803920000002" green="0.96078431369999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="asO-rj-82y" firstAttribute="trailing" secondItem="GnW-bb-rsL" secondAttribute="trailing" id="Isw-tg-7go"/>
@@ -185,10 +186,8 @@ Use the latest Riot on your other devices:</string>
                             <constraint firstItem="GnW-bb-rsL" firstAttribute="top" secondItem="asO-rj-82y" secondAttribute="top" id="b3e-2d-oiV"/>
                             <constraint firstAttribute="bottomMargin" secondItem="asO-rj-82y" secondAttribute="bottom" id="wMk-Oq-DwP"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="GnW-bb-rsL"/>
                     </view>
                     <connections>
-                        <outlet property="additionalInformationLabel" destination="LnW-1H-Ltq" id="TJS-GC-ABf"/>
                         <outlet property="desktopClientImageView" destination="nrB-Kj-4zE" id="yl0-Ju-luK"/>
                         <outlet property="informationLabel" destination="d5Y-pj-XsI" id="TMb-bc-58a"/>
                         <outlet property="mobileClientImageView" destination="P0P-X4-uSQ" id="WtT-ix-yq8"/>
@@ -198,6 +197,7 @@ Use the latest Riot on your other devices:</string>
                         <outlet property="recoverSecretsAvailabilityLoadingLabel" destination="A4x-sK-d5C" id="n5k-IO-RkV"/>
                         <outlet property="recoverSecretsButton" destination="OEt-k0-vgM" id="RHU-ps-4m7"/>
                         <outlet property="recoverSecretsContainerView" destination="nf8-Ye-b9r" id="4az-pe-0Uc"/>
+                        <outlet property="titleLabel" destination="aOD-RJ-1qU" id="qvC-fk-TiU"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OMs-Ee-CjK" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.swift
@@ -129,7 +129,7 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
         self.desktopClientImageView.image = Asset.Images.monitor.image.withRenderingMode(.alwaysTemplate)
         self.mobileClientImageView.image = Asset.Images.smartphone.image.withRenderingMode(.alwaysTemplate)
                 
-        self.recoverSecretsAdditionalInformationLabel.text = VectorL10n.deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp
+        self.recoverSecretsAdditionalInformationLabel.text = VectorL10n.deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp(AppInfo.current.displayName)
     }
 
     private func render(viewState: KeyVerificationSelfVerifyWaitViewState) {

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.swift
@@ -30,13 +30,12 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
     
     // MARK: Outlets
     
+    @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var informationLabel: UILabel!
     
     @IBOutlet private weak var desktopClientImageView: UIImageView!
     @IBOutlet private weak var mobileClientImageView: UIImageView!
-    
-    @IBOutlet private weak var additionalInformationLabel: UILabel!
-    
+        
     @IBOutlet private weak var recoverSecretsAvailabilityLoadingContainerView: UIView!
     @IBOutlet private weak var recoverSecretsAvailabilityLoadingLabel: UILabel!
     @IBOutlet private weak var recoverSecretsAvailabilityActivityIndicatorView: UIActivityIndicatorView!
@@ -70,7 +69,6 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
         super.viewDidLoad()
         
         // Do any additional setup after loading the view.
-        
         self.setupViews()
         self.activityPresenter = ActivityIndicatorPresenter()
         self.errorPresenter = MXKErrorAlertPresentation()
@@ -96,11 +94,11 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
         if let navigationBar = self.navigationController?.navigationBar {
             theme.applyStyle(onNavigationBar: navigationBar)
         }
-        
-        self.informationLabel.textColor = theme.textPrimaryColor
+
+        self.titleLabel.textColor = theme.textPrimaryColor
+        self.informationLabel.textColor = theme.textSecondaryColor
         self.desktopClientImageView.tintColor = theme.tintColor
         self.mobileClientImageView.tintColor = theme.tintColor
-        self.additionalInformationLabel.textColor = theme.textPrimaryColor
         self.recoverSecretsAvailabilityLoadingLabel.textColor = theme.textSecondaryColor
         self.recoverSecretsAvailabilityActivityIndicatorView.color = theme.tintColor
     }
@@ -125,16 +123,13 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
             self.cancelBarButtonItem = cancelBarButtonItem
         }
         
-        self.title = VectorL10n.deviceVerificationSelfVerifyWaitTitle
-        
-        self.informationLabel.text = VectorL10n.deviceVerificationSelfVerifyWaitInformation(AppInfo.current.displayName)
+        self.titleLabel.text = VectorL10n.deviceVerificationSelfVerifyOpenOnOtherDeviceTitle(AppInfo.current.displayName)
+        self.informationLabel.text = VectorL10n.deviceVerificationSelfVerifyOpenOnOtherDeviceInformation
         
         self.desktopClientImageView.image = Asset.Images.monitor.image.withRenderingMode(.alwaysTemplate)
         self.mobileClientImageView.image = Asset.Images.smartphone.image.withRenderingMode(.alwaysTemplate)
-        
-        self.additionalInformationLabel.text = VectorL10n.deviceVerificationSelfVerifyWaitAdditionalInformation(AppInfo.current.displayName)
-        
-        self.recoverSecretsAdditionalInformationLabel.text = VectorL10n.deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalInformation
+                
+        self.recoverSecretsAdditionalInformationLabel.text = VectorL10n.deviceVerificationSelfVerifyWaitRecoverSecretsAdditionalHelp
     }
 
     private func render(viewState: KeyVerificationSelfVerifyWaitViewState) {
@@ -168,7 +163,6 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
     private func renderLoaded(viewData: KeyVerificationSelfVerifyWaitViewData) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         
-        self.title = viewData.isNewSignIn ? VectorL10n.deviceVerificationSelfVerifyWaitNewSignInTitle : VectorL10n.deviceVerificationSelfVerifyWaitTitle
         self.cancelBarButtonItem?.title = viewData.isNewSignIn ? VectorL10n.skip : VectorL10n.cancel
    
         let hideRecoverSecrets: Bool

--- a/Riot/Modules/QRCode/Reader/QRCodeReaderView.swift
+++ b/Riot/Modules/QRCode/Reader/QRCodeReaderView.swift
@@ -1,0 +1,215 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+import ZXingObjC
+import Combine
+
+final class QRCodeReaderView: UIView {
+    
+    // MARK: Public
+    
+    var didFoundData: (Data) -> Void = { _ in }
+    
+    // MARK: Private
+    
+    private lazy var zxCapture: ZXCapture = ZXCapture()
+    private var captureSizeTransform: CGAffineTransform?
+    private var isScanning: Bool = false
+    private var isFirstApplyOrientation: Bool = false
+
+    private var rotationObserver: AnyCancellable?
+    
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    deinit {
+        self.zxCapture.layer.removeFromSuperlayer()
+        self.zxCapture.hard_stop()
+    }
+        
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        
+        if superview == nil {
+            stopScanning()
+        }
+    }
+    
+    // MARK: - Public
+    
+    func startScanning() {
+        self.zxCapture.start()
+        isScanning = true
+    }
+    
+    func stopScanning() {
+        self.zxCapture.stop()
+        isScanning = false
+    }
+    
+    //  MARK: - Private
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        guard isFirstApplyOrientation == false else {
+            return
+        }
+        
+        isFirstApplyOrientation = true
+        applyOrientation()
+    }
+    
+    private func setup() {
+        isUserInteractionEnabled = true
+        clipsToBounds = true
+        self.setupQRCodeReaderView()
+        
+        rotationObserver = NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)
+            .sink(receiveValue: { [weak self] _ in
+                self?.applyOrientation()
+            })
+    }
+    
+    private func setupQRCodeReaderView() {
+        zxCapture.delegate = self
+        zxCapture.camera = zxCapture.back()
+        
+        zxCapture.layer.frame = self.bounds
+        self.layer.addSublayer(zxCapture.layer)
+    }
+    
+    private func applyOrientation() {
+        
+        let orientation = UIApplication.shared.statusBarOrientation
+        let captureRotation: Double
+        let scanRectRotation: Double
+        
+        switch orientation {
+        case .portrait:
+            captureRotation = 0
+            scanRectRotation = 90
+        case .landscapeLeft:
+            captureRotation = 90
+            scanRectRotation = 180
+        case .landscapeRight:
+            captureRotation = 270
+            scanRectRotation = 0
+        case .portraitUpsideDown:
+            captureRotation = 180
+            scanRectRotation = 270
+        default:
+            captureRotation = 0
+            scanRectRotation = 90
+        }
+        
+        applyRectOfInterest(orientation: orientation)
+        
+        let angleRadius = captureRotation / 180.0 * Double.pi
+        let captureTranform = CGAffineTransform(rotationAngle: CGFloat(angleRadius))
+        
+        zxCapture.transform = captureTranform
+        zxCapture.rotation = CGFloat(scanRectRotation)
+        zxCapture.layer.frame = self.bounds
+    }
+    
+    private func applyRectOfInterest(orientation: UIInterfaceOrientation) {
+        var transformedVideoRect = self.frame
+        let cameraSessionPreset = zxCapture.sessionPreset
+        
+        var scaleVideoX, scaleVideoY: CGFloat
+        var videoHeight, videoWidth: CGFloat
+        
+        // Currently support only for 1920x1080 || 1280x720
+        if cameraSessionPreset == AVCaptureSession.Preset.hd1920x1080.rawValue {
+            videoHeight = 1080.0
+            videoWidth = 1920.0
+        } else {
+            videoHeight = 720.0
+            videoWidth = 1280.0
+        }
+        
+        if orientation == UIInterfaceOrientation.portrait {
+            scaleVideoX = self.frame.width / videoHeight
+            scaleVideoY = self.frame.height / videoWidth
+            
+            // Convert CGPoint under portrait mode to map with orientation of image
+            // because the image will be cropped before rotate
+            // reference: https://github.com/TheLevelUp/ZXingObjC/issues/222
+            let realX = transformedVideoRect.origin.y
+            let realY = self.frame.size.width - transformedVideoRect.size.width - transformedVideoRect.origin.x
+            let realWidth = transformedVideoRect.size.height
+            let realHeight = transformedVideoRect.size.width
+            transformedVideoRect = CGRect(x: realX, y: realY, width: realWidth, height: realHeight)
+            
+        } else {
+            scaleVideoX = self.frame.width / videoWidth
+            scaleVideoY = self.frame.height / videoHeight
+        }
+        
+        captureSizeTransform = CGAffineTransform(scaleX: 1.0/scaleVideoX, y: 1.0/scaleVideoY)
+        
+        guard let _captureSizeTransform = captureSizeTransform else {
+            return
+        }
+        
+        let transformRect = transformedVideoRect.applying(_captureSizeTransform)
+        zxCapture.scanRect = transformRect
+    }
+    
+}
+
+
+// MARK: - ZXCaptureDelegate
+extension QRCodeReaderView: ZXCaptureDelegate {
+    
+    func captureCameraIsReady(_ capture: ZXCapture!) {
+        isScanning = true
+    }
+    
+    func captureResult(_ capture: ZXCapture!, result: ZXResult!) {
+        guard let zxResult = result, isScanning == true else {
+            return
+        }
+        
+        guard zxResult.barcodeFormat == kBarcodeFormatQRCode else {
+            return
+        }
+        
+        self.stopScanning()
+        
+        if let bytes = result.resultMetadata.object(forKey: kResultMetadataTypeByteSegments.rawValue) as? NSArray,
+            let byteArray = bytes.firstObject as? ZXByteArray {
+            
+            let data = Data(bytes: UnsafeRawPointer(byteArray.array), count: Int(byteArray.length))
+            
+            self.didFoundData(data)
+        }
+    }
+}

--- a/Riot/Modules/QRCode/Reader/QRCodeReaderViewController.swift
+++ b/Riot/Modules/QRCode/Reader/QRCodeReaderViewController.swift
@@ -15,7 +15,6 @@
  */
 
 import UIKit
-import ZXingObjC
 
 protocol QRCodeReaderViewControllerDelegate: AnyObject {
     func qrCodeReaderViewController(_ viewController: QRCodeReaderViewController, didFound payloadData: Data)
@@ -40,10 +39,7 @@ final class QRCodeReaderViewController: UIViewController {
     private var theme: Theme!
     private var errorPresenter: MXKErrorPresentation!
     
-    private lazy var zxCapture: ZXCapture = ZXCapture()
-    private var captureSizeTransform: CGAffineTransform?
-    private var isScanning: Bool = false
-    private var isFirstApplyOrientation: Bool = false
+    private var qrCodeReaderView: QRCodeReaderView!
     
     // MARK: Public
     
@@ -56,12 +52,7 @@ final class QRCodeReaderViewController: UIViewController {
         viewController.theme = ThemeService.shared().theme
         return viewController
     }
-    
-    deinit {
-        self.zxCapture.layer.removeFromSuperlayer()
-        self.zxCapture.hard_stop()
-    }
-    
+        
     // MARK: - Life cycle
     
     override func viewDidLoad() {
@@ -92,40 +83,14 @@ final class QRCodeReaderViewController: UIViewController {
         return self.theme.statusBarStyle
     }
     
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        guard isFirstApplyOrientation == false else {
-            return
-        }
-        
-        isFirstApplyOrientation = true
-        applyOrientation()
-    }
-    
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        
-        coordinator.animate(alongsideTransition: { (context) in
-            // do nothing
-        }, completion: { [weak self] (context) in
-            guard let self = self else {
-                return
-            }
-            self.applyOrientation()
-        })
-    }
-    
     // MARK: - Public
     
     func startScanning() {
-        self.zxCapture.start()
-        isScanning = true
+        qrCodeReaderView.startScanning()
     }
     
     func stopScanning() {
-        self.zxCapture.stop()
-        isScanning = false
+        qrCodeReaderView.stopScanning()
     }
     
     // MARK: - Private
@@ -145,127 +110,20 @@ final class QRCodeReaderViewController: UIViewController {
     }
     
     private func setupViews() {
-        self.setupQRCodeReaderView()
+        let qrCodeReaderView = QRCodeReaderView()
+        qrCodeReaderView.didFoundData = qrCodeReader(didFound:)
+        self.qrCodeReaderView = qrCodeReaderView
+        
+        self.codeReaderContainerView.vc_addSubViewMatchingParent(qrCodeReaderView)
     }
     
-    private func setupQRCodeReaderView() {
-        zxCapture.delegate = self
-        zxCapture.camera = zxCapture.back()
-        
-        zxCapture.layer.frame = codeReaderContainerView.bounds
-        codeReaderContainerView.layer.addSublayer(zxCapture.layer)
-    }
-    
-    private func applyOrientation() {
-        
-        let orientation = UIApplication.shared.statusBarOrientation
-        let captureRotation: Double
-        let scanRectRotation: Double
-        
-        switch orientation {
-        case .portrait:
-            captureRotation = 0
-            scanRectRotation = 90
-        case .landscapeLeft:
-            captureRotation = 90
-            scanRectRotation = 180
-        case .landscapeRight:
-            captureRotation = 270
-            scanRectRotation = 0
-        case .portraitUpsideDown:
-            captureRotation = 180
-            scanRectRotation = 270
-        default:
-            captureRotation = 0
-            scanRectRotation = 90
-        }
-        
-        applyRectOfInterest(orientation: orientation)
-        
-        let angleRadius = captureRotation / 180.0 * Double.pi
-        let captureTranform = CGAffineTransform(rotationAngle: CGFloat(angleRadius))
-        
-        zxCapture.transform = captureTranform
-        zxCapture.rotation = CGFloat(scanRectRotation)
-        zxCapture.layer.frame = codeReaderContainerView.frame
-    }
-    
-    private func applyRectOfInterest(orientation: UIInterfaceOrientation) {
-        guard var transformedVideoRect = codeReaderContainerView?.frame,
-            let cameraSessionPreset = zxCapture.sessionPreset
-            else { return }
-        
-        var scaleVideoX, scaleVideoY: CGFloat
-        var videoHeight, videoWidth: CGFloat
-        
-        // Currently support only for 1920x1080 || 1280x720
-        if cameraSessionPreset == AVCaptureSession.Preset.hd1920x1080.rawValue {
-            videoHeight = 1080.0
-            videoWidth = 1920.0
-        } else {
-            videoHeight = 720.0
-            videoWidth = 1280.0
-        }
-        
-        if orientation == UIInterfaceOrientation.portrait {
-            scaleVideoX = self.view.frame.width / videoHeight
-            scaleVideoY = self.view.frame.height / videoWidth
-            
-            // Convert CGPoint under portrait mode to map with orientation of image
-            // because the image will be cropped before rotate
-            // reference: https://github.com/TheLevelUp/ZXingObjC/issues/222
-            let realX = transformedVideoRect.origin.y
-            let realY = self.view.frame.size.width - transformedVideoRect.size.width - transformedVideoRect.origin.x
-            let realWidth = transformedVideoRect.size.height
-            let realHeight = transformedVideoRect.size.width
-            transformedVideoRect = CGRect(x: realX, y: realY, width: realWidth, height: realHeight)
-            
-        } else {
-            scaleVideoX = self.view.frame.width / videoWidth
-            scaleVideoY = self.view.frame.height / videoHeight
-        }
-        
-        captureSizeTransform = CGAffineTransform(scaleX: 1.0/scaleVideoX, y: 1.0/scaleVideoY)
-        
-        guard let _captureSizeTransform = captureSizeTransform else {
-            return
-        }
-        
-        let transformRect = transformedVideoRect.applying(_captureSizeTransform)
-        zxCapture.scanRect = transformRect
+    private func qrCodeReader(didFound data: Data) {
+        self.delegate?.qrCodeReaderViewController(self, didFound: data)
     }
     
     // MARK: - Actions
     
     @IBAction private func closeButtonAction(_ sender: Any) {
         self.delegate?.qrCodeReaderViewControllerDidCancel(self)
-    }
-}
-
-// MARK: - ZXCaptureDelegate
-extension QRCodeReaderViewController: ZXCaptureDelegate {
-    
-    func captureCameraIsReady(_ capture: ZXCapture!) {
-        isScanning = true
-    }
-    
-    func captureResult(_ capture: ZXCapture!, result: ZXResult!) {
-        guard let zxResult = result, isScanning == true else {
-            return
-        }
-        
-        guard zxResult.barcodeFormat == kBarcodeFormatQRCode else {
-            return
-        }
-        
-        self.stopScanning()
-        
-        if let bytes = result.resultMetadata.object(forKey: kResultMetadataTypeByteSegments.rawValue) as? NSArray,
-            let byteArray = bytes.firstObject as? ZXByteArray {
-            
-            let data = Data(bytes: UnsafeRawPointer(byteArray.array), count: Int(byteArray.length))
-            
-            self.delegate?.qrCodeReaderViewController(self, didFound: data)
-        }
     }
 }

--- a/changelog.d/3115.change
+++ b/changelog.d/3115.change
@@ -1,0 +1,1 @@
+Session verification: automatically starts scanning for a QR code if we do not have a QR code to display.


### PR DESCRIPTION
Fixes #3115 

When we try to verify a session, sometimes the device doesn't have a QR code to display. In this case, we want to allow the user to directly scan the QR code displayed on another device without breaking the verification flow.

Here is what we currently see in this case:
<img src="https://user-images.githubusercontent.com/4334885/220158196-187759c5-3e50-411e-99a4-f534a8a89d64.PNG" width=50% height=50%>

Here is the implemented design:
<img src="https://user-images.githubusercontent.com/4334885/220156273-808e3c8e-6fec-4a49-9304-7781066338eb.PNG" width=50% height=50%>

<img src="https://user-images.githubusercontent.com/4334885/220156301-8316121c-cc25-4138-a0f0-a85f45707629.PNG" width=50% height=50%>

