### PR TITLE
Simplify event encryption decoration

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -187,7 +187,7 @@
     // Always show a warning badge if there was a decryption error.
     if (event.decryptionError)
     {
-        return EventEncryptionDecorationDecryptionError;
+        return EventEncryptionDecorationRed;
     }
     
     // Unencrypted message events should show a warning unless they're pending local echoes
@@ -199,29 +199,20 @@
             return EventEncryptionDecorationNone;
         }
             
-        return EventEncryptionDecorationNotEncrypted;
+        return EventEncryptionDecorationRed;
     }
     
     // The encryption is in a good state.
-    // Only show a warning badge if there are trust issues.
-    if (event.sender)
+    // Only show a warning badge if there are decryption trust issues.
+    switch (event.decryptionDecoration.color)
     {
-        MXUserTrustLevel *userTrustLevel = [session.crypto trustLevelForUser:event.sender];
-        MXDeviceInfo *deviceInfo = [session.crypto eventDeviceInfo:event];
-        
-        if (userTrustLevel.isVerified && !deviceInfo.trustLevel.isVerified)
-        {
-            return EventEncryptionDecorationUntrustedDevice;
-        }
+        case MXEventDecryptionDecorationColorRed:
+            return EventEncryptionDecorationRed;
+        case MXEventDecryptionDecorationColorGrey:
+            return EventEncryptionDecorationGrey;
+        case MXEventDecryptionDecorationColorNone:
+            return EventEncryptionDecorationNone;
     }
-    
-    if (event.isUntrusted)
-    {
-        return EventEncryptionDecorationUnsafeKey;
-    }
-    
-    // Everything was fine
-    return EventEncryptionDecorationNone;
 }
 
 @end

--- a/Riot/Modules/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/Riot/Modules/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -192,7 +192,12 @@ static NSAttributedString *verticalWhitespace = nil;
         NSString *claimedKey = _mxEvent.keysClaimed[@"ed25519"];
         NSString *algorithm = _mxEvent.wireContent[@"algorithm"];
         NSString *sessionId = _mxEvent.wireContent[@"session_id"];
-        NSString *untrusted = _mxEvent.isUntrusted ? [VectorL10n roomEventEncryptionInfoKeyAuthenticityNotGuaranteed] : [VectorL10n userVerificationSessionsListSessionTrusted];
+        NSString *safetyMessage = _mxEvent.decryptionDecoration.message;
+        if (!safetyMessage)
+        {
+            // Use default copy if none is provided by the decryption decoration
+            safetyMessage = _mxEvent.decryptionDecoration.color != MXEventDecryptionDecorationColorNone ? [VectorL10n roomEventEncryptionInfoKeyAuthenticityNotGuaranteed] : [VectorL10n userVerificationSessionsListSessionTrusted];
+        }
         
         NSString *decryptionError;
         if (_mxEvent.decryptionError)
@@ -218,7 +223,8 @@ static NSAttributedString *verticalWhitespace = nil;
         }
         
         [eventInformationString appendAttributedString:[[NSMutableAttributedString alloc]
-                                                        initWithString:[VectorL10n roomEventEncryptionInfoEventUserId]                                                        attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
+                                                        initWithString:[VectorL10n roomEventEncryptionInfoEventUserId]
+                                                        attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
                                                                      NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
         [eventInformationString appendAttributedString:[[NSMutableAttributedString alloc]
                                                         initWithString:senderId
@@ -284,7 +290,7 @@ static NSAttributedString *verticalWhitespace = nil;
                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
                                                                      NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
         [eventInformationString appendAttributedString:[[NSMutableAttributedString alloc]
-                                                        initWithString:untrusted
+                                                        initWithString:safetyMessage
                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
                                                                      NSFontAttributeName: [UIFont systemFontOfSize:14]}]];
         [eventInformationString appendAttributedString:[MXKEncryptionInfoView verticalWhitespace]];
@@ -368,7 +374,8 @@ static NSAttributedString *verticalWhitespace = nil;
         [deviceInformationString appendAttributedString:[MXKEncryptionInfoView verticalWhitespace]];
         
         [deviceInformationString appendAttributedString:[[NSMutableAttributedString alloc]
-                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceId]                                                             attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
+                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceId]
+                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
         [deviceInformationString appendAttributedString:[[NSMutableAttributedString alloc]
                                                          initWithString:deviceId
                                                          attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
@@ -376,12 +383,14 @@ static NSAttributedString *verticalWhitespace = nil;
         [deviceInformationString appendAttributedString:[MXKEncryptionInfoView verticalWhitespace]];
         
         [deviceInformationString appendAttributedString:[[NSMutableAttributedString alloc]
-                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceVerification]                                                             attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
+                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceVerification]
+                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
         [deviceInformationString appendAttributedString:verification];
         [deviceInformationString appendAttributedString:[MXKEncryptionInfoView verticalWhitespace]];
         
         [deviceInformationString appendAttributedString:[[NSMutableAttributedString alloc]
-                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceFingerprint]                                                             attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
+                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceFingerprint]
+                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont boldSystemFontOfSize:14]}]];
         [deviceInformationString appendAttributedString:[[NSMutableAttributedString alloc]
                                                          initWithString:fingerprint
                                                          attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
@@ -392,7 +401,8 @@ static NSAttributedString *verticalWhitespace = nil;
     {
         // Unknown device
         [deviceInformationString appendAttributedString:[[NSMutableAttributedString alloc]
-                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceUnknown]                                                             attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont italicSystemFontOfSize:14]}]];
+                                                         initWithString:[VectorL10n roomEventEncryptionInfoDeviceUnknown]
+                                                         attributes:@{NSForegroundColorAttributeName: _defaultTextColor, NSFontAttributeName: [UIFont italicSystemFontOfSize:14]}]];
     }
     
     [textViewAttributedString appendAttributedString:deviceInformationString];
