### PR TITLE
Secrets recovery: Fix an issue where the Secrets Reset screen would open twice.

### DIFF
--- a/Riot/Modules/Secrets/Recover/SecretsRecoveryCoordinator.swift
+++ b/Riot/Modules/Secrets/Recover/SecretsRecoveryCoordinator.swift
@@ -121,11 +121,12 @@ final class SecretsRecoveryCoordinator: SecretsRecoveryCoordinatorType {
     private func showSecureBackupSetup(checkKeyBackup: Bool) {
         let coordinator = SecureBackupSetupCoordinator(session: self.session, checkKeyBackup: checkKeyBackup, navigationRouter: self.navigationRouter, cancellable: self.cancellable)
         coordinator.delegate = self
-        coordinator.start()
-        
-        self.navigationRouter.push(coordinator.toPresentable(), animated: true, popCompletion: { [weak self] in
+        // Fix: calling coordinator.start() will update the navigationRouter without a popCompletion
+        coordinator.start(popCompletion: { [weak self] in
             self?.remove(childCoordinator: coordinator)
         })
+        // Fix: do not push the presentable from the coordinator to the navigation router as this has already been done by coordinator.start().
+        //      Also, coordinator.toPresentable() returns a navigation controller, which cannot be pushed into a navigation router.
         self.add(childCoordinator: coordinator)
     }
 }

--- a/Riot/Modules/Secrets/Reset/SecretsResetCoordinator.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetCoordinator.swift
@@ -94,11 +94,11 @@ extension SecretsResetCoordinator: SecretsResetViewModelCoordinatorDelegate {
 extension SecretsResetCoordinator: ReauthenticationCoordinatorDelegate {
     
     func reauthenticationCoordinatorDidComplete(_ coordinator: ReauthenticationCoordinatorType, withAuthenticationParameters authenticationParameters: [String: Any]?) {
-        
         self.secretsResetViewModel.process(viewAction: .authenticationInfoEntered(authenticationParameters ?? [:]))
     }
     
     func reauthenticationCoordinatorDidCancel(_ coordinator: ReauthenticationCoordinatorType) {
+        self.secretsResetViewModel.process(viewAction: .authenticationCancelled)
         self.remove(childCoordinator: coordinator)
     }
     

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewAction.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewAction.swift
@@ -22,6 +22,7 @@ import Foundation
 enum SecretsResetViewAction {
     case loadData
     case reset
+    case authenticationCancelled
     case authenticationInfoEntered(_ authInfo: [String: Any])
     case cancel
 }

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewController.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewController.swift
@@ -132,6 +132,8 @@ final class SecretsResetViewController: UIViewController {
             self.renderLoading()
         case .resetDone:
             self.renderLoaded()
+        case .resetCancelled:
+            self.renderCancelled()
         case .error(let error):
             self.render(error: error)
         }
@@ -142,6 +144,10 @@ final class SecretsResetViewController: UIViewController {
     }
     
     private func renderLoaded() {
+        self.activityPresenter.removeCurrentActivityIndicator(animated: true)
+    }
+    
+    private func renderCancelled() {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
     }
     

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewModel.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewModel.swift
@@ -49,6 +49,8 @@ final class SecretsResetViewModel: SecretsResetViewModelType {
             break
         case .reset:
             self.askAuthentication()
+        case .authenticationCancelled:
+            self.authenticationCancelled()
         case .authenticationInfoEntered(let authParameters):
             self.resetSecrets(with: authParameters)
         case .cancel:
@@ -68,7 +70,6 @@ final class SecretsResetViewModel: SecretsResetViewModelType {
         }
         MXLog.debug("[SecretsResetViewModel] resetSecrets")
 
-        self.update(viewState: .resetting)
         crossSigning.setup(withAuthParams: authParameters, success: { [weak self] in
             guard let self = self else {
                 return
@@ -96,7 +97,13 @@ final class SecretsResetViewModel: SecretsResetViewModelType {
     }
     
     private func askAuthentication() {
+        self.update(viewState: .resetting)
+
         let setupCrossSigningRequest = self.crossSigningService.setupCrossSigningRequest()
         self.coordinatorDelegate?.secretsResetViewModel(self, needsToAuthenticateWith: setupCrossSigningRequest)
+    }
+    
+    private func authenticationCancelled() {
+        self.update(viewState: .resetCancelled)
     }
 }

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewState.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewState.swift
@@ -22,5 +22,6 @@ import Foundation
 enum SecretsResetViewState {
     case resetting
     case resetDone
+    case resetCancelled
     case error(Error)
 }

--- a/Riot/Modules/SecureBackup/Setup/SecureBackupSetupCoordinator.swift
+++ b/Riot/Modules/SecureBackup/Setup/SecureBackupSetupCoordinator.swift
@@ -73,15 +73,19 @@ final class SecureBackupSetupCoordinator: SecureBackupSetupCoordinatorType {
     // MARK: - Public methods
     
     func start() {
+        start(popCompletion: nil)
+    }
+
+    func start(popCompletion: (() -> Void)?) {
         let rootViewController = self.createIntro()
         
         if self.navigationRouter.modules.isEmpty == false {
-            self.navigationRouter.push(rootViewController, animated: true, popCompletion: nil)
+            self.navigationRouter.push(rootViewController, animated: true, popCompletion: popCompletion)
         } else {
-            self.navigationRouter.setRootModule(rootViewController)
+            self.navigationRouter.setRootModule(rootViewController, popCompletion: popCompletion)
         }
     }
-    
+
     func toPresentable() -> UIViewController {
         return self.navigationRouter
             .toPresentable()

--- a/changelog.d/pr-7404.bugfix
+++ b/changelog.d/pr-7404.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the Secrets Reset screen would open twice.


### PR DESCRIPTION
This PR fixes the following issues when resetting secrets:
- SecureBackupSetupIntroViewController is pushed twice into the navigation router (once as a view controller, once via its navigation controller)
- SecureBackupSetupCoordinator is never removed from child coordinators