### PR TITLE
Support for MSC3906 v2

### DIFF
--- a/Riot/Modules/Rendezvous/RendezvousService.swift
+++ b/Riot/Modules/Rendezvous/RendezvousService.swift
@@ -35,7 +35,7 @@ enum RendezvousChannelAlgorithm: String {
 
 /// Algorithm name as per MSC3906
 enum RendezvousFlow: String {
-    ///     The v1 value never actually appears in JSON
+    /// The v1 value never actually appears in JSON
     case SETUP_ADDITIONAL_DEVICE_V1 = "org.matrix.msc3906.v1"
     case SETUP_ADDITIONAL_DEVICE_V2 = "org.matrix.msc3906.setup.additional_device.v2"
 }

--- a/Riot/Modules/Rendezvous/RendezvousService.swift
+++ b/Riot/Modules/Rendezvous/RendezvousService.swift
@@ -33,6 +33,13 @@ enum RendezvousChannelAlgorithm: String {
     case ECDH_V2 = "org.matrix.msc3903.rendezvous.v2.curve25519-aes-sha256"
 }
 
+/// Algorithm name as per MSC3906
+enum RendezvousFlow: String {
+    ///     The v1 value never actually appears in JSON
+    case SETUP_ADDITIONAL_DEVICE_V1 = "org.matrix.msc3906.v1"
+    case SETUP_ADDITIONAL_DEVICE_V2 = "org.matrix.msc3906.setup.additional_device.v2"
+}
+
 /// Allows communication through a secure channel. Based on MSC3886 and MSC3903
 @MainActor
 class RendezvousService {

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Models/QRLoginCode.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Models/QRLoginCode.swift
@@ -18,6 +18,7 @@ import Foundation
 
 struct QRLoginCode: Codable {
     let rendezvous: RendezvousDetails
+    let flow: String?
     let intent: String
 }
 
@@ -42,7 +43,8 @@ struct QRLoginRendezvousPayload: Codable {
     
     var intent: Intent?
     var outcome: Outcome?
-    
+    var reason: FailureReason?
+
     // swiftformat:disable:next redundantBackticks
     var protocols: [`Protocol`]?
     
@@ -64,6 +66,7 @@ struct QRLoginRendezvousPayload: Codable {
         case type
         case intent
         case outcome
+        case reason
         case homeserver
         case user
         case protocols
@@ -77,9 +80,18 @@ struct QRLoginRendezvousPayload: Codable {
     }
     
     enum `Type`: String, Codable {
-        case loginStart = "m.login.start"
         case loginProgress = "m.login.progress"
+        /**
+         This is only used in MSC3906 v1 and will be removed
+         */
         case loginFinish = "m.login.finish"
+        case loginFailure = "m.login.failure"
+        case loginProtocol = "m.login.protocol"
+        case loginProtocols = "m.login.protocols"
+        case loginApproved = "m.login.approved"
+        case loginDeclined = "m.login.declined"
+        case loginSuccess = "m.login.success"
+        case loginVerified = "m.login.verified"
     }
 
     enum Intent: String, Codable {
@@ -87,6 +99,9 @@ struct QRLoginRendezvousPayload: Codable {
         case loginReciprocate = "login.reciprocate"
     }
     
+    /**
+     This is only used in MSC306 v1 and will be removed
+     */
     enum Outcome: String, Codable {
         case success
         case declined
@@ -96,5 +111,12 @@ struct QRLoginRendezvousPayload: Codable {
     // swiftformat:disable:next redundantBackticks
     enum `Protocol`: String, Codable {
         case loginToken = "org.matrix.msc3906.login_token"
+    }
+    
+    enum FailureReason: String, Codable {
+        case cancelled
+        case unsupported
+        case e2eeSecurityError = "e2ee_security_error"
+        case incompatibleIntent = "incompatible_intent"
     }
 }

--- a/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/Mock/MockQRLoginService.swift
+++ b/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/Mock/MockQRLoginService.swift
@@ -20,13 +20,16 @@ import SwiftUI
 
 class MockQRLoginService: QRLoginServiceProtocol {
     private let mockCanDisplayQR: Bool
+    private let mockFlow: String?
 
     init(withState state: QRLoginServiceState = .initial,
          mode: QRLoginServiceMode = .notAuthenticated,
-         canDisplayQR: Bool = true) {
+         canDisplayQR: Bool = true,
+         flow: String? = nil) {
         self.state = state
         self.mode = mode
         mockCanDisplayQR = canDisplayQR
+        mockFlow = flow
     }
 
     // MARK: - QRLoginServiceProtocol
@@ -57,6 +60,7 @@ class MockQRLoginService: QRLoginServiceProtocol {
                                                          uri: "https://matrix.org"),
                                         key: "some.public.key")
         return QRLoginCode(rendezvous: details,
+                           flow: mockFlow,
                            intent: "login.start")
     }
 


### PR DESCRIPTION
This PR adds support for v2 of [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) which is used for Sign in with QR.

Both v1 and v2 are supported so compatibility is maintained.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>