### PR TITLE
Fix: allow to render a TimelinePoll even if the poll is loading

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2405,6 +2405,8 @@ Tap the + to start adding people.";
 
 "poll_timeline_reply_ended_poll" = "Ended poll";
 
+"poll_timeline_loading" = "Loading...";
+
 // MARK: - Location sharing
 
 "location_sharing_title" = "Location";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -4923,6 +4923,10 @@ public class VectorL10n: NSObject {
   public static var pollTimelineEndedText: String { 
     return VectorL10n.tr("Vector", "poll_timeline_ended_text") 
   }
+  /// Loading...
+  public static var pollTimelineLoading: String { 
+    return VectorL10n.tr("Vector", "poll_timeline_loading") 
+  }
   /// Please try again
   public static var pollTimelineNotClosedSubtitle: String { 
     return VectorL10n.tr("Vector", "poll_timeline_not_closed_subtitle") 

--- a/RiotSwiftUI/Modules/Room/PollHistory/PollHistoryDetail/MockPollHistoryDetailScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/PollHistoryDetail/MockPollHistoryDetailScreenState.swift
@@ -48,7 +48,7 @@ enum MockPollHistoryDetailScreenState: MockScreenState, CaseIterable {
     }
     
     var screenView: ([Any], AnyView) {
-        let timelineViewModel = TimelinePollViewModel(timelinePollDetails: poll)
+        let timelineViewModel = TimelinePollViewModel(timelinePollDetailsState: .loaded(poll))
         let viewModel = PollHistoryDetailViewModel(poll: poll)
         
         return ([viewModel], AnyView(PollHistoryDetail(viewModel: viewModel.context, contentPoll: TimelinePollView(viewModel: timelineViewModel.context))))

--- a/RiotSwiftUI/Modules/Room/PollHistory/Service/MatrixSDK/PollHistoryService.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/Service/MatrixSDK/PollHistoryService.swift
@@ -170,6 +170,7 @@ private extension PollHistoryService {
         
         do {
             newContext.pollAggregator = try PollAggregator(session: room.mxSession, room: room, pollEvent: pollStartEvent, delegate: self)
+            newContext.pollAggregator?.reloadPollData()
         } catch {
             pollAggregationContexts.removeValue(forKey: eventId)
         }

--- a/RiotSwiftUI/Modules/Room/PollHistory/Service/MatrixSDK/PollHistoryService.swift
+++ b/RiotSwiftUI/Modules/Room/PollHistory/Service/MatrixSDK/PollHistoryService.swift
@@ -209,7 +209,6 @@ extension PollHistoryService: PollAggregatorDelegate {
     func pollAggregator(_ aggregator: PollAggregator, didFailWithError: Error) { }
     
     func pollAggregatorDidEndLoading(_ aggregator: PollAggregator) {
-        
         guard let poll = aggregator.poll, let context = pollAggregationContexts[poll.id], context.published == false else {
             return
         }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -32,7 +32,7 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
     private let parameters: TimelinePollCoordinatorParameters
     private let selectedAnswerIdentifiersSubject = PassthroughSubject<[String], Never>()
     
-    private var pollAggregator: PollAggregator
+    private var pollAggregator: PollAggregator!
     private(set) var viewModel: TimelinePollViewModelProtocol!
     private var cancellables = Set<AnyCancellable>()
     
@@ -46,10 +46,9 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
     init(parameters: TimelinePollCoordinatorParameters) throws {
         self.parameters = parameters
         
-        try pollAggregator = PollAggregator(session: parameters.session, room: parameters.room, pollEvent: parameters.pollEvent)
-        pollAggregator.delegate = self
+        viewModel = TimelinePollViewModel(timelinePollDetailsState: .loading)
+        try pollAggregator = PollAggregator(session: parameters.session, room: parameters.room, pollEvent: parameters.pollEvent, delegate: self)
         
-        viewModel = TimelinePollViewModel(timelinePollDetails: buildTimelinePollFrom(pollAggregator.poll))
         viewModel.completion = { [weak self] result in
             guard let self = self else { return }
             
@@ -77,8 +76,6 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
                 }
             }
             .store(in: &cancellables)
-        
-        pollAggregator.reloadPollData()
     }
     
     // MARK: - Public
@@ -94,11 +91,11 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
     }
     
     func canEndPoll() -> Bool {
-        pollAggregator.poll.isClosed == false
+        pollAggregator.poll?.isClosed == false
     }
     
     func canEditPoll() -> Bool {
-        pollAggregator.poll.isClosed == false && pollAggregator.poll.totalAnswerCount == 0
+        pollAggregator.poll?.isClosed == false && pollAggregator.poll?.totalAnswerCount == 0
     }
     
     func endPoll() {
@@ -110,20 +107,22 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
     // MARK: - PollAggregatorDelegate
     
     func pollAggregatorDidUpdateData(_ aggregator: PollAggregator) {
-        viewModel.updateWithPollDetails(buildTimelinePollFrom(aggregator.poll))
-        viewModel.updateWithPollState(.loaded)
+        if let poll = aggregator.poll {
+            viewModel.updateWithPollDetailsState(.loaded(buildTimelinePollFrom(poll)))
+        }
     }
     
-    func pollAggregatorDidStartLoading(_ aggregator: PollAggregator) {
-        viewModel.updateWithPollState(.loading)
-    }
+    func pollAggregatorDidStartLoading(_ aggregator: PollAggregator) { }
     
     func pollAggregatorDidEndLoading(_ aggregator: PollAggregator) {
-        viewModel.updateWithPollState(.loaded)
+        guard let poll = aggregator.poll else {
+            return
+        }
+        viewModel.updateWithPollDetailsState(.loaded(buildTimelinePollFrom(poll)))
     }
     
     func pollAggregator(_ aggregator: PollAggregator, didFailWithError: Error) {
-        viewModel.updateWithPollState(.invalidStartEvent)
+        viewModel.updateWithPollDetailsState(.errored)
     }
     
     // MARK: - Private

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Coordinator/TimelinePollCoordinator.swift
@@ -77,6 +77,8 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
                 }
             }
             .store(in: &cancellables)
+        
+        pollAggregator.reloadPollData()
     }
     
     // MARK: - Public
@@ -109,13 +111,20 @@ final class TimelinePollCoordinator: Coordinator, Presentable, PollAggregatorDel
     
     func pollAggregatorDidUpdateData(_ aggregator: PollAggregator) {
         viewModel.updateWithPollDetails(buildTimelinePollFrom(aggregator.poll))
+        viewModel.updateWithPollState(.loaded)
     }
     
-    func pollAggregatorDidStartLoading(_ aggregator: PollAggregator) { }
+    func pollAggregatorDidStartLoading(_ aggregator: PollAggregator) {
+        viewModel.updateWithPollState(.loading)
+    }
     
-    func pollAggregatorDidEndLoading(_ aggregator: PollAggregator) { }
+    func pollAggregatorDidEndLoading(_ aggregator: PollAggregator) {
+        viewModel.updateWithPollState(.loaded)
+    }
     
-    func pollAggregator(_ aggregator: PollAggregator, didFailWithError: Error) { }
+    func pollAggregator(_ aggregator: PollAggregator, didFailWithError: Error) {
+        viewModel.updateWithPollState(.invalidStartEvent)
+    }
     
     // MARK: - Private
 

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/Test/Unit/TimelinePollViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/Test/Unit/TimelinePollViewModelTests.swift
@@ -41,111 +41,134 @@ class TimelinePollViewModelTests: XCTestCase {
                                                hasBeenEdited: false,
                                                hasDecryptionError: false)
         
-        viewModel = TimelinePollViewModel(timelinePollDetails: timelinePoll)
+        viewModel = TimelinePollViewModel(timelinePollDetailsState: .loaded(timelinePoll))
         context = viewModel.context
     }
     
     func testInitialState() {
-        XCTAssertEqual(context.viewState.poll.answerOptions.count, 3)
-        XCTAssertFalse(context.viewState.poll.closed)
-        XCTAssertEqual(context.viewState.poll.type, .disclosed)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions.count, 3)
+        XCTAssertEqual(context.viewState.pollState.poll?.closed, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.type, .disclosed)
     }
     
     func testSingleSelectionOnMax1Allowed() {
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
-        
-        XCTAssertTrue(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, true)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, false)
     }
     
     func testSingleReselectionOnMax1Allowed() {
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
-        
-        XCTAssertTrue(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, true)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, false)
     }
     
     func testMultipleSelectionOnMax1Allowed() {
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("3"))
-        
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, true)
     }
     
     func testMultipleReselectionOnMax1Allowed() {
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("3"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("3"))
-        
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, true)
     }
 
     func testClosedSelection() {
-        viewModel.state.poll.closed = true
+        guard case var .loaded(poll) = context.viewState.pollState else {
+            return XCTFail()
+        }
+        poll.closed = true
+        viewModel.updateWithPollDetailsState(.loaded(poll))
 
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("3"))
         
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, false)
     }
 
     func testSingleSelectionOnMax2Allowed() {
-        viewModel.state.poll.maxAllowedSelections = 2
+        guard case var .loaded(poll) = context.viewState.pollState else {
+            return XCTFail()
+        }
+        poll.maxAllowedSelections = 2
+        viewModel.updateWithPollDetailsState(.loaded(poll))
         
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         
-        XCTAssertTrue(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, true)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, false)
     }
     
     func testSingleReselectionOnMax2Allowed() {
-        viewModel.state.poll.maxAllowedSelections = 2
+        guard case var .loaded(poll) = context.viewState.pollState else {
+            return XCTFail()
+        }
+        poll.maxAllowedSelections = 2
+        viewModel.updateWithPollDetailsState(.loaded(poll))
         
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, false)
     }
     
     func testMultipleSelectionOnMax2Allowed() {
-        viewModel.state.poll.maxAllowedSelections = 2
-        
+        guard case var .loaded(poll) = context.viewState.pollState else {
+            return XCTFail()
+        }
+        poll.maxAllowedSelections = 2
+        viewModel.updateWithPollDetailsState(.loaded(poll))
+
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("3"))
         context.send(viewAction: .selectAnswerOptionWithIdentifier("2"))
         
