### PR TITLE
Use the app's language for accessibility.

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -390,6 +390,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     }
     [NSBundle mxk_setLanguage:language];
     [NSBundle mxk_setFallbackLanguage:@"en"];
+    UIApplication.sharedApplication.accessibilityLanguage = language;
     
     if (BuildSettings.disableRightToLeftLayout)
     {

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -4158,6 +4158,7 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
         || (language == nil && [NSBundle mxk_language]))
     {
         [NSBundle mxk_setLanguage:language];
+        UIApplication.sharedApplication.accessibilityLanguage = language;
 
         // Store user settings
         NSUserDefaults *sharedUserDefaults = [MXKAppSettings standardAppSettings].sharedUserDefaults;

--- a/changelog.d/pr-7493.bugfix
+++ b/changelog.d/pr-7493.bugfix
@@ -1,0 +1,1 @@
+Make sure to use the chosen language for the VoiceOver voice too.


### PR DESCRIPTION
When using a device set to use language A but running Element with language B, this PR makes sure to use the voice from language B for VoiceOver.

Fixes https://github.com/vector-im/customer-retainer/issues/39

Caveats:
- Notifications shown whilst in-app will always be in the system language as they are presented outside of the app.
- The share extension doesn't have a `UIApplication` to set the language on and from what I can tell, doesn't respect the `accessibilityLanguage` property set on the root view controller for setting the voice.