### PR TITLE
Disable accessibility for emojis during verification

### DIFF
--- a/Riot/Modules/KeyVerification/Common/Verify/SAS/Views/VerifyEmojiCollectionViewCell.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/SAS/Views/VerifyEmojiCollectionViewCell.swift
@@ -24,4 +24,9 @@ class VerifyEmojiCollectionViewCell: UICollectionViewCell, Reusable, Themable {
     func update(theme: Theme) {
         name.textColor = theme.textPrimaryColor
     }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        emoji.isAccessibilityElement = false
+    }
 }


### PR DESCRIPTION
This PR removes the accessibility for the emoji during the sessions verification leaving it just for the description labels under them.

**Impacted screen**
![d](https://user-images.githubusercontent.com/19324622/234555939-01adaa63-b2f4-4f81-b08c-c5fdf1584b49.png)
