### PR TITLE
Fix: If a clientPermalinkBaseUrl is defined, we still have to support matrix.to links

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/MXKTools.m
+++ b/Riot/Modules/MatrixKit/Utils/MXKTools.m
@@ -69,8 +69,9 @@ static NSRegularExpression* permalinkRegex;
         httpLinksRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\b(https?://\\S*)\\b" options:NSRegularExpressionCaseInsensitive error:nil];
         htmlTagsRegex  = [NSRegularExpression regularExpressionWithPattern:@"<(\\w+)[^>]*>" options:NSRegularExpressionCaseInsensitive error:nil];
         linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
-                
-        NSString *permalinkPattern = [NSString stringWithFormat:@"%@%@", BuildSettings.clientPermalinkBaseUrl ?: kMXMatrixDotToUrl, kMXKToolsRegexStringForPermalink];
+               
+        // if we have a custom clientPermalinkBaseUrl, we also need to support matrix.to permalinks
+        NSString *permalinkPattern = [NSString stringWithFormat:@"(?:%@|%@)%@", BuildSettings.clientPermalinkBaseUrl, kMXMatrixDotToUrl, kMXKToolsRegexStringForPermalink];
         permalinkRegex = [NSRegularExpression regularExpressionWithPattern:permalinkPattern options:NSRegularExpressionCaseInsensitive error:nil];
     });
 }

--- a/Riot/Modules/Pills/PillType.swift
+++ b/Riot/Modules/Pills/PillType.swift
@@ -27,7 +27,7 @@ enum PillType: Codable {
 extension PillType {
     private static var regexPermalinkTarget: NSRegularExpression? = {
         let clientBaseUrl = BuildSettings.clientPermalinkBaseUrl ?? kMXMatrixDotToUrl
-        let pattern = #"\#(clientBaseUrl)/#/(?:(?:room|user)/)?((?:@|!|#)[^@!#/?\s]*)/?((?:\$)[^\$/?\s]*)?"#
+        let pattern = #"(?:\#(clientBaseUrl)|\#(kMXMatrixDotToUrl))/#/(?:(?:room|user)/)?((?:@|!|#)[^@!#/?\s]*)/?((?:\$)[^\$/?\s]*)?"#
         return try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
     }()
     

--- a/changelog.d/pr-7482.bugfix
+++ b/changelog.d/pr-7482.bugfix
@@ -1,0 +1,1 @@
+Continue to display pills for matrix.to permalinks if a custom permalinkBaseUrl is set.


### PR DESCRIPTION
Currently, if a custom permalinkBaseUrl is set, matrix.to permalinks are not rendered as pills.
This fix is intended to support both types of permalinks.

Current behaviour:
![before](https://user-images.githubusercontent.com/4334885/230626340-011f8842-b3b9-46a9-8d5e-2ecdeaad0f62.jpg)

New behaviour:
![after](https://user-images.githubusercontent.com/4334885/230626359-ef9deea3-9b1a-40b1-8ab4-43de80d0c06e.jpg)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
