### PR TITLE
Fix: text color of the last event description was incorrect.

### DIFF
--- a/Riot/Categories/NSAttributedString+Theme.swift
+++ b/Riot/Categories/NSAttributedString+Theme.swift
@@ -1,0 +1,64 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Custom NSAttributedString.Key to specify the theme
+let themeIdentifierAttributeName = NSAttributedString.Key("ThemeIdentifier")
+/// Custom NSAttributedString.Key to specify a theme color by its name
+let themeColorNameAttributeName = NSAttributedString.Key("ThemeColorName")
+
+extension NSAttributedString {
+    /// Fix foreground color attributes if this attributed string contains the `themeIdentifierAttributeName` and `foregroundColorNameAttributeName` attributes
+    /// - Returns: a new attributed string with updated colors
+    @objc func fixForegroundColor() -> NSAttributedString {
+        let activeTheme = ThemeService.shared().theme
+        
+        // Check if a theme is defined for this attributed string
+        var needUpdate = false
+        self.vc_enumerateAttribute(themeIdentifierAttributeName) { (themeIdentifier: String, range: NSRange, _) in
+            needUpdate = themeIdentifier != activeTheme.identifier
+        }
+        
+        guard needUpdate else {
+            return self
+        }
+        
+        // Build a new attributedString with the proper colors if possible
+        let mutableAttributedString = NSMutableAttributedString(attributedString: self)
+        mutableAttributedString.vc_enumerateAttribute(themeColorNameAttributeName) { (colorName: String, range: NSRange, _) in
+            if let color = ThemeColorResolver.getColorByName(colorName) {
+                mutableAttributedString.addAttribute(.foregroundColor, value: color, range: range)
+            }
+        }
+        return mutableAttributedString
+    }
+}
+
+extension NSMutableAttributedString {
+    /// Adds a theme color name attribute
+    /// - Parameters:
+    ///   - colorName: color name
+    ///   - range:range for this attribute
+    @objc func addThemeColorNameAttribute(_ colorName: String, range: NSRange) {
+        self.addAttribute(themeColorNameAttributeName, value: colorName, range: range)
+    }
+    
+    /// Adds a theme identifier attribute
+    @objc func addThemeIdentifierAttribute() {
+        self.addAttribute(themeIdentifierAttributeName, value: ThemeService.shared().theme.identifier, range: .init(location: 0, length: length))
+    }
+}

--- a/Riot/Managers/Theme/ThemeService.swift
+++ b/Riot/Managers/Theme/ThemeService.swift
@@ -23,5 +23,5 @@ extension ThemeService {
             return nil
         }        
         return ThemeIdentifier(rawValue: themeId)
-    }    
+    }
 }

