### PR TITLE
Direct Message: manage encrypted DM in case of invite by email

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2297,7 +2297,7 @@ Tap the + to start adding people.";
 "room_invites_empty_view_information" = "This is where your invites appear.";
 
 "room_waiting_other_participants_title" = "Waiting for users to join %@";
-"room_waiting_other_participants_message" = "Once all users invited have joined %@, you will be able to chat and the room will be end-to end encrypted";
+"room_waiting_other_participants_message" = "Once all invited users have joined %@, you will be able to chat and the room will be end to end encrypted";
 
 // MARK: - Space Selector
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2297,7 +2297,7 @@ Tap the + to start adding people.";
 "room_invites_empty_view_information" = "This is where your invites appear.";
 
 "room_waiting_other_participants_title" = "Waiting for users to join %@";
-"room_waiting_other_participants_message" = "Once all invited users have joined %@, you will be able to chat and the room will be end to end encrypted";
+"room_waiting_other_participants_message" = "Once invited users have joined %@, you will be able to chat and the room will be end-to-end encrypted";
 
 // MARK: - Space Selector
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -365,6 +365,7 @@
 "room_creation_invite_another_user" = "User ID, name or email";
 "room_creation_error_invite_user_by_email_without_identity_server" = "No identity server is configured so you cannot add a participant with an email.";
 "room_creation_dm_error" = "We couldn't create your DM. Please check the users you want to invite and try again.";
+"room_creation_only_one_email_invite" = "You can only invite one email at a time";
 
 // Room recents
 "room_recents_directory_section" = "ROOM DIRECTORY";
@@ -2294,6 +2295,9 @@ Tap the + to start adding people.";
 
 "room_invites_empty_view_title" = "Nothing new.";
 "room_invites_empty_view_information" = "This is where your invites appear.";
