### PR TITLE
Fix a flickering issue when the timeline datasource is reloaded.

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.m
@@ -457,11 +457,6 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
 
 - (void)reset
 {
-    [self resetNotifying:YES];
-}
-
-- (void)resetNotifying:(BOOL)notify
-{
     if (roomDidFlushDataNotificationObserver)
     {
         [[NSNotificationCenter defaultCenter] removeObserver:roomDidFlushDataNotificationObserver];
@@ -556,12 +551,6 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     }
     
     _serverSyncEventCount = 0;
-
-    // Notify the delegate to reload its tableview
-    if (notify && self.delegate)
-    {
-        [self.delegate dataSource:self didCellChange:nil];
-    }
 }
 
 - (void)reload
@@ -575,10 +564,16 @@ typedef NS_ENUM (NSUInteger, MXKRoomDataSourceError) {
     
     [self setState:MXKDataSourceStatePreparing];
     
-    [self resetNotifying:notify];
+    [self reset];
     
     // Reload
     [self didMXSessionStateChange];
+    
+    // Notify the delegate to refresh the tableview
+    if (notify && self.delegate)
+    {
+        [self.delegate dataSource:self didCellChange:nil];
+    }
 }
 
 - (void)destroy

--- a/changelog.d/7523.bugfix
+++ b/changelog.d/7523.bugfix
@@ -1,0 +1,1 @@
+Fix a flickering issue when the timeline datasource is reloaded.


### PR DESCRIPTION
This PR fixes #7523 

When the `MXKRoomDataSource` was reloaded, the tableView was refreshed immediately after the reset, showing a blank screen.
With this fix, the tableView is refreshed at the end of the `reload` method, which prevents a blank screen from appearing.

The `MXKRoomDataSource resetNotifying` method no longer seems necessary with this fix, as the original reset method was only called from:
- `MXKRoomDataSource::reload`
- `MXKRoomDataSource::destroy`: in this case its delegate is already nil