### PR TITLE
Pin Xcode version to 14.2. The app is currently failing ASC validatio…

### DIFF
--- a/changelog.d/7476.build
+++ b/changelog.d/7476.build
@@ -1,0 +1,1 @@
+Pinned used Xcode version to 14.2 as newer version fail ASC validation

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :ios do
 
   before_all do
     # Ensure used Xcode version
-    xcversion(version: "~> 14.2")
+    xcversion(version: "14.2")
   end
 
   #### Public ####


### PR DESCRIPTION
…n on using private symbols from Down.
