### PR TITLE
MatrixRoomSummary displayname renamed to displayName

### DIFF
--- a/Riot/Categories/MXRoomSummary+Riot.m
+++ b/Riot/Categories/MXRoomSummary+Riot.m
@@ -27,7 +27,7 @@
 {
     [mxkImageView vc_setRoomAvatarImageWith:self.avatar
                                      roomId:self.roomId
-                                displayName:self.displayname
+                                displayName:self.displayName
                                mediaManager:self.mxSession.mediaManager];
 }
 

--- a/Riot/Managers/Call/CallPresenter.swift
+++ b/Riot/Managers/Call/CallPresenter.swift
@@ -208,7 +208,7 @@ class CallPresenter: NSObject {
             if error == nil {
                 JMCallKitProxy.reportCallUpdate(with: newUUID,
                                                 handle: roomId,
-                                                displayName: room.summary.displayname,
+                                                displayName: room.summary.displayName,
                                                 hasVideo: true)
                 JMCallKitProxy.reportOutgoingCall(with: newUUID, connectedAt: nil)
 

--- a/Riot/Model/Room/RoomPreviewData.m
+++ b/Riot/Model/Room/RoomPreviewData.m
@@ -123,7 +123,7 @@
             [self.roomDataSource finalizeInitialization];
             self.roomDataSource.markTimelineInitialEvent = YES;
 
-            self->_roomName = peekingRoom.summary.displayname;
+            self->_roomName = peekingRoom.summary.displayName;
             self->_roomAvatarUrl = peekingRoom.summary.avatar;
 
             self->_roomTopic = [MXTools stripNewlineCharacters:peekingRoom.summary.topic];;

--- a/Riot/Modules/Call/CallViewController.m
+++ b/Riot/Modules/Call/CallViewController.m
@@ -484,7 +484,7 @@ CallAudioRouteMenuViewDelegate>
     else if (self.mxCall.room)
     {
         return [AvatarGenerator generateAvatarForMatrixItem:self.mxCall.room.roomId
-                                            withDisplayName:self.mxCall.room.summary.displayname
+                                            withDisplayName:self.mxCall.room.summary.displayName
                                                        size:self.callerImageViewWidthConstraint.constant
                                                 andFontSize:fontSize];
     }

--- a/Riot/Modules/Call/PiP/CallPiPView.swift
+++ b/Riot/Modules/Call/PiP/CallPiPView.swift
@@ -158,7 +158,7 @@ class CallPiPView: UIView {
                                                   andFontSize: fontSize)
         } else if let room = call?.room {
             return AvatarGenerator.generateAvatar(forMatrixItem: room.roomId,
-                                                  withDisplayName: room.summary.displayname,
+                                                  withDisplayName: room.summary.displayName,
                                                   size: imageView.bounds.width,
                                                   andFontSize: fontSize)
         }

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -1103,7 +1103,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
             RecentEmptySectionTableViewCell *tableViewCell = [tableView dequeueReusableCellWithIdentifier:[RecentEmptySpaceSectionTableViewCell defaultReuseIdentifier]];
 
             tableViewCell.iconView.image = [ThemeService.shared isCurrentThemeDark] ? AssetImages.allChatsEmptySpaceArtworkDark.image : AssetImages.allChatsEmptySpaceArtwork.image;
-            tableViewCell.titleLabel.text = [VectorL10n allChatsEmptyViewTitle: self.currentSpace.summary.displayname];
+            tableViewCell.titleLabel.text = [VectorL10n allChatsEmptyViewTitle: self.currentSpace.summary.displayName];
             tableViewCell.messageLabel.text = VectorL10n.allChatsEmptySpaceInformation;
             
             return tableViewCell;
@@ -1670,7 +1670,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
             
             NSString* tagOrder = [room.mxSession tagOrderToBeAtIndex:newPath.row from:oldPos withTag:dstRoomTag];
             
-            MXLogDebug(@"[RecentsDataSource] Update the room %@ [%@] tag from %@ to %@ with tag order %@", room.roomId, room.summary.displayname, oldRoomTag, dstRoomTag, tagOrder);
+            MXLogDebug(@"[RecentsDataSource] Update the room %@ [%@] tag from %@ to %@ with tag order %@", room.roomId, room.summary.displayName, oldRoomTag, dstRoomTag, tagOrder);
             
             [room replaceTag:oldRoomTag
                        byTag:dstRoomTag

--- a/Riot/Modules/Common/Recents/Service/Mock/MockRecentsListService.swift
+++ b/Riot/Modules/Common/Recents/Service/Mock/MockRecentsListService.swift
@@ -95,7 +95,7 @@ public class MockRecentsListService: NSObject, RecentsListServiceProtocol {
             } else if i % 11 == 0 {
                 room.dataTypes = .serverNotice
             }
-            room.displayname = "Room \(i+1)"
+            room.displayName = "Room \(i+1)"
             if let event = MXEvent(fromJSON: [
                 "event_id": MXTools.generateTransactionId() as Any,
                 "room_id": room.roomId,

--- a/Riot/Modules/Common/Recents/Service/Mock/MockRoomSummary.swift
+++ b/Riot/Modules/Common/Recents/Service/Mock/MockRoomSummary.swift
@@ -26,7 +26,7 @@ public class MockRoomSummary: NSObject, MXRoomSummaryProtocol {
     
     public var avatar: String?
     
-    public var displayname: String?
+    public var displayName: String?
     
     public var topic: String?
     

--- a/Riot/Modules/Contacts/Details/Views/RoomTableViewCell.m
+++ b/Riot/Modules/Contacts/Details/Views/RoomTableViewCell.m
@@ -48,7 +48,7 @@
 {
     [room.summary setRoomAvatarImageIn:self.avatarImageView];
     
-    self.titleLabel.text = room.summary.displayname;
+    self.titleLabel.text = room.summary.displayName;
 }
 
 + (CGFloat)cellHeight

--- a/Riot/Modules/ContextMenu/ActionProviders/AllChatsEditActionProvider.swift
+++ b/Riot/Modules/ContextMenu/ActionProviders/AllChatsEditActionProvider.swift
@@ -40,7 +40,7 @@ class AllChatsEditActionProvider {
     private var rootSpaceCount: Int = 0
     private var parentSpace: MXSpace? {
         didSet {
-            parentName = parentSpace?.summary?.displayname ?? VectorL10n.spaceTag
+            parentName = parentSpace?.summary?.displayName ?? VectorL10n.spaceTag
         }
     }
     private var parentName: String = VectorL10n.spaceTag

--- a/Riot/Modules/ContextMenu/ActionProviders/AllChatsSpaceActionProvider.swift
+++ b/Riot/Modules/ContextMenu/ActionProviders/AllChatsSpaceActionProvider.swift
@@ -39,7 +39,7 @@ class AllChatsSpaceActionProvider {
 
     private var currentSpace: MXSpace? {
         didSet {
-            spaceName = currentSpace?.summary?.displayname ?? VectorL10n.spaceTag
+            spaceName = currentSpace?.summary?.displayName ?? VectorL10n.spaceTag
         }
     }
     private var spaceName: String = VectorL10n.spaceTag

--- a/Riot/Modules/GlobalSearch/Files/CellData/FilesSearchCellData.m
+++ b/Riot/Modules/GlobalSearch/Files/CellData/FilesSearchCellData.m
@@ -100,7 +100,7 @@
         MXRoom *room = [searchDataSource.mxSession roomWithRoomId:roomId];
         if (room)
         {
-            roomDisplayName = room.summary.displayname;
+            roomDisplayName = room.summary.displayName;
             if (!roomDisplayName.length)
             {
                 roomDisplayName = [VectorL10n roomDisplaynameEmptyRoom];

--- a/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultAttachmentBubbleCell.m
+++ b/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultAttachmentBubbleCell.m
@@ -41,7 +41,7 @@
         MXRoom* room = [bubbleData.mxSession roomWithRoomId:bubbleData.roomId];
         if (room)
         {
-            self.roomNameLabel.text = room.summary.displayname;
+            self.roomNameLabel.text = room.summary.displayName;
             if (!self.roomNameLabel.text.length)
             {
                 self.roomNameLabel.text = [VectorL10n roomDisplaynameEmptyRoom];

--- a/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultTextMsgBubbleCell.m
+++ b/Riot/Modules/GlobalSearch/Messages/Views/MessagesSearchResultTextMsgBubbleCell.m
@@ -41,7 +41,7 @@
         MXRoom* room = [bubbleData.mxSession roomWithRoomId:bubbleData.roomId];
         if (room)
         {
-            self.roomNameLabel.text = room.summary.displayname;
+            self.roomNameLabel.text = room.summary.displayName;
         }
         else
         {

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -415,7 +415,7 @@ class AllChatsViewController: HomeViewController {
         let title: String
         let informationText: String
         if let currentSpace = self.dataSource?.currentSpace {
-            title = VectorL10n.allChatsEmptyViewTitle(currentSpace.summary?.displayname ?? VectorL10n.spaceTag)
+            title = VectorL10n.allChatsEmptyViewTitle(currentSpace.summary?.displayName ?? VectorL10n.spaceTag)
             informationText = VectorL10n.allChatsEmptySpaceInformation
         } else {
             let myUser = mainSession.myUser
@@ -495,7 +495,7 @@ class AllChatsViewController: HomeViewController {
 
     private func updateUI() {
         let currentSpace = self.dataSource?.currentSpace
-        self.title = currentSpace?.summary?.displayname ?? VectorL10n.allChatsTitle
+        self.title = currentSpace?.summary?.displayName ?? VectorL10n.allChatsTitle
         
         setupEditOptions()
         updateToolbar(with: editActionProvider.updateMenu(with: mainSession, parentSpace: currentSpace, completion: { [weak self] menu in
@@ -638,7 +638,7 @@ class AllChatsViewController: HomeViewController {
             return
         }
         
-        let name = spaceSummary.displayname ?? VectorL10n.spaceTag
+        let name = spaceSummary.displayName ?? VectorL10n.spaceTag
         
         let selectionHeader = MatrixItemChooserSelectionHeader(title: VectorL10n.leaveSpaceSelectionTitle,
                                                                selectAllTitle: VectorL10n.leaveSpaceSelectionAllRooms,

--- a/Riot/Modules/Integrations/Widgets/Jitsi/JitsiViewController.m
+++ b/Riot/Modules/Integrations/Widgets/Jitsi/JitsiViewController.m
@@ -272,7 +272,7 @@ static NSString * _Nonnull kJitsiFeatureFlagChatEnabled = @"chat.enabled";
             builder.room = conferenceId;
             builder.videoMuted = !self.startWithVideo;
 
-            builder.subject = roomSummary.displayname;
+            builder.subject = roomSummary.displayName;
             builder.userInfo = [[JitsiMeetUserInfo alloc] initWithDisplayName:userDisplayName
                                                                      andEmail:nil
                                                                     andAvatar:avatarUrl];

--- a/Riot/Modules/MatrixKit/Controllers/MXKCallViewController.m
+++ b/Riot/Modules/MatrixKit/Controllers/MXKCallViewController.m
@@ -503,7 +503,7 @@ static const CGFloat kLocalPreviewMargin = 20;
     }
     else if (mxCall.isConferenceCall)
     {
-        peerDisplayName = mxCall.room.summary.displayname;
+        peerDisplayName = mxCall.room.summary.displayName;
         peerAvatarURL = mxCall.room.summary.avatar;
     }
     

--- a/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellData.m
+++ b/Riot/Modules/MatrixKit/Models/RoomList/MXKRecentCellData.m
@@ -86,7 +86,7 @@
     {
         return self.roomSummary.spaceChildInfo.displayName;
     }
-    return roomSummary.displayname;
+    return roomSummary.displayName;
 }
 
 - (NSString *)avatarUrl

--- a/Riot/Modules/MatrixKit/Models/Search/MXKSearchCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Search/MXKSearchCellData.m
@@ -45,7 +45,7 @@
             MXRoom *room = [searchDataSource.mxSession roomWithRoomId:searchResult.result.roomId];
             if (room)
             {
-                title = room.summary.displayname;
+                title = room.summary.displayName;
             }
             else
             {

--- a/Riot/Modules/MatrixKit/Views/PushRule/MXKPushRuleCreationTableViewCell.m
+++ b/Riot/Modules/MatrixKit/Views/PushRule/MXKPushRuleCreationTableViewCell.m
@@ -169,7 +169,7 @@
         if ((row >= 0) && (row < rooms.count))
         {
             MXRoom* room = [rooms objectAtIndex:row];
-            _inputTextField.text = room.summary.displayname;
+            _inputTextField.text = room.summary.displayName;
             _addButton.enabled = YES;
         }
         
@@ -191,7 +191,7 @@
     rooms = [_mxSession.rooms sortedArrayUsingComparator:^NSComparisonResult(MXRoom* firstRoom, MXRoom* secondRoom) {
         
         // Alphabetic order
-        return [firstRoom.summary.displayname compare:secondRoom.summary.displayname options:NSCaseInsensitiveSearch];
+        return [firstRoom.summary.displayName compare:secondRoom.summary.displayName options:NSCaseInsensitiveSearch];
     }];
 
     return rooms.count;
@@ -202,7 +202,7 @@
 - (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component
 {
     MXRoom* room = [rooms objectAtIndex:row];
-    return room.summary.displayname;
+    return room.summary.displayName;
 }
 
 @end

--- a/Riot/Modules/MatrixKit/Views/PushRule/MXKPushRuleTableViewCell.m
+++ b/Riot/Modules/MatrixKit/Views/PushRule/MXKPushRuleTableViewCell.m
@@ -71,7 +71,7 @@
             MXRoom *room = [_mxSession roomWithRoomId:mxPushRule.ruleId];
             if (room)
             {
-                description = [VectorL10n notificationSettingsRoomRuleTitle:room.summary.displayname];
+                description = [VectorL10n notificationSettingsRoomRuleTitle:room.summary.displayName];
             }
             break;
         }

--- a/Riot/Modules/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
@@ -82,7 +82,7 @@
     if (_mxRoom)
     {
         // Replace empty string by nil : avoid having the placeholder 'Room name" when there is no displayname
-        self.displayNameTextField.text = (_mxRoom.summary.displayname.length) ? _mxRoom.summary.displayname : nil;
+        self.displayNameTextField.text = (_mxRoom.summary.displayName.length) ? _mxRoom.summary.displayName : nil;
     }
     else if (_mxUser)
     {
@@ -189,7 +189,7 @@
             if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomName])
             {
                 // Only the room name is edited here, update the text field with the room name
-                textField.text = _mxRoom.summary.displayname;
+                textField.text = _mxRoom.summary.displayName;
                 textField.backgroundColor = [UIColor whiteColor];
             }
             else
@@ -236,7 +236,7 @@
         textField.backgroundColor = [UIColor clearColor];
         
         NSString *roomName = textField.text;
-        if ((roomName.length || _mxRoom.summary.displayname.length) && [roomName isEqualToString:_mxRoom.summary.displayname] == NO)
+        if ((roomName.length || _mxRoom.summary.displayName.length) && [roomName isEqualToString:_mxRoom.summary.displayName] == NO)
         {
             if ([self.delegate respondsToSelector:@selector(roomTitleView:isSaving:)])
             {
@@ -266,7 +266,7 @@
                     }
                     
                     // Revert change
-                    textField.text = strongSelf.mxRoom.summary.displayname;
+                    textField.text = strongSelf.mxRoom.summary.displayName;
                     MXLogDebug(@"[MXKRoomTitleView] Rename room failed");
                     // Notify MatrixKit user
                     NSString *myUserId = strongSelf.mxRoom.mxSession.myUser.userId;
@@ -278,7 +278,7 @@
         else
         {
             // No change on room name, restore title with room displayName
-            textField.text = _mxRoom.summary.displayname;
+            textField.text = _mxRoom.summary.displayName;
         }
     }
 }

--- a/Riot/Modules/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
+++ b/Riot/Modules/MatrixKit/Views/RoomTitle/MXKRoomTitleViewWithTopic.m
@@ -367,7 +367,7 @@
             if (userPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomName])
             {
                 // Only the room name is edited here, update the text field with the room name
-                textField.text = self.mxRoom.summary.displayname;
+                textField.text = self.mxRoom.summary.displayName;
                 textField.backgroundColor = [UIColor whiteColor];
             }
             else

--- a/Riot/Modules/Room/CreationModal/RoomCreationEventsModal/RoomCreationEventsModalViewModel.swift
+++ b/Riot/Modules/Room/CreationModal/RoomCreationEventsModal/RoomCreationEventsModalViewModel.swift
@@ -62,7 +62,7 @@ final class RoomCreationEventsModalViewModel: RoomCreationEventsModalViewModelTy
         guard let summary = session.roomSummary(withRoomId: roomState.roomId) else {
             return nil
         }
-        return summary.displayname
+        return summary.displayName
     }
     
     var roomInfo: String? {

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -760,7 +760,7 @@
         else
         {
             // set default title
-            self.navigationItem.title = roomDataSource.room.summary.displayname;
+            self.navigationItem.title = roomDataSource.room.summary.displayName;
         }
         
         // Show input tool bar
@@ -780,7 +780,7 @@
                 }
                 else
                 {
-                    self.navigationItem.title = roomDataSource.room.summary.displayname;
+                    self.navigationItem.title = roomDataSource.room.summary.displayName;
                 }
             }
             else
@@ -890,7 +890,7 @@
         
     } failure:^(NSError *error) {
         cancelIndicator();
-        MXLogDebug(@"[MXKRoomVC] Failed to join room (%@)", self->roomDataSource.room.summary.displayname);
+        MXLogDebug(@"[MXKRoomVC] Failed to join room (%@)", self->roomDataSource.room.summary.displayName);
         [self processRoomJoinFailureWithError:error completion:completion];
     }];
 }

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -366,11 +366,11 @@
             
             switch (roomPowerLevel) {
                 case RoomPowerLevelAdmin:
-                    self.roomMemberPowerLevelLabel.text = [VectorL10n roomMemberPowerLevelAdminIn:self.mxRoom.summary.displayname];
+                    self.roomMemberPowerLevelLabel.text = [VectorL10n roomMemberPowerLevelAdminIn:self.mxRoom.summary.displayName];
                     self.roomMemberPowerLevelContainerView.hidden = NO;
                     break;
                 case RoomPowerLevelModerator:
-                    self.roomMemberPowerLevelLabel.text = [VectorL10n roomMemberPowerLevelModeratorIn:self.mxRoom.summary.displayname];
+                    self.roomMemberPowerLevelLabel.text = [VectorL10n roomMemberPowerLevelModeratorIn:self.mxRoom.summary.displayName];
                     self.roomMemberPowerLevelContainerView.hidden = NO;
                     break;
                 default:

--- a/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewModel.swift
+++ b/Riot/Modules/Room/RoomInfo/RoomInfoList/RoomInfoListViewModel.swift
@@ -39,7 +39,7 @@ final class RoomInfoListViewModel: NSObject, RoomInfoListViewModelType {
         let basicInfoViewData = RoomInfoBasicViewData(avatarUrl: room.summary.avatar,
                                                       mediaManager: session.mediaManager,
                                                       roomId: room.roomId,
-                                                      roomDisplayName: room.summary.displayname,
+                                                      roomDisplayName: room.summary.displayName,
                                                       mainRoomAlias: room.summary.aliases?.first,
                                                       roomTopic: room.summary.topic,
                                                       encryptionImage: encryptionImage,

--- a/Riot/Modules/Room/TimelineCells/Call/Group/RoomGroupCallStatusCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Call/Group/RoomGroupCallStatusCell.swift
@@ -237,13 +237,13 @@ class RoomGroupCallStatusCell: RoomCallBaseCell {
             TimeInterval(widgetEvent.age)/MSEC_PER_SEC < Constants.secondsToDisplayAnswerDeclineOptions {
             
             if JitsiService.shared.isWidgetDeclined(withId: widgetId) {
-                innerContentView.callerNameLabel.text = room.summary.displayname
+                innerContentView.callerNameLabel.text = room.summary.displayName
                 room.summary.setRoomAvatarImageIn(innerContentView.avatarImageView)
                 
                 viewState = .declined
                 statusText = VectorL10n.eventFormatterCallYouDeclined
             } else {
-                innerContentView.callerNameLabel.text = VectorL10n.eventFormatterGroupCallIncoming(bubbleCellData.senderDisplayName, room.summary.displayname)
+                innerContentView.callerNameLabel.text = VectorL10n.eventFormatterGroupCallIncoming(bubbleCellData.senderDisplayName, room.summary.displayName)
                 
                 innerContentView.avatarImageView.setImageURI(bubbleCellData.senderAvatarUrl,
                                             withType: nil,
@@ -257,7 +257,7 @@ class RoomGroupCallStatusCell: RoomCallBaseCell {
                 statusText = nil
             }
         } else {
-            innerContentView.callerNameLabel.text = room.summary.displayname
+            innerContentView.callerNameLabel.text = room.summary.displayName
             
             room.summary.setRoomAvatarImageIn(innerContentView.avatarImageView)
         }

--- a/Riot/Modules/Room/TimelineCells/RoomCreationIntro/RoomCreationIntroCell.swift
+++ b/Riot/Modules/Room/TimelineCells/RoomCreationIntro/RoomCreationIntroCell.swift
@@ -189,7 +189,7 @@ class RoomCreationIntroCell: MXKRoomBubbleTableViewCell {
             discussionType = .room(topic: roomSummary.topic, canInvitePeople: bubbleData.canInvitePeople)
         }
         
-        let displayName = roomSummary.displayname ?? ""
+        let displayName = roomSummary.displayName ?? ""
         
         let roomAvatarViewData = RoomAvatarViewData(roomId: roomId,
                                                     displayName: displayName,

--- a/Riot/Modules/Room/Views/Title/RoomTitleView.m
+++ b/Riot/Modules/Room/Views/Title/RoomTitleView.m
@@ -85,7 +85,7 @@
     [super customizeViewRendering];
 
     self.backgroundColor = UIColor.clearColor;
-    self.displayNameTextField.textColor = (self.mxRoom.summary.displayname.length ? ThemeService.shared.theme.textPrimaryColor : ThemeService.shared.theme.textSecondaryColor);
+    self.displayNameTextField.textColor = (self.mxRoom.summary.displayName.length ? ThemeService.shared.theme.textPrimaryColor : ThemeService.shared.theme.textSecondaryColor);
     self.typingLabel.textColor = ThemeService.shared.theme.textSecondaryColor;
     self.dotView.backgroundColor = ThemeService.shared.theme.warningColor;
     self.missedDiscussionsBadgeLabel.textColor = ThemeService.shared.theme.tintColor;
@@ -121,7 +121,7 @@
             [self.presenceIndicatorView stopListeningPresenceUpdates];
         }
         
-        self.displayNameTextField.text = self.mxRoom.summary.displayname;
+        self.displayNameTextField.text = self.mxRoom.summary.displayName;
         if (!self.displayNameTextField.text.length)
         {
             self.displayNameTextField.text = [VectorL10n roomDisplaynameEmptyRoom];

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageMediaServiceProvider.swift
@@ -48,7 +48,7 @@ import MediaPlayer
         didSet {
             //  set avatar placeholder for now
             roomAvatar = AvatarGenerator.generateAvatar(forMatrixItem: currentRoomSummary?.roomId,
-                                                        withDisplayName: currentRoomSummary?.displayname,
+                                                        withDisplayName: currentRoomSummary?.displayName,
                                                         size: Constants.roomAvatarImageSize.width,
                                                         andFontSize: Constants.roomAvatarFontSize)
             

--- a/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewModel.swift
+++ b/Riot/Modules/Rooms/ShowDirectory/ShowDirectoryViewModel.swift
@@ -237,7 +237,7 @@ final class ShowDirectoryViewModel: NSObject, ShowDirectoryViewModelType {
     }
     
     private func roomCellViewModel(with room: MXRoom) -> DirectoryRoomTableViewCellVM {
-        let displayName = room.summary.displayname
+        let displayName = room.summary.displayName
         let joinedMembersCount = Int(room.summary.membersCount.joined)
         let topic = MXTools.stripNewlineCharacters(room.summary.topic)
         let isJoined = room.summary.membership == .join || room.summary.membershipTransitionState == .joined

--- a/Riot/Modules/Spaces/SpaceDetail/SpaceDetailViewModel.swift
+++ b/Riot/Modules/Spaces/SpaceDetail/SpaceDetailViewModel.swift
@@ -102,7 +102,7 @@ class SpaceDetailViewModel: SpaceDetailViewModelType {
             }
             
             let parameters = SpaceDetailLoadedParameters(spaceId: space.spaceId,
-                                                         displayName: summary.displayname,
+                                                         displayName: summary.displayName,
                                                          topic: summary.topic,
                                                          avatarUrl: summary.avatar,
                                                          joinRule: nil,
@@ -130,7 +130,7 @@ class SpaceDetailViewModel: SpaceDetailViewModelType {
                 })
                 
                 let parameters = SpaceDetailLoadedParameters(spaceId: space.spaceId,
-                                                             displayName: summary.displayname,
+                                                             displayName: summary.displayName,
                                                              topic: summary.topic,
                                                              avatarUrl: summary.avatar,
                                                              joinRule: joinRule,

--- a/Riot/Modules/Spaces/SpaceList/SpaceListViewModel.swift
+++ b/Riot/Modules/Spaces/SpaceList/SpaceListViewModel.swift
@@ -248,9 +248,9 @@ final class SpaceListViewModel: SpaceListViewModelType {
         var invites: [SpaceListItemViewData] = []
         var spaces: [SpaceListItemViewData] = []
         session.spaceService.rootSpaceSummaries.forEach { summary in
-            let avatarViewData = AvatarViewData(matrixItemId: summary.roomId, displayName: summary.displayname, avatarUrl: summary.avatar, mediaManager: session.mediaManager, fallbackImage: .matrixItem(summary.roomId, summary.displayname))
+            let avatarViewData = AvatarViewData(matrixItemId: summary.roomId, displayName: summary.displayName, avatarUrl: summary.avatar, mediaManager: session.mediaManager, fallbackImage: .matrixItem(summary.roomId, summary.displayName))
             let notificationState = session.spaceService.notificationCounter.notificationState(forSpaceWithId: summary.roomId)
-            let viewData = SpaceListItemViewData(spaceId: summary.roomId, title: summary.displayname,
+            let viewData = SpaceListItemViewData(spaceId: summary.roomId, title: summary.displayName,
                                                  avatarViewData: avatarViewData,
                                                  isInvite: summary.membership == .invite,
                                                  notificationCount: notificationState?.groupMissedDiscussionsCount ?? 0,

--- a/Riot/Modules/Spaces/SpaceMembers/MemberList/SpaceMemberListViewController.swift
+++ b/Riot/Modules/Spaces/SpaceMembers/MemberList/SpaceMemberListViewController.swift
@@ -142,7 +142,7 @@ final class SpaceMemberListViewController: RoomParticipantsViewController {
     private func renderLoaded(space: MXSpace) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         self.mxRoom = space.room
-        if let spaceName = space.summary?.displayname {
+        if let spaceName = space.summary?.displayName {
             self.titleView.breadcrumbView.breadcrumbs = [spaceName]
         } else {
             self.titleView.breadcrumbView.breadcrumbs = []

--- a/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
+++ b/Riot/Modules/Spaces/SpaceMenu/SpaceMenuPresenter.swift
@@ -101,7 +101,7 @@ class SpaceMenuPresenter: NSObject {
     }
     
     private func showLeaveSpace() {
-        let name = session.spaceService.getSpace(withId: spaceId)?.summary?.displayname ?? VectorL10n.spaceTag
+        let name = session.spaceService.getSpace(withId: spaceId)?.summary?.displayName ?? VectorL10n.spaceTag
         
         let selectionHeader = MatrixItemChooserSelectionHeader(title: VectorL10n.leaveSpaceSelectionTitle,
                                                                selectAllTitle: VectorL10n.leaveSpaceSelectionAllRooms,

--- a/Riot/Modules/Spaces/SpaceMenu/SpaceMenuViewController.swift
+++ b/Riot/Modules/Spaces/SpaceMenu/SpaceMenuViewController.swift
@@ -140,9 +140,9 @@ class SpaceMenuViewController: UIViewController {
             return
         }
         
-        let avatarViewData = AvatarViewData(matrixItemId: summary.roomId, displayName: summary.displayname, avatarUrl: summary.avatar, mediaManager: self.session.mediaManager, fallbackImage: .matrixItem(summary.roomId, summary.displayname))
+        let avatarViewData = AvatarViewData(matrixItemId: summary.roomId, displayName: summary.displayName, avatarUrl: summary.avatar, mediaManager: self.session.mediaManager, fallbackImage: .matrixItem(summary.roomId, summary.displayName))
 
-        self.titleLabel.text = space.summary?.displayname
+        self.titleLabel.text = space.summary?.displayName
         // TODO: display members instead once done on android
 //        self.subtitleLabel.text = space.membersId.count == 1 ? VectorL10n.roomTitleOneMember :
 //            VectorL10n.roomTitleMembers("\(space.membersId.count)")

--- a/Riot/Modules/Spaces/SpaceRoomList/ExploreRoomCoordinator.swift
+++ b/Riot/Modules/Spaces/SpaceRoomList/ExploreRoomCoordinator.swift
@@ -60,7 +60,7 @@ final class ExploreRoomCoordinator: NSObject, ExploreRoomCoordinatorType {
     
     func start() {
 
-        let rootCoordinator = self.createShowSpaceExploreRoomCoordinator(session: self.session, spaceId: self.spaceId, spaceName: self.session.spaceService.getSpace(withId: self.spaceId)?.summary?.displayname)
+        let rootCoordinator = self.createShowSpaceExploreRoomCoordinator(session: self.session, spaceId: self.spaceId, spaceName: self.session.spaceService.getSpace(withId: self.spaceId)?.summary?.displayName)
 
         rootCoordinator.start()
 

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -607,14 +607,14 @@
                 inMatrixSession:(MXSession*)mxSession
 {
     if (roomParentId) {
-        NSString *parentName = [mxSession roomSummaryWithRoomId:roomParentId].displayname;
+        NSString *parentName = [mxSession roomSummaryWithRoomId:roomParentId].displayName;
         NSMutableArray<NSString *> *breadcrumbs = [[NSMutableArray alloc] initWithObjects:parentName, nil];
 
         MXSpace *firstRootAncestor = roomParentId ? [mxSession.spaceService firstRootAncestorForRoomWithId:roomParentId] : nil;
         NSString *rootName = nil;
         if (firstRootAncestor)
         {
-            rootName = [mxSession roomSummaryWithRoomId:firstRootAncestor.spaceId].displayname;
+            rootName = [mxSession roomSummaryWithRoomId:firstRootAncestor.spaceId].displayName;
             [breadcrumbs insertObject:rootName atIndex:0];
         }
         titleView.breadcrumbView.breadcrumbs = breadcrumbs;

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -241,7 +241,7 @@ class NotificationService: UNNotificationServiceExtension {
         
         // If a room summary is available, use the displayname for the best attempt title.
         guard let roomSummary = NotificationService.backgroundSyncService.roomSummary(forRoomId: roomId) else { return }
-        guard let roomDisplayName = roomSummary.displayname else { return }
+        guard let roomDisplayName = roomSummary.displayName else { return }
         bestAttemptContents[eventId]?.title = roomDisplayName
         
         // At this stage we don't know the message type, so leave the body as set in didReceive.
@@ -383,7 +383,7 @@ class NotificationService: UNNotificationServiceExtension {
                     var ignoreBadgeUpdate = false
                     var threadIdentifier: String? = roomId
                     let currentUserId = account.mxCredentials.userId
-                    let roomDisplayName = roomSummary?.displayname
+                    let roomDisplayName = roomSummary?.displayName
                     let pushRule = NotificationService.backgroundSyncService.pushRule(matching: event, roomState: roomState)
                 
                     // if the push rule must not be notified we complete and return

--- a/RiotShareExtension/Shared/ShareDataSource.m
+++ b/RiotShareExtension/Shared/ShareDataSource.m
@@ -141,7 +141,7 @@
         {
             for (NSString* pattern in patternsList)
             {
-                if (cellData.roomSummary.displayname && [cellData.roomSummary.displayname rangeOfString:pattern options:NSCaseInsensitiveSearch].location != NSNotFound)
+                if (cellData.roomSummary.displayName && [cellData.roomSummary.displayName rangeOfString:pattern options:NSCaseInsensitiveSearch].location != NSNotFound)
                 {
                     [self.visibleRoomCellDatas addObject:cellData];
                     break;

--- a/RiotSwiftUI/Modules/Common/Extensions/MatrixSDK/MXRoomAvatarable.swift
+++ b/RiotSwiftUI/Modules/Common/Extensions/MatrixSDK/MXRoomAvatarable.swift
@@ -25,6 +25,6 @@ extension MXRoom: Avatarable {
     }
     
     var displayName: String? {
-        summary.displayname
+        summary.displayName
     }
 }

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/Coordinator/RoomNotificationSettingsCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/Coordinator/RoomNotificationSettingsCoordinator.swift
@@ -41,12 +41,12 @@ final class RoomNotificationSettingsCoordinator: RoomNotificationSettingsCoordin
         let avatarData = showAvatar ? AvatarInput(
             mxContentUri: room.summary.avatar,
             matrixItemId: room.roomId,
-            displayName: room.summary.displayname
+            displayName: room.summary.displayName
         ) : nil
         let viewModel = RoomNotificationSettingsSwiftUIViewModel(
             roomNotificationService: roomNotificationService,
             avatarData: avatarData,
-            displayName: room.summary.displayname,
+            displayName: room.summary.displayName,
             roomEncrypted: room.summary.isEncrypted
         )
         let avatarService: AvatarServiceProtocol = AvatarService(mediaManager: room.mxSession.mediaManager)

--- a/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/MatrixSDK/MatrixListItemData+Riot.swift
+++ b/RiotSwiftUI/Modules/Spaces/MatrixItemChooser/Service/MatrixSDK/MatrixListItemData+Riot.swift
@@ -27,7 +27,7 @@ extension MatrixListItemData {
         if parentSpaceIds.isEmpty {
             detailText = nil
         } else {
-            if let spaceName = spaceService.getSpace(withId: parentSpaceIds.first ?? "")?.summary?.displayname {
+            if let spaceName = spaceService.getSpace(withId: parentSpaceIds.first ?? "")?.summary?.displayName {
                 let count = parentSpaceIds.count - 1
                 switch count {
                 case 0:
@@ -51,6 +51,6 @@ extension MatrixListItemData {
         } else {
             type = .room
         }
-        self.init(id: mxRoom.roomId, type: type, avatar: mxRoom.avatarData, displayName: mxRoom.summary.displayname, detailText: detailText)
+        self.init(id: mxRoom.roomId, type: type, avatar: mxRoom.avatarData, displayName: mxRoom.summary.displayName, detailText: detailText)
     }
 }

--- a/RiotSwiftUI/Modules/Spaces/SpaceCreation/Coordinator/SpaceCreationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceCreation/Coordinator/SpaceCreationCoordinator.swift
@@ -47,7 +47,7 @@ final class SpaceCreationCoordinator: Coordinator {
     init(parameters: SpaceCreationCoordinatorParameters) {
         let title: String
         let message: String
-        if let parentSpaceId = parameters.parentSpaceId, let parentSpaceName = parameters.session.spaceService.getSpace(withId: parentSpaceId)?.summary?.displayname {
+        if let parentSpaceId = parameters.parentSpaceId, let parentSpaceName = parameters.session.spaceService.getSpace(withId: parentSpaceId)?.summary?.displayName {
             title = VectorL10n.spacesSubspaceCreationVisibilityTitle
             message = VectorL10n.spacesSubspaceCreationVisibilityMessage(parentSpaceName)
         } else {

--- a/RiotSwiftUI/Modules/Spaces/SpaceSelectorBottomSheet/SpaceSelector/Service/MatrixSDK/SpaceSelectorService.swift
+++ b/RiotSwiftUI/Modules/Spaces/SpaceSelectorBottomSheet/SpaceSelector/Service/MatrixSDK/SpaceSelectorService.swift
@@ -77,7 +77,7 @@ class SpaceSelectorService: SpaceSelectorServiceProtocol {
             return nil
         }
         
-        return summary.displayname
+        return summary.displayName
     }
     
     // MARK: Public
@@ -117,7 +117,7 @@ private extension SpaceSelectorListItemData {
         
         return SpaceSelectorListItemData(id: summary.roomId,
                                          avatar: summary.room.avatarData,
-                                         displayName: summary.displayname,
+                                         displayName: summary.displayName,
                                          notificationCount: notificationState?.groupMissedDiscussionsCount ?? 0,
                                          highlightedNotificationCount: notificationState?.groupMissedDiscussionsHighlightedCount ?? 0,
                                          hasSubItems: !space.childSpaces.isEmpty,

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/MatrixSDK/TemplateRoomChatService.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomChat/Service/MatrixSDK/TemplateRoomChatService.swift
@@ -28,7 +28,7 @@ class TemplateRoomChatService: TemplateRoomChatServiceProtocol {
     private(set) var roomInitializationStatus: CurrentValueSubject<TemplateRoomChatRoomInitializationStatus, Never>
     
     var roomName: String? {
-        room.summary.displayname
+        room.summary.displayName
     }
     
     init(room: MXRoom) {

--- a/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/MatrixSDK/TemplateRoomListService.swift
+++ b/RiotSwiftUI/Modules/Template/TemplateAdvancedRoomsExample/TemplateRoomList/Service/MatrixSDK/TemplateRoomListService.swift
@@ -35,6 +35,6 @@ class TemplateRoomListService: TemplateRoomListServiceProtocol {
 
 private extension TemplateRoomListRoom {
     init(mxRoom: MXRoom) {
-        self.init(id: mxRoom.roomId, avatar: mxRoom.avatarData, displayName: mxRoom.summary.displayname)
+        self.init(id: mxRoom.roomId, avatar: mxRoom.avatarData, displayName: mxRoom.summary.displayName)
     }
 }

--- a/SiriIntents/ContactResolver/ContactResolver.m
+++ b/SiriIntents/ContactResolver/ContactResolver.m
@@ -122,7 +122,7 @@
                             INPersonHandle *personHandle = [[INPersonHandle alloc] initWithValue:user.userId type:INPersonHandleTypeUnknown];
                             
                             // For rooms we try to use room display name
-                            NSString *displayName = summary.displayname ? summary.displayname : user.displayname;
+                            NSString *displayName = summary.displayName ? summary.displayName : user.displayname;
                             
                             INPerson *person = [[INPerson alloc] initWithPersonHandle:personHandle
                                                                        nameComponents:nil


### PR DESCRIPTION
In the latest develop version of the matrix sdk the RoomSummary displayname has been renamed displayName.
The PR fixes any error related to the name change.

Requires the latest Matrix SDK.
