### PR TITLE
Fix partial text messages not being saved for each room with RTE enabled

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "758f226a92d6726ab626c1e78ecd183bdba77016",
-        "version" : "2.0.0"
+        "revision" : "ff5e8054da60212051cb0dec244500ca0f441bac",
+        "version" : "2.1.0"
       }
     },
     {

--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.h
@@ -213,6 +213,15 @@ typedef enum : NSUInteger
  */
 - (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView updateActivityIndicator:(BOOL)isAnimating;
 
+/**
+ Tells the delegate that the partial content of the composer has changed
+ and should be stored to allow restoring it later if needed.
+
+ @param toolbarView the room input toolbar view
+ @param partialAttributedTextMessage the partial content to store
+ */
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView*)toolbarView shouldStorePartialContent:(NSAttributedString*)partialAttributedTextMessage;
+
 @end
 
 /**
@@ -389,6 +398,11 @@ typedef enum : NSUInteger
  The current attributed text message in message composer.
  */
 @property (nonatomic) NSAttributedString *attributedTextMessage;
+
+/**
+ Sets the partial text message to apply to the current message composer.
+ */
+- (void)setPartialContent:(NSAttributedString *)attributedTextMessage;
 
 /**
  Default font for the message composer.

--- a/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomInputToolbar/MXKRoomInputToolbarView.m
@@ -1405,4 +1405,9 @@ NSString* MXKFileSizes_description(MXKFileSizes sizes)
     return NO;
 }
 
+- (void)setPartialContent:(NSAttributedString *)attributedTextMessage
+{
+    self.attributedTextMessage = attributedTextMessage;
+}
+
 @end

--- a/Riot/Modules/Room/MXKRoomViewController.m
+++ b/Riot/Modules/Room/MXKRoomViewController.m
@@ -360,7 +360,7 @@ static const CGFloat kCellVisibilityMinimumHeight = 8.0;
     {
         // Retrieve the potential message partially typed during last room display.
         // Note: We have to wait for viewDidAppear before updating growingTextView (viewWillAppear is too early)
-        inputToolbarView.attributedTextMessage = roomDataSource.partialAttributedTextMessage;
+        [inputToolbarView setPartialContent:roomDataSource.partialAttributedTextMessage];
     }
     
     if (!hasAppearedOnce)

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -693,7 +693,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     {
         // Retrieve the potential message partially typed during last room display.
         // Note: We have to wait for viewDidAppear before updating growingTextView (viewWillAppear is too early)
-        self.inputToolbarView.attributedTextMessage = self.roomDataSource.partialAttributedTextMessage;
+        [self.inputToolbarView setPartialContent:self.roomDataSource.partialAttributedTextMessage];
     }
     
     [self setMaximisedToolbarIsHiddenIfNeeded: NO];
@@ -5293,6 +5293,11 @@ static CGSize kThreadListBarButtonItemImageSize;
     }];
 }
 
+- (void)roomInputToolbarView:(MXKRoomInputToolbarView *)toolbarView shouldStorePartialContent:(NSAttributedString *)partialAttributedTextMessage
+{
+    self.roomDataSource.partialAttributedTextMessage = partialAttributedTextMessage;
+}
+
 #pragma mark - MXKRoomMemberDetailsViewControllerDelegate
 
 - (void)roomMemberDetailsViewController:(MXKRoomMemberDetailsViewController *)roomMemberDetailsViewController startChatWithMemberId:(NSString *)matrixId completion:(void (^)(void))completion
@@ -6135,7 +6140,7 @@ static CGSize kThreadListBarButtonItemImageSize;
             if (self.saveProgressTextInput)
             {
                 // Restore the potential message partially typed before jump to last unread messages.
-                self.inputToolbarView.attributedTextMessage = roomDataSource.partialAttributedTextMessage;
+                [self.inputToolbarView setPartialContent:roomDataSource.partialAttributedTextMessage];
             }
         };
 

--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -303,7 +303,7 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
                     // Note: filter out `plainTextMode` being off, as switching to RTE will trigger this
                     // publisher with empty content. This avoids saving the partial text message
                     // or trying to compute suggestion from this empty content.
-                    guard let self, wysiwygViewModel.plainTextMode else { return }
+                    guard let self, self.wysiwygViewModel.plainTextMode else { return }
                     self.textMessage = attributed.string
                     self.toolbarViewDelegate?.roomInputToolbarViewDidChangeTextMessage(self)
                     self.toolbarViewDelegate?.roomInputToolbarView?(self, shouldStorePartialContent: attributed)

--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -96,11 +96,17 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
         // Note: this is only interactive in plain text mode. If RTE is enabled,
         // APIs from the composer view model should be used.
         get {
-            guard !self.textFormattingEnabled else { return nil }
+            guard !self.textFormattingEnabled else {
+                MXLog.failure("[WysiwygInputToolbarView] Trying to get attributedTextMessage in RTE mode")
+                return nil
+            }
             return self.wysiwygViewModel.textView.attributedText
         }
         set {
-            guard !self.textFormattingEnabled else { return }
+            guard !self.textFormattingEnabled else {
+                MXLog.failure("[WysiwygInputToolbarView] Trying to set attributedTextMessage in RTE mode")
+                return
+            }
             self.wysiwygViewModel.textView.attributedText = newValue
         }
     }
@@ -174,6 +180,16 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
             showKeyboard()
         }
     }
+
+    override func setPartialContent(_ attributedTextMessage: NSAttributedString) {
+        let content: String
+        if #available(iOS 15.0, *) {
+            content = PillsFormatter.stringByReplacingPills(in: attributedTextMessage, mode: .markdown)
+        } else {
+            content = attributedTextMessage.string
+        }
+        self.wysiwygViewModel.setMarkdownContent(content)
+    }
     
     func showKeyboard() {
         self.viewModel.showKeyboard()
@@ -191,7 +207,7 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
     }
 
     func mention(_ member: MXRoomMember) {
-        self.wysiwygViewModel.setMention(link: MXTools.permalinkToUser(withUserId: member.userId),
+        self.wysiwygViewModel.setMention(url: MXTools.permalinkToUser(withUserId: member.userId),
                                          name: member.displayname,
                                          mentionType: .user)
     }
@@ -281,12 +297,31 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
                 },
 
             wysiwygViewModel.$plainTextContent
-                .dropFirst()
                 .removeDuplicates()
-                .sink { [weak self] value in
-                    guard let self else { return }
-                    self.textMessage = value.string
+                .dropFirst()
+                .sink { [weak self] attributed in
+                    // Note: filter out `plainTextMode` being off, as switching to RTE will trigger this
+                    // publisher with empty content. This avoids saving the partial text message
+                    // or trying to compute suggestion from this empty content.
+                    guard let self, wysiwygViewModel.plainTextMode else { return }
+                    self.textMessage = attributed.string
                     self.toolbarViewDelegate?.roomInputToolbarViewDidChangeTextMessage(self)
+                    self.toolbarViewDelegate?.roomInputToolbarView?(self, shouldStorePartialContent: attributed)
+                },
+            
+            wysiwygViewModel.$attributedContent
+                .removeDuplicates(by: {
+                    $0.text == $1.text
+                })
+                .dropFirst()
+                .sink { [weak self] _ in
+                    // Note: filter out `plainTextMode` being on, as switching to plain text mode will trigger this
+                    // publisher with empty content. This avoids saving the partial text message
+                    // or trying to compute suggestion from this empty content.
+                    guard let self, !self.wysiwygViewModel.plainTextMode else { return }
+                    let markdown = self.wysiwygViewModel.content.markdown
+                    let attributed = NSAttributedString(string: markdown, attributes: [.font: self.defaultFont])
+                    self.toolbarViewDelegate?.roomInputToolbarView?(self, shouldStorePartialContent: attributed)
                 }
         ]
 

--- a/RiotSwiftUI/Modules/Room/Composer/LinkAction/MockComposerLinkActionScreenState.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/LinkAction/MockComposerLinkActionScreenState.swift
@@ -33,7 +33,7 @@ enum MockComposerLinkActionScreenState: MockScreenState, CaseIterable {
         case .create:
             viewModel = .init(from: .create)
         case .edit:
-            viewModel = .init(from: .edit(link: "https://element.io"))
+            viewModel = .init(from: .edit(url: "https://element.io"))
         }
         return (
             [viewModel],

--- a/RiotSwiftUI/Modules/Room/Composer/LinkAction/Test/Unit/ComposerLinkActionViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/LinkAction/Test/Unit/ComposerLinkActionViewModelTests.swift
@@ -54,7 +54,7 @@ final class ComposerLinkActionViewModelTests: XCTestCase {
     
     func testEditDefaultState() {
         let link = "element.io"
-        setUp(with: .edit(link: link))
+        setUp(with: .edit(url: link))
         XCTAssertEqual(context.viewState.bindings.text, "")
         XCTAssertEqual(context.viewState.bindings.linkUrl, link)
         XCTAssertTrue(context.viewState.isSaveButtonDisabled)
@@ -83,7 +83,7 @@ final class ComposerLinkActionViewModelTests: XCTestCase {
     }
     
     func testRemoveAction() {
-        setUp(with: .edit(link: "element.io"))
+        setUp(with: .edit(url: "element.io"))
         var result: ComposerLinkActionViewModelResult!
         viewModel.callback = { value in
             result = value
@@ -119,7 +119,7 @@ final class ComposerLinkActionViewModelTests: XCTestCase {
     }
     
     func testSaveActionForEdit() {
-        setUp(with: .edit(link: "element.io"))
+        setUp(with: .edit(url: "element.io"))
         var result: ComposerLinkActionViewModelResult!
         viewModel.callback = { value in
             result = value

--- a/RiotSwiftUI/Modules/Room/Composer/LinkAction/ViewModel/ComposerLinkActionViewModel.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/LinkAction/ViewModel/ComposerLinkActionViewModel.swift
@@ -36,7 +36,7 @@ final class ComposerLinkActionViewModel: ComposerLinkActionViewModelType, Compos
         switch linkAction {
         case let .edit(link):
             initialViewState = .init(
-                linkAction: .edit(link: link),
+                linkAction: .edit(url: link),
                 bindings: .init(
                     text: "",
                     linkUrl: link

--- a/RiotSwiftUI/Modules/Room/Composer/Test/Unit/ComposerViewModelTests.swift
+++ b/RiotSwiftUI/Modules/Room/Composer/Test/Unit/ComposerViewModelTests.swift
@@ -98,7 +98,7 @@ final class ComposerViewModelTests: XCTestCase {
         XCTAssertEqual(result, .linkTapped(LinkAction: .createWithText))
         context.send(viewAction: .linkTapped(linkAction: .create))
         XCTAssertEqual(result, .linkTapped(LinkAction: .create))
-        context.send(viewAction: .linkTapped(linkAction: .edit(link: "https://element.io")))
-        XCTAssertEqual(result, .linkTapped(LinkAction: .edit(link: "https://element.io")))
+        context.send(viewAction: .linkTapped(linkAction: .edit(url: "https://element.io")))
+        XCTAssertEqual(result, .linkTapped(LinkAction: .edit(url: "https://element.io")))
     }
 }

--- a/changelog.d/7535.bugfix
+++ b/changelog.d/7535.bugfix
@@ -1,0 +1,1 @@
+Labs: Rich Text Editor: Fix partial text messages not being saved for each room

--- a/project.yml
+++ b/project.yml
@@ -56,7 +56,7 @@ packages:
     branch: 0.0.1
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    version: 2.0.0
+    version: 2.1.0
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0


### PR DESCRIPTION
Fixes #7535 

Also updates the RTE library version to 2.1.0 and apply API changes. See [CHANGELOG](https://github.com/matrix-org/matrix-rich-text-editor/blob/2.1.0/CHANGELOG.md) for details.


https://user-images.githubusercontent.com/80891108/235922934-bf71fd18-3b02-48c1-a921-13639514b952.mp4

