### PR TITLE
Manage bad m.file attachment format

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -1362,13 +1362,20 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
                         {
                             body = body? body : [VectorL10n noticeFileAttachment];
                             
-                            NSDictionary *fileInfo = contentToUse[@"info"];
+                            NSDictionary *fileInfo;
+                            MXJSONModelSetDictionary(fileInfo, contentToUse[@"info"]);
                             if (fileInfo)
                             {
-                                NSNumber *fileSize = fileInfo[@"size"];
+                                NSNumber *fileSize;
+                                MXJSONModelSetNumber(fileSize, fileInfo[@"size"])
                                 if (fileSize)
                                 {
                                     body = [NSString stringWithFormat:@"%@ (%@)", body, [MXTools fileSizeToString: fileSize.longValue]];
+                                }
+                                else
+                                {
+                                    MXLogDebug(@"[MXKEventFormatter] Warning: Unsupported m.file format: %@", event.description);
+                                    *error = MXKEventFormatterErrorUnsupported;
                                 }
                             }
                         }

--- a/changelog.d/7406.bugfix
+++ b/changelog.d/7406.bugfix
@@ -1,0 +1,1 @@
+Manage bad m.file attachment format.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-ios/issues/7406

By using value type checker methods.

With this fix, attachments with a wrong `size` format are still displayed in the timeline. Only the size is omitted like on the last item on this screenshot:

<img width="393" alt="Screenshot 2023-03-15 at 14 52 21" src="https://user-images.githubusercontent.com/8418515/225337706-ca01f046-6d83-4fd4-86f5-eb9c648b2b9f.png">


