### PR TITLE
Fix: Update the read marker position even if it is not displayed

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -7956,7 +7956,7 @@ static CGSize kThreadListBarButtonItemImageSize;
         // Give the data source ownership to the room view controller.
         self.hasRoomDataSourceOwnership = YES;
         
-        // Force the read marker update if needed (this
+        // Force the read marker update if needed (e.g if we jumped on the last unread message using the banner).
         self.updateRoomReadMarker |= forceUpdateRoomMarker;
     }];
 }

--- a/changelog.d/7420.bugfix
+++ b/changelog.d/7420.bugfix
@@ -1,0 +1,1 @@
+Update the read marker position even if it is not displayed


### PR DESCRIPTION
This PR fixes #7420 

The current implementation only updates the read marker if we are able to display the read marker view and we have identified some cases where the read marker is not updated because its view cannot be displayed:
- when it is placed on a reaction (or potentially any event that relates to another one)
- when it is placed on a redaction
- when it is placed on an event displayed in a collapsed cell (e.g. a room member update)

Also, relatesTo events can be problematic as they can cause the user to jump backwards in the timeline, even if the current read marker timestamp is more recent than the related event.

To fix these issues:
- When checking the visibility of the "jump to unread" banner, we now ask for the read marker to be updated when we are supposed to render it.
- Also, the read marker update was linked to the read receipt update. To prevent setting the read marker on an incorrect event (such as reaction, redaction ...), the read marker update is now performed separately from the read receipt.

### Pull Request Checklist

- [X] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [X] Pull request is based on the develop branch
- [X] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [X] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
