### PR TITLE
Fix poll ended event rendering (PSG-1177)

### DIFF
--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -1072,6 +1072,15 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
         // We do not want to merge room create event cells with other cell types
         return NO;
     }
+    
+    if (self.tag == RoomBubbleCellDataTagPoll) {
+        MXEvent* event = self.events.firstObject;
+        
+        if (event) {
+            // m.poll.ended events should always show the sender information
+            return event.eventType != MXEventTypePollEnd;
+        }
+    }
 
     if (self.hasThreadRoot || bubbleCellData.hasThreadRoot)
     {

--- a/changelog.d/pr-7402.bugfix
+++ b/changelog.d/pr-7402.bugfix
@@ -1,0 +1,1 @@
+Polls: improve rendering of poll ended events.


### PR DESCRIPTION
### Description

This PR improves the rendering of the `m.poll.end` message adding always the sender information.

| Before | After |
|---|---|
| ![b](https://user-images.githubusercontent.com/19324622/222496949-df429128-b06c-4200-a6ae-816366f14ec6.png)| ![a](https://user-images.githubusercontent.com/19324622/222497017-d308dde7-8b14-4626-a440-bc3e68f307f0.png)|