### PR TITLE
Increase local rust crypto rollout to 20% of all users

### DIFF
--- a/Riot/Experiments/CryptoSDKFeature.swift
+++ b/Riot/Experiments/CryptoSDKFeature.swift
@@ -15,6 +15,7 @@
 //
 
 import Foundation
+import MatrixSDKCrypto
 
 /// An implementation of `MXCryptoV2Feature` which uses `UserDefaults` to persist the enabled status
 /// of `CryptoSDK`, and which uses feature flags to control rollout availability.
@@ -29,6 +30,11 @@ import Foundation
 /// feature group.
 @objc class CryptoSDKFeature: NSObject, MXCryptoV2Feature {
     @objc static let shared = CryptoSDKFeature()
+    
+    var version: String {
+        // Will be moved into the olm machine as API
+        Bundle(for: OlmMachine.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
     
     var isEnabled: Bool {
         RiotSettings.shared.enableCryptoSDK
@@ -45,7 +51,7 @@ import Foundation
             // Local feature is currently set to 0% target, and all availability is fully controlled
             // by the remote feature. Once the remote is fully rolled out, target for local feature will
             // be gradually increased.
-            targetPercentage: 0.0
+            targetPercentage: 0.2
         )
     }
     

--- a/Riot/Modules/Analytics/SentryMonitoringClient.swift
+++ b/Riot/Modules/Analytics/SentryMonitoringClient.swift
@@ -46,6 +46,9 @@ struct SentryMonitoringClient {
                 if let message = event.message?.formatted {
                     event.fingerprint = [message]
                 }
+                event.tags = [
+                    "crypto_module": MXSDKOptions.sharedInstance().cryptoModuleId
+                ]
                 MXLog.debug("[SentryMonitoringClient] Issue detected: \(event)")
                 return event
             }

--- a/changelog.d/pr-7434.change
+++ b/changelog.d/pr-7434.change
@@ -1,0 +1,1 @@
+Crypto: Increase local rust crypto rollout to 20% of all users


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-ios-sdk/pull/1742

Also, add crypto module identification to Sentry issues