### PR TITLE
Disable removing mention/command text trigger with RTE enabled

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -8147,6 +8147,14 @@ static CGSize kThreadListBarButtonItemImageSize;
 - (void)removeTriggerTextFromComposer:(NSString *)textTrigger
 {
     RoomInputToolbarView *toolbar = (RoomInputToolbarView *)self.inputToolbarView;
+    Class roomInputToolbarViewClass = [RoomViewController mainToolbarClass];
+
+    // RTE handles removing the text trigger by itself.
+    if (roomInputToolbarViewClass == WysiwygInputToolbarView.class && RiotSettings.shared.enableWysiwygTextFormatting)
+    {
+        return;
+    }
+
     if (toolbar && textTrigger.length) {
         NSMutableAttributedString *attributedTextMessage = [[NSMutableAttributedString alloc] initWithAttributedString:toolbar.attributedTextMessage];
         [[attributedTextMessage mutableString] replaceOccurrencesOfString:textTrigger


### PR DESCRIPTION
Removes unnecessary trying to delete the trigger text of a mention with RTE enabled.
This might not be worth a changelog, as it doesn't change anything (as RTE doesn't allow editing the attributedText) but it will avoid a MXLog.failure(...) in debug mode.