--- a/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
+++ b/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
@@ -81,7 +81,8 @@
         // Manage lastEventAttributedTextMessage optional property
         if (!roomCellData.roomSummary.spaceChildInfo && [roomCellData respondsToSelector:@selector(lastEventAttributedTextMessage)])
         {
-            self.lastEventDescription.attributedText = roomCellData.lastEventAttributedTextMessage;
+            // Attempt to correct the attributed string colors to match the current theme
+            self.lastEventDescription.attributedText = [roomCellData.lastEventAttributedTextMessage fixForegroundColor];
         }
         else
         {

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -573,8 +573,13 @@ withVoiceBroadcastInfoStateEvent:lastVoiceBroadcastInfoEvent
     {
         // Force the default text color for the last message (cancel highlighted message color)
         NSMutableAttributedString *lastEventDescription = [[NSMutableAttributedString alloc] initWithAttributedString:summary.lastMessage.attributedText];
-        [lastEventDescription addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.textSecondaryColor
-                                     range:NSMakeRange(0, lastEventDescription.length)];
+        NSRange range = NSMakeRange(0, lastEventDescription.length);
+        [lastEventDescription addAttribute:NSForegroundColorAttributeName
+                                     value:ThemeService.shared.theme.colors.secondaryContent
+                                     range:range];
+        [lastEventDescription addThemeColorNameAttribute:@"secondaryContent" range:range];
+        [lastEventDescription addThemeIdentifierAttribute];
+        
         summary.lastMessage.attributedText = lastEventDescription;
     }
     
@@ -670,9 +675,11 @@ withVoiceBroadcastInfoStateEvent:lastVoiceBroadcastInfoEvent
     
     NSAttributedString *attachmentString = nil;
     UIColor *textColor;
+    NSString *colorIdentifier;
     if (isStoppedVoiceBroadcast)
     {
-        textColor = ThemeService.shared.theme.textSecondaryColor;
+        textColor = ThemeService.shared.theme.colors.secondaryContent;
+        colorIdentifier = @"secondaryContent";
         NSString *senderDisplayName;
         if ([stateEvent.stateKey isEqualToString:session.myUser.userId])
         {
@@ -688,6 +695,7 @@ withVoiceBroadcastInfoStateEvent:lastVoiceBroadcastInfoEvent
     else
     {
         textColor = ThemeService.shared.theme.colors.alert;
+        colorIdentifier = @"alert";
         UIImage *liveImage = AssetImages.voiceBroadcastLive.image;
         
         NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
@@ -717,6 +725,12 @@ withVoiceBroadcastInfoStateEvent:lastVoiceBroadcastInfoEvent
     }
     
     [lastMessage addAttribute:NSForegroundColorAttributeName value:textColor range:NSMakeRange(0, lastMessage.length)];
+    if (colorIdentifier)
+    {
+        [lastMessage addThemeColorNameAttribute:colorIdentifier range:NSMakeRange(0, lastMessage.length)];
+        [lastMessage addThemeIdentifierAttribute];
+    }
+
     summary.lastMessage.attributedText = lastMessage;
     
     return YES;

--- a/Riot/Utils/ThemeColorResolver.swift
+++ b/Riot/Utils/ThemeColorResolver.swift
@@ -1,0 +1,48 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// Utility struct to get a theme color by its name
+struct ThemeColorResolver {
+    private static var theme: Theme?
+    private static var colorsTable: [String: UIColor] = [:]
+    private static let queue = DispatchQueue(label: "io.element.ThemeColorResolver.queue", qos: .userInteractive)
+
+    private static func setTheme(theme: Theme) {
+        queue.sync {
+            guard self.theme?.identifier != theme.identifier else {
+                return
+            }
+            self.theme = theme
+            colorsTable = [:]
+            let mirror = Mirror(reflecting: theme.colors)
+            for child in mirror.children {
+                if let colorName = child.label {
+                    colorsTable[colorName] = child.value as? UIColor
+                }
+            }
+        }
+    }
+    
+    /// Finds a color by its name in the current theme colors
+    /// - Parameter name: color name
+    /// - Returns: the corresponding color or nil
+    static func getColorByName(_ name: String) -> UIColor? {
+        setTheme(theme: ThemeService.shared().theme)
+        return colorsTable[name]
+    }
+}

--- a/changelog.d/pr-7545.bugfix
+++ b/changelog.d/pr-7545.bugfix
@@ -1,0 +1,1 @@
+Fix: The last event description text color now matches the active theme.


### PR DESCRIPTION
This PR fixes a problem where the font color of `lastEventDescription` is not updated when the theme changes.

In the `RecentTableViewCell`, the `lastEventDescription` label has a foreground color but most of the time it displays the `roomCellData.lastEventAttributedTextMessage` which is an attributed string containing its own set of text color attributes.

By default, this attributed string uses only the `secondaryTextColor`, but in some scenarios (such as a live broadcast), the text may have a different color.

This attributed string is calculated by the `EventFormatter` when updating the room summary. The solution chosen for this PR was add two custom attributes for this attributed string:
- `themeIdentifierAttributeName`: to store which theme was active when the attributed string was created
- `themeColorNameAttributeName`: to store the name for the color

Before rendering the attributed string, if it contains the `themeIdentifierAttributeName` attribute and the active theme doesn't match, then the colors for the string will be updated to the current theme using the `themeColorNameAttributeName` attribute.
