### PR TITLE
Fix: prevent a crash if we don’t have a display name for the user mentionned by the pill

### DIFF
--- a/Riot/Modules/Pills/PillProvider.swift
+++ b/Riot/Modules/Pills/PillProvider.swift
@@ -267,7 +267,7 @@ struct PillProvider {
         let displayText: String
         let avatar: PillTextAttachmentItem
         if let roomMember {
-            displayText = VectorL10n.pillMessageFrom(roomMember.displayname)
+            displayText = VectorL10n.pillMessageFrom(roomMember.displayname ?? roomMember.userId)
             avatar = .avatar(url: roomMember.avatarUrl,
                              string: roomMember.displayname,
                              matrixId: roomMember.userId)


### PR DESCRIPTION
This PR fixes a crash that can occur if we don't have a display name to put in the user pill.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
