### PR TITLE
RoomCreationIntroCell now conforms to Themable protocol

### DIFF
--- a/Riot/Modules/Room/TimelineCells/RoomCreationIntro/RoomCreationIntroCell.swift
+++ b/Riot/Modules/Room/TimelineCells/RoomCreationIntro/RoomCreationIntroCell.swift
@@ -17,7 +17,7 @@
 import UIKit
 
 @objcMembers
-class RoomCreationIntroCell: MXKRoomBubbleTableViewCell {
+class RoomCreationIntroCell: MXKRoomBubbleTableViewCell, Themable {
     
     // MARK: - Constants
     

--- a/changelog.d/7554.bugfix
+++ b/changelog.d/7554.bugfix
@@ -1,0 +1,1 @@
+Timeline: Room creation intro cell now correctly adjusts to light / dark theme changes.


### PR DESCRIPTION
RoomCreationIntroCell now conforms to Themable protocol, making this cell type able to be updated when the system changes from light to dark theme and vice-versa. The update method was already implemented but just not called because the runtime did not match the Themable protocol on the TableViewCell object.

This fixes issue #7554 , as shown in video below:

![room-creation-intro-cell-theme-fixed](https://github.com/vector-im/element-ios/assets/26399/3f9cbc07-fcf4-46c7-bbf3-54a2f966dd6b)

Signed-off-by: Milton Moura <miltonmoura@gmail.com>

### Pull Request Checklist

- [X] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [X] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [X] Accessibility has been taken into account.
* [X] Pull request is based on the develop branch
- [X] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [X] You've made a self review of your PR
- [X] Pull request includes screenshots or videos of UI changes
- [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
