### PR TITLE
Fix: Remove the matrix id from the notice display name changed event

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2984,6 +2984,7 @@ To enable access, tap Settings> Location and select Always";
 "notice_avatar_url_changed" = "%@ changed their avatar";
 "notice_display_name_set" = "%@ set their display name to %@";
 "notice_display_name_changed_from" = "%@ changed their display name from %@ to %@";
+"notice_display_name_changed_to" = "%@ changed their display name to %@";
 "notice_display_name_removed" = "%@ removed their display name";
 "notice_topic_changed" = "%@ changed the topic to \"%@\".";
 "notice_room_name_changed" = "%@ changed the room name to %@.";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3899,6 +3899,10 @@ public class VectorL10n: NSObject {
   public static func noticeDisplayNameChangedFromByYou(_ p1: String, _ p2: String) -> String {
     return VectorL10n.tr("Vector", "notice_display_name_changed_from_by_you", p1, p2)
   }
+  /// %@ changed their display name to %@
+  public static func noticeDisplayNameChangedTo(_ p1: String, _ p2: String) -> String {
+    return VectorL10n.tr("Vector", "notice_display_name_changed_to", p1, p2)
+  }
   /// %@ removed their display name
   public static func noticeDisplayNameRemoved(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "notice_display_name_removed", p1)

--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -571,7 +571,7 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
                             }
                             else
                             {
-                                displayText = [VectorL10n noticeDisplayNameChangedFrom:event.sender :prevDisplayname :displayname];
+                                displayText = [VectorL10n noticeDisplayNameChangedTo:prevDisplayname :displayname];
                             }
                         }
                     }

--- a/changelog.d/7517.change
+++ b/changelog.d/7517.change
@@ -1,0 +1,1 @@
+Timeline: Remove the matrix ID displayed when someone has changed its display name.


### PR DESCRIPTION
This PR fixes #7517 

Old behaviour:
<img width="516" alt="7517_old" src="https://user-images.githubusercontent.com/4334885/234509768-1657da7b-9612-4ab1-a12d-41673c8e22da.png">

New behaviour:
<img width="373" alt="7517_new" src="https://user-images.githubusercontent.com/4334885/234509820-45863a8a-ce78-46b6-99e2-40eb58ea2039.png">