-        XCTAssertTrue(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, true)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, true)
         
         context.send(viewAction: .selectAnswerOptionWithIdentifier("1"))
         
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, true)
         
         context.send(viewAction: .selectAnswerOptionWithIdentifier("2"))
         
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, true)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, true)
         
         context.send(viewAction: .selectAnswerOptionWithIdentifier("3"))
         
-        XCTAssertFalse(context.viewState.poll.answerOptions[0].selected)
-        XCTAssertTrue(context.viewState.poll.answerOptions[1].selected)
-        XCTAssertFalse(context.viewState.poll.answerOptions[2].selected)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[0].selected, false)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[1].selected, true)
+        XCTAssertEqual(context.viewState.pollState.poll?.answerOptions[2].selected, false)
+    }
+}
+
+private extension TimelinePollDetailsState {
+    var poll: TimelinePollDetails? {
+        switch self {
+        case .loaded(let poll):
+            return poll
+        default:
+            return nil
+        }
     }
 }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
@@ -37,10 +37,10 @@ enum TimelinePollEventType {
     case ended
 }
 
-enum TimelinePollState {
+enum TimelinePollDetailsState {
     case loading
-    case loaded
-    case invalidStartEvent
+    case loaded(TimelinePollDetails)
+    case errored
 }
 
 struct TimelinePollAnswerOption: Identifiable {
@@ -100,12 +100,11 @@ struct TimelinePollDetails {
 extension TimelinePollDetails: Identifiable { }
 
 struct TimelinePollViewState: BindableState {
-    var poll: TimelinePollDetails
+    var pollState: TimelinePollDetailsState
     var bindings: TimelinePollViewStateBindings
 }
 
 struct TimelinePollViewStateBindings {
-    var pollState: TimelinePollState
     var alertInfo: AlertInfo<TimelinePollAlertType>?
 }
 

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollModels.swift
@@ -37,6 +37,12 @@ enum TimelinePollEventType {
     case ended
 }
 
+enum TimelinePollState {
+    case loading
+    case loaded
+    case invalidStartEvent
+}
+
 struct TimelinePollAnswerOption: Identifiable {
     var id: String
     var text: String
@@ -99,6 +105,7 @@ struct TimelinePollViewState: BindableState {
 }
 
 struct TimelinePollViewStateBindings {
+    var pollState: TimelinePollState
     var alertInfo: AlertInfo<TimelinePollAlertType>?
 }
 

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
@@ -48,21 +48,20 @@ enum MockTimelinePollScreenState: MockScreenState, CaseIterable {
                                        hasBeenEdited: false,
                                        hasDecryptionError: false)
         
-        let viewModel = TimelinePollViewModel(timelinePollDetails: poll)
+        let viewModel: TimelinePollViewModel
         
         switch self {
         case .loading:
-            viewModel.updateWithPollState(.loading)
+            viewModel = TimelinePollViewModel(timelinePollDetailsState: .loading)
         case .invalidStartEvent:
-            viewModel.updateWithPollState(.invalidStartEvent)
+            viewModel = TimelinePollViewModel(timelinePollDetailsState: .errored)
         default:
-            viewModel.updateWithPollState(.loaded)
+            viewModel = TimelinePollViewModel(timelinePollDetailsState: .loaded(poll))
         }
         
         if self == .withAlert {
             viewModel.showAnsweringFailure()
         }
-        
         
         return ([viewModel], AnyView(TimelinePollView(viewModel: viewModel.context)))
     }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollScreenState.swift
@@ -23,6 +23,9 @@ enum MockTimelinePollScreenState: MockScreenState, CaseIterable {
     case openUndisclosed
     case closedUndisclosed
     case closedPollEnded
+    case loading
+    case invalidStartEvent
+    case withAlert
     
     var screenType: Any.Type {
         TimelinePollDetails.self
@@ -46,6 +49,20 @@ enum MockTimelinePollScreenState: MockScreenState, CaseIterable {
                                        hasDecryptionError: false)
         
         let viewModel = TimelinePollViewModel(timelinePollDetails: poll)
+        
+        switch self {
+        case .loading:
+            viewModel.updateWithPollState(.loading)
+        case .invalidStartEvent:
+            viewModel.updateWithPollState(.invalidStartEvent)
+        default:
+            viewModel.updateWithPollState(.loaded)
+        }
+        
+        if self == .withAlert {
+            viewModel.showAnsweringFailure()
+        }
+        
         
         return ([viewModel], AnyView(TimelinePollView(viewModel: viewModel.context)))
     }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
@@ -30,8 +30,8 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     
     // MARK: - Setup
     
-    init(timelinePollDetails: TimelinePollDetails) {
-        super.init(initialViewState: TimelinePollViewState(poll: timelinePollDetails, bindings: TimelinePollViewStateBindings(pollState: .loading)))
+    init(timelinePollDetailsState: TimelinePollDetailsState) {
+        super.init(initialViewState: TimelinePollViewState(pollState: timelinePollDetailsState, bindings: TimelinePollViewStateBindings()))
     }
     
     // MARK: - Public
@@ -40,11 +40,11 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
         switch viewAction {
         // Update local state. An update will be pushed from the coordinator once sent.
         case .selectAnswerOptionWithIdentifier(let identifier):
-            guard !state.poll.closed else {
+            // only if the poll is ready and not closed
+            guard case let .loaded(poll) = state.pollState, !poll.closed else {
                 return
             }
-            
-            if state.poll.maxAllowedSelections == 1 {
+            if poll.maxAllowedSelections == 1 {
                 updateSingleSelectPollLocalState(selectedAnswerIdentifier: identifier, callback: completion)
             } else {
                 updateMultiSelectPollLocalState(&state, selectedAnswerIdentifier: identifier, callback: completion)
@@ -54,12 +54,8 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     
     // MARK: - TimelinePollViewModelProtocol
     
-    func updateWithPollDetails(_ pollDetails: TimelinePollDetails) {
-        state.poll = pollDetails
-    }
-    
-    func updateWithPollState(_ pollState: TimelinePollState) {
-        state.bindings.pollState = pollState
+    func updateWithPollDetailsState(_ pollDetailsState: TimelinePollDetailsState) {
+        state.pollState = pollDetailsState
     }
     
     func showAnsweringFailure() {
@@ -77,33 +73,40 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     // MARK: - Private
     
     func updateSingleSelectPollLocalState(selectedAnswerIdentifier: String, callback: TimelinePollViewModelCallback?) {
-        state.poll.answerOptions.updateEach { answerOption in
+        guard case var .loaded(poll) = state.pollState else { return }
+        
+        var pollAnswerOptions = poll.answerOptions
+        pollAnswerOptions.updateEach { answerOption in
             if answerOption.selected {
                 answerOption.selected = false
                 answerOption.count = UInt(max(0, Int(answerOption.count) - 1))
-                state.poll.totalAnswerCount = UInt(max(0, Int(state.poll.totalAnswerCount) - 1))
+                poll.totalAnswerCount = UInt(max(0, Int(poll.totalAnswerCount) - 1))
             }
             
             if answerOption.id == selectedAnswerIdentifier {
                 answerOption.selected = true
                 answerOption.count += 1
-                state.poll.totalAnswerCount += 1
+                poll.totalAnswerCount += 1
             }
         }
-        
+        poll.answerOptions = pollAnswerOptions
+        state.pollState = .loaded(poll)
         informCoordinatorOfSelectionUpdate(state: state, callback: callback)
     }
     
     func updateMultiSelectPollLocalState(_ state: inout TimelinePollViewState, selectedAnswerIdentifier: String, callback: TimelinePollViewModelCallback?) {
-        let selectedAnswerOptions = state.poll.answerOptions.filter { $0.selected == true }
+        guard case .loaded(var poll) = state.pollState else { return }
+        
+        let selectedAnswerOptions = poll.answerOptions.filter { $0.selected == true }
         
         let isDeselecting = selectedAnswerOptions.filter { $0.id == selectedAnswerIdentifier }.count > 0
         
-        if !isDeselecting, selectedAnswerOptions.count >= state.poll.maxAllowedSelections {
+        if !isDeselecting, selectedAnswerOptions.count >= poll.maxAllowedSelections {
             return
         }
         
-        state.poll.answerOptions.updateEach { answerOption in
+        var pollAnswerOptions = poll.answerOptions
+        pollAnswerOptions.updateEach { answerOption in
             if answerOption.id != selectedAnswerIdentifier {
                 return
             }
@@ -111,22 +114,24 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
             if answerOption.selected {
                 answerOption.selected = false
                 answerOption.count = UInt(max(0, Int(answerOption.count) - 1))
-                state.poll.totalAnswerCount = UInt(max(0, Int(state.poll.totalAnswerCount) - 1))
+                poll.totalAnswerCount = UInt(max(0, Int(poll.totalAnswerCount) - 1))
             } else {
                 answerOption.selected = true
                 answerOption.count += 1
-                state.poll.totalAnswerCount += 1
+                poll.totalAnswerCount += 1
             }
         }
-        
+        poll.answerOptions = pollAnswerOptions
+        state.pollState = .loaded(poll)
         informCoordinatorOfSelectionUpdate(state: state, callback: callback)
     }
     
     func informCoordinatorOfSelectionUpdate(state: TimelinePollViewState, callback: TimelinePollViewModelCallback?) {
-        let selectedIdentifiers = state.poll.answerOptions.compactMap { answerOption in
+        guard case .loaded(let poll) = state.pollState else { return }
+        
+        let selectedIdentifiers = poll.answerOptions.compactMap { answerOption in
             answerOption.selected ? answerOption.id : nil
         }
-        
         callback?(.selectedAnswerOptionsWithIdentifiers(selectedIdentifiers))
     }
 }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModel.swift
@@ -31,7 +31,7 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     // MARK: - Setup
     
     init(timelinePollDetails: TimelinePollDetails) {
-        super.init(initialViewState: TimelinePollViewState(poll: timelinePollDetails, bindings: TimelinePollViewStateBindings()))
+        super.init(initialViewState: TimelinePollViewState(poll: timelinePollDetails, bindings: TimelinePollViewStateBindings(pollState: .loading)))
     }
     
     // MARK: - Public
@@ -56,6 +56,10 @@ class TimelinePollViewModel: TimelinePollViewModelType, TimelinePollViewModelPro
     
     func updateWithPollDetails(_ pollDetails: TimelinePollDetails) {
         state.poll = pollDetails
+    }
+    
+    func updateWithPollState(_ pollState: TimelinePollState) {
+        state.bindings.pollState = pollState
     }
     
     func showAnsweringFailure() {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModelProtocol.swift
@@ -21,6 +21,7 @@ protocol TimelinePollViewModelProtocol {
     var completion: ((TimelinePollViewModelResult) -> Void)? { get set }
     
     func updateWithPollDetails(_ pollDetails: TimelinePollDetails)
+    func updateWithPollState(_ pollState: TimelinePollState)
     func showAnsweringFailure()
     func showClosingFailure()
 }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModelProtocol.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/TimelinePollViewModelProtocol.swift
@@ -20,8 +20,7 @@ protocol TimelinePollViewModelProtocol {
     var context: TimelinePollViewModelType.Context { get }
     var completion: ((TimelinePollViewModelResult) -> Void)? { get set }
     
-    func updateWithPollDetails(_ pollDetails: TimelinePollDetails)
-    func updateWithPollState(_ pollState: TimelinePollState)
+    func updateWithPollDetailsState(_ pollDetailsState: TimelinePollDetailsState)
     func showAnsweringFailure()
     func showClosingFailure()
 }

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
@@ -28,6 +28,23 @@ struct TimelinePollView: View {
     @ObservedObject var viewModel: TimelinePollViewModel.Context
     
     var body: some View {
+        Group {
+            switch viewModel.pollState {
+            case .loading:
+                TimelinePollMessageView(message: "loading...")
+            case .loaded:
+                pollContent
+            case .invalidStartEvent:
+                TimelinePollMessageView(message: VectorL10n.pollTimelineReplyEndedPoll)
+            }
+        }
+        .alert(item: $viewModel.alertInfo) { info in
+            info.alert
+        }
+    }
+    
+    @ViewBuilder
+    private var pollContent: some View {
         let poll = viewModel.viewState.poll
         
         VStack(alignment: .leading, spacing: 16.0) {
@@ -61,9 +78,6 @@ struct TimelinePollView: View {
         }
         .padding([.horizontal, .top], 2.0)
         .padding([.bottom])
-        .alert(item: $viewModel.alertInfo) { info in
-            info.alert
-        }
     }
     
     private var totalVotesString: String {

--- a/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
+++ b/RiotSwiftUI/Modules/Room/TimelinePoll/View/TimelinePollView.swift
@@ -29,12 +29,12 @@ struct TimelinePollView: View {
     
     var body: some View {
         Group {
-            switch viewModel.pollState {
+            switch viewModel.viewState.pollState {
             case .loading:
-                TimelinePollMessageView(message: "loading...")
-            case .loaded:
-                pollContent
-            case .invalidStartEvent:
+                TimelinePollMessageView(message: VectorL10n.pollTimelineLoading)
+            case .loaded(let poll):
+                pollContent(poll)
+            case .errored:
                 TimelinePollMessageView(message: VectorL10n.pollTimelineReplyEndedPoll)
             }
         }
@@ -44,9 +44,7 @@ struct TimelinePollView: View {
     }
     
     @ViewBuilder
-    private var pollContent: some View {
-        let poll = viewModel.viewState.poll
-        
+    private func pollContent(_ poll: TimelinePollDetails) -> some View {
         VStack(alignment: .leading, spacing: 16.0) {
             if poll.representsPollEndedEvent {
                 Text(VectorL10n.pollTimelineEndedText)
@@ -57,7 +55,7 @@ struct TimelinePollView: View {
             Text(poll.question)
                 .font(theme.fonts.bodySB)
                 .foregroundColor(theme.colors.primaryContent) +
-                Text(editedText)
+                Text(editedText(poll))
                 .font(theme.fonts.footnote)
                 .foregroundColor(theme.colors.secondaryContent)
             
@@ -71,7 +69,7 @@ struct TimelinePollView: View {
             .disabled(poll.closed)
             .fixedSize(horizontal: false, vertical: true)
             
-            Text(totalVotesString)
+            Text(totalVotesString(poll))
                 .lineLimit(2)
                 .font(theme.fonts.footnote)
                 .foregroundColor(theme.colors.tertiaryContent)
@@ -80,9 +78,7 @@ struct TimelinePollView: View {
         .padding([.bottom])
     }
     
-    private var totalVotesString: String {
-        let poll = viewModel.viewState.poll
-        
+    private func totalVotesString(_ poll: TimelinePollDetails) -> String {
         if poll.hasDecryptionError, poll.totalAnswerCount > 0 {
             return VectorL10n.pollTimelineDecryptionError
         }
@@ -109,8 +105,8 @@ struct TimelinePollView: View {
         }
     }
     
-    private var editedText: String {
-        viewModel.viewState.poll.hasBeenEdited ? " \(VectorL10n.eventFormatterMessageEditedMention)" : ""
+    private func editedText(_ poll: TimelinePollDetails) -> String {
+        poll.hasBeenEdited ? " \(VectorL10n.eventFormatterMessageEditedMention)" : ""
     }
 }
 

--- a/changelog.d/7497.bugfix
+++ b/changelog.d/7497.bugfix
@@ -1,0 +1,1 @@
+Poll: The timeline sometimes displayed closed polls in the wrong order.


### PR DESCRIPTION
This PR fix #7497 

_This PR is related to this one (matrix-ios-sdk): [Fix: Refreshing the poll when receiving pollEnd can break the chronological order in the store. #1776](https://github.com/matrix-org/matrix-ios-sdk/pull/1776)_

It displays a temporary poll while fetching the `pollStartEvent`:
<img width="393" alt="Screenshot 2023-04-25 at 16 05 44" src="https://user-images.githubusercontent.com/4334885/234302750-cf1572db-1022-4d70-b7ac-bc7cbaadbefe.png">

If we failed to get the start event (or to decrypt it), we'll fallback on the normal rendering:
<img width="120" alt="Screenshot 2023-04-25 at 16 07 07" src="https://user-images.githubusercontent.com/4334885/234302721-005bcd41-f03b-40d9-b9ef-96558f23d1e4.png">

Also, the `PollAggregator` delegate was not defined early enough in `TimelinePollCoordinator` (and so the delegate's methods were not called).
I had to make public the `PollAggregator.reloadPollData()` method because:
- once the PollAggregator is instantiated, it immediately loads the poll data.
  - and once the poll is loaded, the delegate is called (but not yet defined).
  - the delegate method `func pollAggregatorDidUpdateData(_ aggregator: PollAggregator)` needs the viewModel which is not ready at this stage because we need to instantiate it with the poll built by the `PollAggregator`
```
try pollAggregator = PollAggregator(session: parameters.session, room: parameters.room, pollEvent: parameters.pollEvent)
pollAggregator.delegate = self
        
viewModel = TimelinePollViewModel(timelinePollDetails: buildTimelinePollFrom(pollAggregator.poll))

```
To make it works, the `PollAggregator` no longer loads the poll data during its `init` function, and is only called when the viewModel is ready.

In this way, if the `PollAggregator` doesn't find the `pollStartEvent` in the store, it will generate a temporary poll which will be replaced by the correct one once the fetch is complete.
During this loading phase, the `PollView` will be in the `.loading` state. And once the data have been loaded, its state will be `.loaded` (or `.invalidStartEvent`)