### PR TITLE
Improve avatar tappability

### DIFF
--- a/Riot/Modules/Home/AllChats/AllChatsCoordinator.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsCoordinator.swift
@@ -366,7 +366,8 @@ class AllChatsCoordinator: NSObject, SplitViewMasterCoordinatorProtocol {
         view.backgroundColor = .clear
         
         let avatarInsets: UIEdgeInsets = .init(top: 7, left: 7, bottom: 7, right: 7)
-        let button: UIButton = .init(frame: view.bounds.inset(by: avatarInsets))
+        let button: UIButton = .init(frame: view.bounds)
+        button.imageEdgeInsets = avatarInsets
         button.setImage(Asset.Images.tabPeople.image, for: .normal)
         button.menu = avatarMenu
         button.showsMenuAsPrimaryAction = true
@@ -386,12 +387,12 @@ class AllChatsCoordinator: NSObject, SplitViewMasterCoordinatorProtocol {
     }
     
     private func updateAvatarButtonItem() {
-        guard let avatarView = avatarMenuView, let button = avatarMenuButton, let avatar = userAvatarViewData(from: currentMatrixSession) else {
-            return
+        if let avatar = userAvatarViewData(from: currentMatrixSession) {
+            avatarMenuView?.fill(with: avatar)
+            avatarMenuButton?.setImage(nil, for: .normal)
+        } else {
+            avatarMenuButton?.setImage(Asset.Images.tabPeople.image, for: .normal)
         }
-        
-        button.setImage(nil, for: .normal)
-        avatarView.fill(with: avatar)
     }
     
     private func showRoom(withId roomId: String, eventId: String? = nil) {

--- a/changelog.d/pr-7427.bugfix
+++ b/changelog.d/pr-7427.bugfix
@@ -1,0 +1,1 @@
+Room list: increase tappability area of the avatar button.


### PR DESCRIPTION
This PR improves the tappability area (in red) of the avatar icon in the room list.
It also improves bit the fallback case when the avatar may not be available.

Fixes https://github.com/vector-im/customer-retainer/issues/13

| **Before** | **After** |
|---|---|
| ![b2](https://user-images.githubusercontent.com/19324622/225049953-ad03e1f4-e4fe-4e10-a111-5e222a2b20b7.png)| ![b3](https://user-images.githubusercontent.com/19324622/225050053-503eb96a-1817-483f-b77b-5263b64b9518.png)|