### PR TITLE
Fix: add missing foreground color attribute

### DIFF
--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -103,7 +103,8 @@ static NSString *const kEventFormatterTimeFormat = @"HH:mm";
                 @"event_id": event.eventId ?: @"unknown"
             });
             string = [[NSAttributedString alloc] initWithString:[VectorL10n noticeErrorUnformattableEvent] attributes:@{
-                NSFontAttributeName: [self encryptedMessagesTextFont]
+                NSFontAttributeName: [self encryptedMessagesTextFont],
+                NSForegroundColorAttributeName: [self encryptingTextColor]
             }];
         }
     }

--- a/changelog.d/pr-7501.bugfix
+++ b/changelog.d/pr-7501.bugfix
@@ -1,0 +1,1 @@
+Add a foreground color attribute for the unformattable event error message.


### PR DESCRIPTION
If the event formatter fails to create an attributed string for an event, a default attributed string is generated but it does not have a colour attribute, making it difficult to see in dark mode.

Current behaviour:
<img width="393" alt="missing-color-attribute" src="https://user-images.githubusercontent.com/4334885/232502493-20c52edd-619c-40e0-8520-46de4c06b2f3.png">

With this fix:
<img width="394" alt="missing-color-attribute-fix" src="https://user-images.githubusercontent.com/4334885/232502769-3ccc5927-0fcc-403c-8853-4567fdd174e5.png">