@@ -462,7 +472,8 @@ static NSAttributedString *verticalWhitespace = nil;
         {
             // Prompt user
             NSMutableAttributedString *textViewAttributedString = [[NSMutableAttributedString alloc]
-                                                                   initWithString:[VectorL10n roomEventEncryptionVerifyTitle]                                                                   attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
+                                                                   initWithString:[VectorL10n roomEventEncryptionVerifyTitle]
+                                                                   attributes:@{NSForegroundColorAttributeName: _defaultTextColor,
                                                                                 NSFontAttributeName: [UIFont boldSystemFontOfSize:17]}];
             
             NSString *message = [VectorL10n roomEventEncryptionVerifyMessage:_mxDeviceInfo.displayName :_mxDeviceInfo.deviceId :_mxDeviceInfo.fingerprint];

--- a/Riot/Modules/Room/TimelineCells/Encryption/EventEncryptionDecoration.h
+++ b/Riot/Modules/Room/TimelineCells/Encryption/EventEncryptionDecoration.h
@@ -17,14 +17,14 @@
 #ifndef EventEncryptionDecoration_h
 #define EventEncryptionDecoration_h
 
+/**
+ Decoration used alongside encrypted events
+ */
 typedef NS_ENUM(NSUInteger, EventEncryptionDecoration)
 {
     EventEncryptionDecorationNone,
-    EventEncryptionDecorationUnsafeKey,
-    EventEncryptionDecorationDecryptionError,
-    EventEncryptionDecorationNotEncrypted,
-    EventEncryptionDecorationUntrustedDevice
+    EventEncryptionDecorationGrey,
+    EventEncryptionDecorationRed
 };
-
 
 #endif /* EventEncryptionDecoration_h */

--- a/Riot/Modules/Room/TimelineCells/Encryption/RoomEncryptedDataBubbleCell.m
+++ b/Riot/Modules/Room/TimelineCells/Encryption/RoomEncryptedDataBubbleCell.m
@@ -27,11 +27,9 @@ NSString *const kRoomEncryptedDataBubbleCellTapOnEncryptionIcon = @"kRoomEncrypt
     switch (bubbleComponent.encryptionDecoration) {
         case EventEncryptionDecorationNone:
             return nil;
-        case EventEncryptionDecorationUnsafeKey:
+        case EventEncryptionDecorationGrey:
             return AssetImages.encryptionUntrusted.image;
-        case EventEncryptionDecorationDecryptionError:
-        case EventEncryptionDecorationNotEncrypted:
-        case EventEncryptionDecorationUntrustedDevice:
+        case EventEncryptionDecorationRed:
             return AssetImages.encryptionWarning.image;
         default:
             return nil;

--- a/changelog.d/pr-7440.change
+++ b/changelog.d/pr-7440.change
@@ -1,0 +1,1 @@
+Encryption: Simplify event encryption decoration


### PR DESCRIPTION
Related SDK change https://github.com/matrix-org/matrix-ios-sdk/pull/1743

Resolves https://github.com/vector-im/element-ios/issues/7441

Move some of the event encryption decoration logic down into the SDK and simplify the model to only mention colors (red, grey, none) rather than reasons (unsafe key, untrusted ...)