### PR TITLE
Fix for unsupported audio messages

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift
@@ -206,11 +206,12 @@ class VoiceMessageAttachmentCacheManager {
     }
     
     private func convertFileAtPath(_ path: String?, numberOfSamples: Int, identifier: String, semaphore: DispatchSemaphore) {
-        guard let filePath = path else {
+        guard let path else {
             return
         }
-        
-        let fileExtension = filePath.hasSuffix(".mp4") ? "mp4" : "m4a"
+
+        let filePath = URL(fileURLWithPath: path)
+        let fileExtension = filePath.hasSupportedAudioExtension ? filePath.pathExtension : "m4a"
         let newURL = temporaryFilesFolderURL.appendingPathComponent(identifier).appendingPathExtension(fileExtension)
         
         let conversionCompletion: (Result<Void, VoiceMessageAudioConverterError>) -> Void = { result in
@@ -252,7 +253,7 @@ class VoiceMessageAttachmentCacheManager {
         if FileManager.default.fileExists(atPath: newURL.path) {
             conversionCompletion(Result.success(()))
         } else {
-            VoiceMessageAudioConverter.convertToMPEG4AAC(sourceURL: URL(fileURLWithPath: filePath), destinationURL: newURL, completion: conversionCompletion)
+            VoiceMessageAudioConverter.convertToMPEG4AACIfNeeded(sourceURL: filePath, destinationURL: newURL, completion: conversionCompletion)
         }
     }
     

--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioConverter.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageAudioConverter.swift
@@ -39,10 +39,10 @@ struct VoiceMessageAudioConverter {
         }
     }
     
-    static func convertToMPEG4AAC(sourceURL: URL, destinationURL: URL, completion: @escaping (Result<Void, VoiceMessageAudioConverterError>) -> Void) {
+    static func convertToMPEG4AACIfNeeded(sourceURL: URL, destinationURL: URL, completion: @escaping (Result<Void, VoiceMessageAudioConverterError>) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
-                if sourceURL.pathExtension == "mp4" {
+                if sourceURL.hasSupportedAudioExtension {
                     try FileManager.default.copyItem(atPath: sourceURL.path, toPath: destinationURL.path)
                 } else {
                     try OGGConverter.convertOpusOGGToM4aFile(src: sourceURL, dest: destinationURL)
@@ -84,5 +84,13 @@ struct VoiceMessageAudioConverter {
             default: break
             }
         }
+    }
+}
+
+extension URL {
+    /// Returns true if the URL has a supported audio extension
+    var hasSupportedAudioExtension: Bool {
+        let supportedExtensions = ["mp3", "mp4", "m4a", "wav", "aac"]
+        return supportedExtensions.contains(pathExtension.lowercased())
     }
 }

--- a/changelog.d/7451.bugfix
+++ b/changelog.d/7451.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that prevented audio messages that were not .mp4 to be played in the timeline


### PR DESCRIPTION
Essentially any audio message that was not a voice message or an mp4, could not be played in the timeline.
Now we can support multiple formats (the most common ones like .mp4, .aac, .mp3, .wav)