### PR TITLE
Enable Rust Crypto for all users

### DIFF
--- a/Riot/Experiments/CryptoSDKFeature.swift
+++ b/Riot/Experiments/CryptoSDKFeature.swift
@@ -52,7 +52,7 @@ import MatrixSDKCrypto
     
     init(
         remoteFeature: RemoteFeaturesClientProtocol = PostHogAnalyticsClient.shared,
-        localTargetPercentage: Double = 0.5
+        localTargetPercentage: Double = 1
     ) {
         self.remoteFeature = remoteFeature
         self.localFeature = PhasedRolloutFeature(

--- a/RiotTests/SessionCreatorTests.swift
+++ b/RiotTests/SessionCreatorTests.swift
@@ -25,8 +25,9 @@ class SessionCreatorTests: XCTestCase {
         let mockIS = "mock_identity_server"
 
         let credentials = MXCredentials(homeServer: "mock_home_server",
-                                        userId: "mock_user_id",
+                                        userId: "@mock_user_id:localhost",
                                         accessToken: "mock_access_token")
+        credentials.deviceId = "mock_device_id"
         let client = MXRestClient(credentials: credentials)
         client.identityServer = mockIS
         let session = await sessionCreator.createSession(credentials: credentials, client: client, removeOtherAccounts: false)

--- a/changelog.d/pr-7485.change
+++ b/changelog.d/pr-7485.change
@@ -1,0 +1,1 @@
+Crypto: Enable Rust Crypto for all users


### PR DESCRIPTION
In this final stage of Rust Crypto rollout enable the feature to all users. The feature flags mechanism and other now-unnecessary code will be removed in future PRs

Note that this change will be released as "hotfix" to only contain the target percentage change and no other features