+
+"room_waiting_other_participants_title" = "Waiting for users to join %@";
+"room_waiting_other_participants_message" = "Once all users invited have joined %@, you will be able to chat and the room will be end-to end encrypted";
 
 // MARK: - Space Selector
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -6627,7 +6627,7 @@ public class VectorL10n: NSObject {
   public static var roomUnsentMessagesUnknownDevicesNotification: String { 
     return VectorL10n.tr("Vector", "room_unsent_messages_unknown_devices_notification") 
   }
-  /// Once all users invited have joined %@, you will be able to chat and the room will be end-to end encrypted
+  /// Once invited users have joined %@, you will be able to chat and the room will be end-to-end encrypted
   public static func roomWaitingOtherParticipantsMessage(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "room_waiting_other_participants_message", p1)
   }

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -5267,6 +5267,10 @@ public class VectorL10n: NSObject {
   public static var roomCreationNameTitle: String { 
     return VectorL10n.tr("Vector", "room_creation_name_title") 
   }
+  /// You can only invite one email at a time
+  public static var roomCreationOnlyOneEmailInvite: String { 
+    return VectorL10n.tr("Vector", "room_creation_only_one_email_invite") 
+  }
   /// (e.g. @bob:homeserver1; @john:homeserver2...)
   public static var roomCreationParticipantsPlaceholder: String { 
     return VectorL10n.tr("Vector", "room_creation_participants_placeholder") 
@@ -6622,6 +6626,14 @@ public class VectorL10n: NSObject {
   /// Message failed to send due to unknown sessions being present.
   public static var roomUnsentMessagesUnknownDevicesNotification: String { 
     return VectorL10n.tr("Vector", "room_unsent_messages_unknown_devices_notification") 
+  }
+  /// Once all users invited have joined %@, you will be able to chat and the room will be end-to end encrypted
+  public static func roomWaitingOtherParticipantsMessage(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "room_waiting_other_participants_message", p1)
+  }
+  /// Waiting for users to join %@
+  public static func roomWaitingOtherParticipantsTitle(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "room_waiting_other_participants_title", p1)
   }
   /// End-to-end encryption is in beta and may not be reliable.\n\nYou should not yet trust it to secure data.\n\nDevices will not yet be able to decrypt history from before they joined the room.\n\nEncrypted messages will not be visible on clients that do not yet implement encryption.
   public static var roomWarningAboutEncryption: String { 

--- a/Riot/Modules/Room/RoomInfo/RoomInfoCoordinator.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoCoordinator.swift
@@ -31,6 +31,7 @@ final class RoomInfoCoordinator: NSObject, RoomInfoCoordinatorType {
     private let parentSpaceId: String?
     private let initialSection: RoomInfoSection
     private let dismissOnCancel: Bool
+    private let canAddParticipants: Bool
     private weak var roomSettingsViewController: RoomSettingsViewController?
     
     private lazy var segmentedViewController: SegmentedViewController = {
@@ -43,6 +44,8 @@ final class RoomInfoCoordinator: NSObject, RoomInfoCoordinatorType {
         participants.parentSpaceId = self.parentSpaceId
         participants.delegate = self
         participants.screenTracker = AnalyticsScreenTracker(screen: .roomMembers)
+        participants.showInviteUserFab = self.canAddParticipants
+        
         
         let files = RoomFilesViewController()
         files.finalizeInit()
@@ -105,6 +108,7 @@ final class RoomInfoCoordinator: NSObject, RoomInfoCoordinatorType {
         self.room = parameters.room
         self.parentSpaceId = parameters.parentSpaceId
         self.initialSection = parameters.initialSection
+        self.canAddParticipants = parameters.canAddParticipants
         self.dismissOnCancel = parameters.dismissOnCancel
     }    
     

--- a/Riot/Modules/Room/RoomInfo/RoomInfoCoordinatorParameters.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoCoordinatorParameters.swift
@@ -33,12 +33,14 @@ class RoomInfoCoordinatorParameters: NSObject {
     let parentSpaceId: String?
     let initialSection: RoomInfoSection
     let dismissOnCancel: Bool
+    let canAddParticipants: Bool
     
-    init(session: MXSession, room: MXRoom, parentSpaceId: String?, initialSection: RoomInfoSection, dismissOnCancel: Bool) {
+    init(session: MXSession, room: MXRoom, parentSpaceId: String?, initialSection: RoomInfoSection, canAddParticipants: Bool = true, dismissOnCancel: Bool) {
         self.session = session
         self.room = room
         self.parentSpaceId = parentSpaceId
         self.initialSection = initialSection
+        self.canAddParticipants = canAddParticipants
         self.dismissOnCancel = dismissOnCancel
         super.init()
     }
@@ -49,5 +51,9 @@ class RoomInfoCoordinatorParameters: NSObject {
     
     convenience init(session: MXSession, room: MXRoom, parentSpaceId: String?, initialSection: RoomInfoSection) {
         self.init(session: session, room: room, parentSpaceId: parentSpaceId, initialSection: initialSection, dismissOnCancel: false)
+    }
+
+    convenience init(session: MXSession, room: MXRoom, parentSpaceId: String?, initialSection: RoomInfoSection, canAddParticipants: Bool) {
+        self.init(session: session, room: room, parentSpaceId: parentSpaceId, initialSection: initialSection, canAddParticipants: canAddParticipants, dismissOnCancel: false)
     }
 }

--- a/Riot/Modules/Room/RoomViewController.h
+++ b/Riot/Modules/Room/RoomViewController.h
@@ -125,6 +125,8 @@ extern NSTimeInterval const kResizeComposerAnimationDuration;
 
 @property (nonatomic, strong, nullable) ComposerLinkActionBridgePresenter *composerLinkActionBridgePresenter;
 
+@property (weak, nonatomic, nullable) UIViewController *waitingOtherParticipantViewController;
+@property (nonatomic) BOOL isWaitingForOtherParticipants;
 
 /**
  Retrieve the live data source in cases where the timeline is not live.

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -185,6 +185,9 @@ static CGSize kThreadListBarButtonItemImageSize;
     
     // Time to display notification content in the timeline
     MXTaskProfile *notificationTaskProfile;
+    
+    // Observe kMXEventTypeStringRoomMember events
+    __weak id roomMemberEventListener;
 }
 
 @property (nonatomic, strong) RemoveJitsiWidgetView *removeJitsiWidgetView;
@@ -232,6 +235,9 @@ static CGSize kThreadListBarButtonItemImageSize;
 // to autoscroll to the bottom again or not. Instead we need to capture the
 // scroll state just before the layout change, and restore it after the layout.
 @property (nonatomic) BOOL wasScrollAtBottomBeforeLayout;
+
+// Check if we should wait for other participants
+@property (nonatomic, readonly) BOOL shouldWaitForOtherParticipants;
 
 @end
 
@@ -329,6 +335,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     
     _showMissedDiscussionsBadge = YES;
     _scrollToBottomHidden = YES;
+    _isWaitingForOtherParticipants = NO;
     
     // Listen to the event sent state changes
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventDidChangeSentState:) name:kMXEventDidChangeSentStateNotification object:nil];
@@ -372,7 +379,10 @@ static CGSize kThreadListBarButtonItemImageSize;
     
     // Prepare missed dicussion badge (if any)
     self.showMissedDiscussionsBadge = _showMissedDiscussionsBadge;
-    
+
+    // Refresh the waiting for other participants state
+    [self refreshWaitForOtherParticipantsState];
+
     // Set up the room title view according to the data source (if any)
     [self refreshRoomTitle];
     
@@ -1194,9 +1204,9 @@ static CGSize kThreadListBarButtonItemImageSize;
         
         BOOL canSend = (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsMessage:kMXEventTypeStringRoomMessage]);
         BOOL isRoomObsolete = self.roomDataSource.roomState.isObsolete;
-        BOOL isResourceLimitExceeded = [self.roomDataSource.mxSession.syncError.errcode isEqualToString:kMXErrCodeStringResourceLimitExceeded];
+        BOOL isResourceLimitExceeded = [self.roomDataSource.mxSession.syncError.errcode isEqualToString:kMXErrCodeStringResourceLimitExceeded];        
         
-        if (isRoomObsolete || isResourceLimitExceeded)
+        if (isRoomObsolete || isResourceLimitExceeded || _isWaitingForOtherParticipants)
         {
             roomInputToolbarViewClass = nil;
             shouldDismissContextualMenu = YES;
@@ -1532,6 +1542,8 @@ static CGSize kThreadListBarButtonItemImageSize;
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeSentStateNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeIdentifierNotification object:nil];
     
+    [self waitForOtherParticipant:NO];
+    
     [super destroy];
 }
 
@@ -1636,6 +1648,57 @@ static CGSize kThreadListBarButtonItemImageSize;
 - (BOOL)shouldShowLiveLocationSharingBannerView
 {
     return self.customizedRoomDataSource.isCurrentUserSharingActiveLocation;
+}
+
+#pragma mark - Wait for 3rd party invitee
+
+- (void)setIsWaitingForOtherParticipants:(BOOL)isWaitingForOtherParticipants
+{
+    if (_isWaitingForOtherParticipants == isWaitingForOtherParticipants)
+    {
+        return;
+    }
+
+    _isWaitingForOtherParticipants = isWaitingForOtherParticipants;
+    [self updateRoomInputToolbarViewClassIfNeeded];
+    
+    if (_isWaitingForOtherParticipants)
+    {
+        if (self->roomMemberEventListener == nil)
+        {
+            MXWeakify(self);
+            self->roomMemberEventListener = [self.roomDataSource.room listenToEventsOfTypes:@[kMXEventTypeStringRoomMember] onEvent:^(MXEvent *event, MXTimelineDirection direction, MXRoomState *roomState) {
+                MXStrongifyAndReturnIfNil(self);
+                if (direction != MXTimelineDirectionForwards)
+                {
+                    return;
+                }
+                [self refreshWaitForOtherParticipantsState];
+            }];
+        }
+    }
+    else
+    {
+        if (self->roomMemberEventListener != nil)
+        {
+            [self.roomDataSource.room removeListener:self->roomMemberEventListener];
+            self->roomMemberEventListener = nil;
+        }
+    }
+}
+
+- (BOOL)shouldWaitForOtherParticipants
+{
+    MXRoomState *roomState = self.roomDataSource.roomState;
+    BOOL isDirect = self.roomDataSource.room.isDirect;
+    
+    // Wait for the other participant only if it is a direct encrypted room with only one member waiting for a third party guest.
+    return (isDirect && roomState.isEncrypted && roomState.membersCount.members == 1 && roomState.thirdPartyInvites.count > 0);
+}
+
+- (void)refreshWaitForOtherParticipantsState
+{
+    [self waitForOtherParticipant:self.shouldWaitForOtherParticipants];
 }
 
 #pragma mark - Internals
@@ -1948,7 +2011,7 @@ static CGSize kThreadListBarButtonItemImageSize;
         
         [self refreshMissedDiscussionsCount:YES];
         
-        if (RiotSettings.shared.enableThreads)
+        if (RiotSettings.shared.enableThreads && !_isWaitingForOtherParticipants)
         {
             if (self.roomDataSource.threadId)
             {
@@ -2260,8 +2323,8 @@ static CGSize kThreadListBarButtonItemImageSize;
 
 - (void)showRoomInfoWithInitialSection:(RoomInfoSection)roomInfoSection animated:(BOOL)animated
 {
-    RoomInfoCoordinatorParameters *parameters = [[RoomInfoCoordinatorParameters alloc] initWithSession:self.roomDataSource.mxSession room:self.roomDataSource.room parentSpaceId:self.parentSpaceId initialSection:roomInfoSection];
-    
+    RoomInfoCoordinatorParameters *parameters = [[RoomInfoCoordinatorParameters alloc] initWithSession:self.roomDataSource.mxSession room:self.roomDataSource.room parentSpaceId:self.parentSpaceId initialSection:roomInfoSection canAddParticipants: !self.isWaitingForOtherParticipants];
+
     self.roomInfoCoordinatorBridgePresenter = [[RoomInfoCoordinatorBridgePresenter alloc] initWithParameters:parameters];
     
     self.roomInfoCoordinatorBridgePresenter.delegate = self;
@@ -7450,7 +7513,7 @@ static CGSize kThreadListBarButtonItemImageSize;
 
 - (void)updateThreadListBarButtonItem:(UIBarButtonItem *)barButtonItem with:(MXThreadingService *)service
 {
-    if (!service)
+    if (!service || _isWaitingForOtherParticipants)
     {
         return;
     }

--- a/Riot/Modules/Room/RoomViewController.swift
+++ b/Riot/Modules/Room/RoomViewController.swift
@@ -251,6 +251,50 @@ extension RoomViewController {
         composerLinkActionBridgePresenter = presenter
         presenter.present(from: self, animated: true)
     }
+    
+    @objc func showWaitingOtherParticipantHeader() {
+        let controller = VectorHostingController(rootView: RoomWaitingForMembers())
+        guard let headerView = controller.view else {
+            return
+        }
+        self.waitingOtherParticipantViewController = controller
+        self.addChild(controller)
+                
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.vc_addSubViewMatchingParent(headerView, withInsets: UIEdgeInsets(top: 9, left: 9, bottom: -9, right: -9))
+
+        self.bubblesTableView.tableHeaderView = containerView
+        NSLayoutConstraint.activate([
+            containerView.centerXAnchor.constraint(equalTo: self.bubblesTableView.centerXAnchor),
+            containerView.widthAnchor.constraint(equalTo: self.bubblesTableView.widthAnchor),
+            containerView.topAnchor.constraint(equalTo: self.bubblesTableView.topAnchor)
+        ])
+        controller.didMove(toParent: self)
+        
+        self.bubblesTableView.tableHeaderView?.layoutIfNeeded()
+    }
+    
+    @objc func hideWaitingOtherParticipantHeader() {
+        guard let waitingOtherParticipantViewController else {
+            return
+        }
+        waitingOtherParticipantViewController.removeFromParent()
+        self.bubblesTableView.tableHeaderView = nil
+        waitingOtherParticipantViewController.didMove(toParent: nil)
+        self.waitingOtherParticipantViewController = nil
+    }
+    
+    @objc func waitForOtherParticipant(_ wait: Bool) {
+        self.isWaitingForOtherParticipants = wait
+        if wait {
+            showWaitingOtherParticipantHeader()
+        } else {
+            hideWaitingOtherParticipantHeader()
+        }
+    }
+    
 }
 
 // MARK: - Private Helpers

--- a/Riot/Modules/StartChat/StartChatViewController.m
+++ b/Riot/Modules/StartChat/StartChatViewController.m
@@ -316,7 +316,7 @@
     }
 }
 
-- (BOOL) participantsAlreadyContainAnEmail
+- (BOOL)participantsAlreadyContainAnEmail
 {
     for (MXKContact* participant in participants)
     {
@@ -328,7 +328,7 @@
     return NO;
 }
 
-- (BOOL) canAddParticipant: (NSString*) displayName
+- (BOOL)canAddParticipant: (NSString*) displayName
 {
     if (!displayName)
     {
@@ -336,30 +336,30 @@
     }
     displayName = [displayName stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     
-    // The following rules will apply only if the resulting room is going to be encrypted
+    // The following rules will be applied only if the resulting room is going to be encrypted
     if (![self.mainSession vc_homeserverConfiguration].encryption.isE2EEByDefaultEnabled)
     {
         return YES;
     }
-    
+
+    // If we have already invited an email, we cannot add another participant
+    if ([self participantsAlreadyContainAnEmail])
+    {
+        return NO;
+    }
+
     BOOL isEmail = [MXTools isEmailAddress:displayName];
     // If it is an email, we prevent to add it if we already have invited someone else
     if (isEmail && participants.count > 0)
     {
         return NO;
     }
-    
-    // If it is a MatrixID, we prevent to add it if we already have invited an email
-    if (!isEmail && [self participantsAlreadyContainAnEmail])
-    {
-        return NO;
-    }
-    
+        
     // Otherwise, we should be able to add this participant
     return YES;
 }
 
-- (void) showAllowOnlyOneInvitByEmailAllowedHeaderView:(BOOL)visible
+- (void)showAllowOnlyOneInvitByEmailAllowedHeaderView:(BOOL)visible
 {
     if (visible)
     {

--- a/Riot/Modules/StartChat/StartChatViewController.xib
+++ b/Riot/Modules/StartChat/StartChatViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,6 +13,7 @@
                 <outlet property="contactsTableView" destination="kNf-Ll-jvH" id="PDi-bW-2CG"/>
                 <outlet property="searchBarHeader" destination="Zm7-AB-ZtE" id="6ee-P0-twi"/>
                 <outlet property="searchBarHeaderBorder" destination="gcy-W7-89G" id="tsy-SP-KaJ"/>
+                <outlet property="searchBarHeaderHeightConstraint" destination="kSM-fg-IHB" id="nrd-MK-yrq"/>
                 <outlet property="searchBarView" destination="bsq-3U-VjV" id="x3M-wX-RW8"/>
                 <outlet property="view" destination="iN0-l3-epB" id="csR-cn-S4h"/>
             </connections>

--- a/RiotSwiftUI/Modules/Room/WaitingForMembers/View/RoomWaitingForMembers.swift
+++ b/RiotSwiftUI/Modules/Room/WaitingForMembers/View/RoomWaitingForMembers.swift
@@ -1,0 +1,50 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct RoomWaitingForMembers: View {
+    @Environment(\.theme) private var theme: ThemeSwiftUI
+    
+    var body: some View {
+        ZStack {
+            HStack(alignment: .top) {
+                Image(uiImage: Asset.Images.membersListIcon.image)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(VectorL10n.roomWaitingOtherParticipantsTitle(AppInfo.current.displayName))
+                        .font(theme.fonts.bodySB)
+                        .foregroundColor(theme.colors.primaryContent)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    
+                    Text(VectorL10n.roomWaitingOtherParticipantsMessage(AppInfo.current.displayName))
+                        .font(theme.fonts.caption1)
+                        .foregroundColor(theme.colors.secondaryContent)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(9)
+            .background(theme.colors.system)
+            .cornerRadius(4)
+        }
+    }
+}
+
+struct RoomWaitingForMembers_Previews: PreviewProvider {
+    static var previews: some View {
+        RoomWaitingForMembers()
+            .padding(16)
+    }
+}

--- a/changelog.d/6612.change
+++ b/changelog.d/6612.change
@@ -1,0 +1,1 @@
+Direct Message: manage encrypted DM in case of invite by email 


### PR DESCRIPTION
This PR fixes #6612 

Here is a summary of the changes:
- Don’t allow to invite more than one contact by email
- The DM will be created by enabling the encryption when the HS promotes the encryption
- The chat composer is disabled until a matrix account is created by using the invited email

This PR is related to [matrix-ios-sdk PR #1727](https://github.com/matrix-org/matrix-ios-sdk/pull/1727)