### PR TITLE
Display upgrade verification prompt

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1560,6 +1560,11 @@ Tap the + to start adding people.";
 "key_verification_self_verify_current_session_alert_message" = "Other users may not trust it.";
 "key_verification_self_verify_current_session_alert_validate_action" = "Verify";
 
+// Legacy to Rust security upgrade
+
+"key_verification_self_verify_security_upgrade_alert_title" = "Encryption upgraded";
+"key_verification_self_verify_security_upgrade_alert_message" = "The end-to-end encryption has been upgraded to be more secure. Please re-verify your account.";
+
 // Unverified sessions
 "key_verification_alert_title" = "You have unverified sessions";
 "key_verification_alert_body" = "Review to ensure your account is safe.";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1562,8 +1562,8 @@ Tap the + to start adding people.";
 
 // Legacy to Rust security upgrade
 
-"key_verification_self_verify_security_upgrade_alert_title" = "Encryption upgraded";
-"key_verification_self_verify_security_upgrade_alert_message" = "The end-to-end encryption has been upgraded to be more secure. Please re-verify your account.";
+"key_verification_self_verify_security_upgrade_alert_title" = "App updated";
+"key_verification_self_verify_security_upgrade_alert_message" = "Secure messaging has been improved with the latest update. Please re-verify your device.";
 
 // Unverified sessions
 "key_verification_alert_title" = "You have unverified sessions";

--- a/Riot/Experiments/CryptoSDKFeature.swift
+++ b/Riot/Experiments/CryptoSDKFeature.swift
@@ -40,7 +40,18 @@ import MatrixSDKCrypto
         RiotSettings.shared.enableCryptoSDK
     }
     
+    var needsVerificationUpgrade: Bool {
+        get {
+            return RiotSettings.shared.showVerificationUpgradeAlert
+        }
+        set {
+            RiotSettings.shared.showVerificationUpgradeAlert = newValue
+        }
+    }
+    
     private static let FeatureName = "ios-crypto-sdk"
+    private static let FeatureNameV2 = "ios-crypto-sdk-v2"
+    
     private let remoteFeature: RemoteFeaturesClientProtocol
     private let localFeature: PhasedRolloutFeature
     
@@ -98,6 +109,13 @@ import MatrixSDKCrypto
     }
     
     private func isFeatureEnabled(userId: String) -> Bool {
-        remoteFeature.isFeatureEnabled(Self.FeatureName) || localFeature.isEnabled(userId: userId)
+        // This feature includes app version with a bug, and thus will not be rolled out to 100% users
+        remoteFeature.isFeatureEnabled(Self.FeatureName)
+        
+        // Second version of the remote feature with a bugfix and released eventually to 100% users
+        || remoteFeature.isFeatureEnabled(Self.FeatureNameV2)
+        
+        // Local feature
+        || localFeature.isEnabled(userId: userId)
     }
 }

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3027,6 +3027,14 @@ public class VectorL10n: NSObject {
   public static var keyVerificationSelfVerifyCurrentSessionAlertValidateAction: String { 
     return VectorL10n.tr("Vector", "key_verification_self_verify_current_session_alert_validate_action") 
   }
+  /// Your end-to-end encryption algorithms have been upgraded to be more secure. Please re-verify your account.
+  public static var keyVerificationSelfVerifySecurityUpgradeAlertMessage: String { 
+    return VectorL10n.tr("Vector", "key_verification_self_verify_security_upgrade_alert_message") 
+  }
+  /// Encryption upgraded
+  public static var keyVerificationSelfVerifySecurityUpgradeAlertTitle: String { 
+    return VectorL10n.tr("Vector", "key_verification_self_verify_security_upgrade_alert_title") 
+  }
   /// Review
   public static var keyVerificationSelfVerifyUnverifiedSessionsAlertValidateAction: String { 
     return VectorL10n.tr("Vector", "key_verification_self_verify_unverified_sessions_alert_validate_action") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3027,11 +3027,11 @@ public class VectorL10n: NSObject {
   public static var keyVerificationSelfVerifyCurrentSessionAlertValidateAction: String { 
     return VectorL10n.tr("Vector", "key_verification_self_verify_current_session_alert_validate_action") 
   }
-  /// Your end-to-end encryption algorithms have been upgraded to be more secure. Please re-verify your account.
+  /// Secure messaging has been improved with the latest update. Please re-verify your device.
   public static var keyVerificationSelfVerifySecurityUpgradeAlertMessage: String { 
     return VectorL10n.tr("Vector", "key_verification_self_verify_security_upgrade_alert_message") 
   }
-  /// Encryption upgraded
+  /// App updated
   public static var keyVerificationSelfVerifySecurityUpgradeAlertTitle: String { 
     return VectorL10n.tr("Vector", "key_verification_self_verify_security_upgrade_alert_title") 
   }

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -211,6 +211,9 @@ final class RiotSettings: NSObject {
     @UserDefault(key: "hideVerifyThisSessionAlert", defaultValue: false, storage: defaults)
     var hideVerifyThisSessionAlert
     
+    @UserDefault(key: "showVerificationUpgradeAlert", defaultValue: false, storage: defaults)
+    var showVerificationUpgradeAlert
+    
     @UserDefault(key: "matrixApps", defaultValue: false, storage: defaults)
     var matrixApps
     

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -988,10 +988,8 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
         let title: String
         let message: String
         
-        if
-            let feature = MXSDKOptions.sharedInstance().cryptoSDKFeature,
-            feature.isEnabled && feature.needsVerificationUpgrade
-        {
+        if let feature = MXSDKOptions.sharedInstance().cryptoSDKFeature,
+           feature.isEnabled && feature.needsVerificationUpgrade {
             title = VectorL10n.keyVerificationSelfVerifySecurityUpgradeAlertTitle
             message = VectorL10n.keyVerificationSelfVerifySecurityUpgradeAlertMessage
         } else {

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -985,8 +985,22 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     private func presentVerifyCurrentSessionAlert(with session: MXSession) {
         MXLog.debug("[AllChatsViewController] presentVerifyCurrentSessionAlertWithSession")
         
-        let alert = UIAlertController(title: VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertTitle,
-                                      message: VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertMessage,
+        let title: String
+        let message: String
+        
+        if
+            let feature = MXSDKOptions.sharedInstance().cryptoSDKFeature,
+            feature.isEnabled && feature.needsVerificationUpgrade
+        {
+            title = VectorL10n.keyVerificationSelfVerifySecurityUpgradeAlertTitle
+            message = VectorL10n.keyVerificationSelfVerifySecurityUpgradeAlertMessage
+        } else {
+            title = VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertTitle
+            message = VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertMessage
+        }
+        
+        let alert = UIAlertController(title: title,
+                                      message: message,
                                       preferredStyle: .alert)
         
         alert.addAction(UIAlertAction(title: VectorL10n.keyVerificationSelfVerifyCurrentSessionAlertValidateAction,

--- a/changelog.d/pr-7454.change
+++ b/changelog.d/pr-7454.change
@@ -1,0 +1,1 @@
+Verification: Display upgrade verification prompt 


### PR DESCRIPTION
Related SDK change https://github.com/matrix-org/matrix-ios-sdk/pull/1751

Resolves https://github.com/vector-im/crypto-internal/issues/58

Display customized modal alert if upgrading from legacy to rust crypto and needing to verify the account.