### PR TITLE
Fix: Calculation of the frame for a component of a bubble

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.h
@@ -145,6 +145,15 @@
 - (CGFloat)rawTextHeight:(NSAttributedString*)attributedText;
 
 /**
+ Return the raw height of the provided text by removing any vertical margin/inset and constraining the width.
+ 
+ @param attributedText the attributed text to measure
+ @param maxTextViewWidth the maximum text width
+ @return the computed height
+ */
+- (CGFloat)rawTextHeight:(NSAttributedString*)attributedText withMaxWidth:(CGFloat)maxTextViewWidth;
+
+/**
  Return the content size of a text view initialized with the provided attributed text.
  CAUTION: This method runs only on main thread.
  

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellData.m
@@ -501,22 +501,33 @@
 // Return the raw height of the provided text by removing any margin
 - (CGFloat)rawTextHeight: (NSAttributedString*)attributedText
 {
+    return [self rawTextHeight:attributedText withMaxWidth:_maxTextViewWidth];
+}
+
+// Return the raw height of the provided text by removing any vertical margin/inset and constraining the width.
+- (CGFloat)rawTextHeight: (NSAttributedString*)attributedText withMaxWidth:(CGFloat)maxTextViewWidth
+{
     __block CGSize textSize;
     if ([NSThread currentThread] != [NSThread mainThread])
     {
         dispatch_sync(dispatch_get_main_queue(), ^{
-            textSize = [self textContentSize:attributedText removeVerticalInset:YES];
+            textSize = [self textContentSize:attributedText removeVerticalInset:YES maxTextViewWidth:maxTextViewWidth];
         });
     }
     else
     {
-        textSize = [self textContentSize:attributedText removeVerticalInset:YES];
+        textSize = [self textContentSize:attributedText removeVerticalInset:YES maxTextViewWidth:maxTextViewWidth];
     }
     
     return textSize.height;
 }
 
 - (CGSize)textContentSize:(NSAttributedString*)attributedText removeVerticalInset:(BOOL)removeVerticalInset
+{
+    return [self textContentSize:attributedText removeVerticalInset:removeVerticalInset maxTextViewWidth:_maxTextViewWidth];
+}
+
+- (CGSize)textContentSize:(NSAttributedString*)attributedText removeVerticalInset:(BOOL)removeVerticalInset maxTextViewWidth:(CGFloat)maxTextViewWidth
 {
     static UITextView* measurementTextView = nil;
     static UITextView* measurementTextViewWithoutInset = nil;
@@ -536,7 +547,7 @@
         // Select the right text view for measurement
         UITextView *selectedTextView = (removeVerticalInset ? measurementTextViewWithoutInset : measurementTextView);
         
-        selectedTextView.frame = CGRectMake(0, 0, _maxTextViewWidth, 0);
+        selectedTextView.frame = CGRectMake(0, 0, maxTextViewWidth, 0);
         selectedTextView.attributedText = attributedText;
         
         // Force the layout manager to layout the text, fixes problems starting iOS 16

--- a/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/TextMessage/Outgoing/TextMessageOutgoingWithoutSenderInfoBubbleCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Styles/Bubble/Cells/TextMessage/Outgoing/TextMessageOutgoingWithoutSenderInfoBubbleCell.swift
@@ -35,6 +35,15 @@ class TextMessageOutgoingWithoutSenderInfoBubbleCell: TextMessageBaseBubbleCell,
         self.textMessageContentView?.bubbleBackgroundView?.backgroundColor = theme.roomCellOutgoingBubbleBackgroundColor
     }
     
+    override func render(_ cellData: MXKCellData!) {
+        // This cell displays an outgoing message without any sender information.
+        // However, we need to set the following properties to our cellData, otherwise, to make room for the timestamp, a whitespace could be added when calculating the position of the components.
+        // If we don't, the component frame calculation will not work for this cell.
+        (cellData as? RoomBubbleCellData)?.shouldHideSenderName = false
+        (cellData as? RoomBubbleCellData)?.shouldHideSenderInformation = false
+        super.render(cellData)
+    }
+    
     // MARK: - Private
     
     private func setupBubbleConstraints() {

--- a/changelog.d/pr-7512.bugfix
+++ b/changelog.d/pr-7512.bugfix
@@ -1,0 +1,1 @@
+Fix the position of the send confirmation icon.


### PR DESCRIPTION
This PR fixes some issues with the calculation of the frame for a bubble component.
- the height of the text is not calculated with the correct width, resulting in an incorrect calculated Y position when using the bubble timeline style.
- the component's position may be calculated with an extra positioning space (to make room for the timestamp above the component), even for cells of kind `TextMessageOutgoingWithoutSenderInfoBubbleCell`

These issues result in the sent confirmation icon being misplaced and make it difficult to run to detect the sent confirmation icon in UITests.

### Examples:

### First message in a room:
**Current implementation:**
<kbd><img width="388" alt="1st message" src="https://user-images.githubusercontent.com/4334885/233298324-9d9599f4-bb3c-4a17-9bc9-0481d4a600bf.png"></kbd>

after a restart of the app, the sent confirmation icon has moved:
<kbd><img width="388" alt="1st message - relaunch" src="https://user-images.githubusercontent.com/4334885/233298521-7434de59-eb10-4a65-8d39-31c1133e0566.png"></kbd>

**With this PR:**
<kbd><img width="392" alt="1st message - fix" src="https://user-images.githubusercontent.com/4334885/233298645-6f2f307d-d0e2-4288-b91e-d2a178698472.png"></kbd>

after a restart, the icon stays at the same position:
<kbd><img width="390" alt="1st message - relaunch - fix" src="https://user-images.githubusercontent.com/4334885/233298762-c7bbbbfe-6128-4f05-b106-90447deccfae.png"></kbd>

### Second message in a room:
**Current implementation:** the icon position is not a the same place
<kbd><img width="388" alt="2nd message" src="https://user-images.githubusercontent.com/4334885/233298870-f9b5ff17-fc8e-44d0-8d87-9a9539cb1708.png"></kbd>

**With this PR:** the icon remains aligned with the bottom of the component.
<kbd><img width="392" alt="2nd message - fix" src="https://user-images.githubusercontent.com/4334885/233299451-d12d7ceb-a250-4be3-aa89-53d54149f1b0.png"></kbd>

### Long message:
**Current implementation:**
<kbd><img width="388" alt="long message" src="https://user-images.githubusercontent.com/4334885/233299824-5afddbac-32a0-465c-859c-98be682cf70b.png"></kbd>

**With this PR:**
<kbd><img width="392" alt="long message - fix" src="https://user-images.githubusercontent.com/4334885/233299883-c7ef3f81-bf19-4cda-b751-27cff8d53246.png"></kbd>

### With pagination:
**Current implementation:**
<kbd><img width="389" alt="with pagination" src="https://user-images.githubusercontent.com/4334885/233300024-ed4c0e7d-5656-4e8b-9abd-971253d475cd.png"></kbd>

**With this PR:**
<kbd><img width="391" alt="with pagination - fix" src="https://user-images.githubusercontent.com/4334885/233300079-e1be42ae-eeef-4570-b5fa-73ff5b8247d8.png"></kbd>
