### PR TITLE
No event decoration if no decryption result

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.m
@@ -204,14 +204,21 @@
     
     // The encryption is in a good state.
     // Only show a warning badge if there are decryption trust issues.
-    switch (event.decryptionDecoration.color)
+    if (event.decryptionDecoration)
     {
-        case MXEventDecryptionDecorationColorRed:
-            return EventEncryptionDecorationRed;
-        case MXEventDecryptionDecorationColorGrey:
-            return EventEncryptionDecorationGrey;
-        case MXEventDecryptionDecorationColorNone:
-            return EventEncryptionDecorationNone;
+        switch (event.decryptionDecoration.color)
+        {
+            case MXEventDecryptionDecorationColorNone:
+                return EventEncryptionDecorationNone;
+            case MXEventDecryptionDecorationColorGrey:
+                return EventEncryptionDecorationGrey;
+            case MXEventDecryptionDecorationColorRed:
+                return EventEncryptionDecorationRed;
+        }
+    }
+    else
+    {
+        return EventEncryptionDecorationNone;
     }
 }
 

--- a/Riot/Modules/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
+++ b/Riot/Modules/MatrixKit/Views/EncryptionInfoView/MXKEncryptionInfoView.m
@@ -196,7 +196,8 @@ static NSAttributedString *verticalWhitespace = nil;
         if (!safetyMessage)
         {
             // Use default copy if none is provided by the decryption decoration
-            safetyMessage = _mxEvent.decryptionDecoration.color != MXEventDecryptionDecorationColorNone ? [VectorL10n roomEventEncryptionInfoKeyAuthenticityNotGuaranteed] : [VectorL10n userVerificationSessionsListSessionTrusted];
+            BOOL isUntrusted = _mxEvent.decryptionDecoration && _mxEvent.decryptionDecoration.color != MXEventDecryptionDecorationColorNone;
+            safetyMessage = isUntrusted ? [VectorL10n roomEventEncryptionInfoKeyAuthenticityNotGuaranteed] : [VectorL10n userVerificationSessionsListSessionTrusted];
         }
         
         NSString *decryptionError;

--- a/changelog.d/pr-7471.bugfix
+++ b/changelog.d/pr-7471.bugfix
@@ -1,0 +1,1 @@
+Timeline: No event decoration if no decryption result


### PR DESCRIPTION
There is a bug in objective-c event trust decoration, where the absence of event's `decryptionDecoration`  (i.e. it is `nil`) gets evaluated to `0` in a switch statement, which happens to be a red shield. The `decryptionDecoration` gets set pretty quickly after local echo but it does display a brief moment where a red shield is shown, even though it shoudn't be.

To solve this add explicit `nill handling to objective-c, and also [swap the order](https://github.com/matrix-org/matrix-ios-sdk/pull/1756/files#diff-ceca7b4860bf6983c2b04390eba12a4044161831c0d68b82d1de35f6df275ac1R20-R23) of decoration colors, so that 0 is none rather than red