### PR TITLE
Implement MSC3987: Push actions clean-up

### DIFF
--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -80,8 +80,15 @@
     // Check whether an override rule has been defined with the roomm id as rule id.
     // This kind of rule is created to mute the room
     MXPushRule* rule = [self getOverrideRoomPushRule];
-    if (rule)
+    if (rule && rule.enabled)
     {
+        // Support for MSC3987: The dont_notify push rule action is deprecated.
+        if (rule.actions.count == 0)
+        {
+            return true;
+        }
+        
+        // Support deprecated dont_notify push rule action for compatibility purposes.
         for (MXPushRuleAction *ruleAction in rule.actions)
         {
             if (ruleAction.actionType == MXPushRuleActionTypeDontNotify)
@@ -98,7 +105,7 @@
                         
                         if (key && pattern && [key isEqualToString:@"room_id"] && [pattern isEqualToString:self.roomId])
                         {
-                            return rule.enabled;
+                            return true;
                         }
                     }
                 }
@@ -113,13 +120,20 @@
 {
     // Check push rules at room level
     MXPushRule *rule = [self getRoomPushRule];
-    if (rule)
+    if (rule && rule.enabled)
     {
+        // Support for MSC3987: The dont_notify push rule action is deprecated.
+        if (rule.actions.count == 0)
+        {
+            return true;
+        }
+        
+        // Support deprecated dont_notify push rule action for compatibility purposes.
         for (MXPushRuleAction *ruleAction in rule.actions)
         {
             if (ruleAction.actionType == MXPushRuleActionTypeDontNotify)
             {
-                return rule.enabled;
+                return true;
             }
         }
     }
@@ -178,12 +192,21 @@
         // check if the user did not define one
         BOOL hasDontNotifyRule = NO;
         
-        for (MXPushRuleAction *ruleAction in rule.actions)
+        // Support for MSC3987: The dont_notify push rule action is deprecated.
+        if (rule.actions.count == 0)
         {
-            if (ruleAction.actionType == MXPushRuleActionTypeDontNotify)
+            hasDontNotifyRule = YES;
+        }
+        else
+        {
+            // Support deprecated dont_notify push rule action for compatibility purposes.
+            for (MXPushRuleAction *ruleAction in rule.actions)
             {
-                hasDontNotifyRule = YES;
-                break;
+                if (ruleAction.actionType == MXPushRuleActionTypeDontNotify)
+                {
+                    hasDontNotifyRule = YES;
+                    break;
+                }
             }
         }
         
@@ -256,12 +279,21 @@
         // check if the user did not define one
         BOOL hasDontNotifyRule = NO;
         
-        for (MXPushRuleAction *ruleAction in rule.actions)
+        // Support for MSC3987: The dont_notify push rule action is deprecated.
+        if (rule.actions.count == 0)
         {
-            if (ruleAction.actionType == MXPushRuleActionTypeDontNotify)
+            hasDontNotifyRule = YES;
+        }
+        else
+        {
+            // Support deprecated dont_notify push rule action for compatibility purposes.
+            for (MXPushRuleAction *ruleAction in rule.actions)
             {
-                hasDontNotifyRule = YES;
-                break;
+                if (ruleAction.actionType == MXPushRuleActionTypeDontNotify)
+                {
+                    hasDontNotifyRule = YES;
+                    break;
+                }
             }
         }
         

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -888,6 +888,7 @@ class NotificationService: UNNotificationServiceExtension {
 private extension MXPushRule {
     var dontNotify: Bool {
         let actions = (actions as? [MXPushRuleAction]) ?? []
-        return actions.contains { $0.actionType == MXPushRuleActionTypeDontNotify }
+        // Support for MSC3987: The dont_notify push rule action is deprecated and replaced by an empty actions list.
+        return actions.isEmpty || actions.contains { $0.actionType == MXPushRuleActionTypeDontNotify }
     }
 }

--- a/RiotSwiftUI/Modules/Room/NotificationSettings/Service/MatrixSDK/MXRoomNotificationSettingsService.swift
+++ b/RiotSwiftUI/Modules/Room/NotificationSettings/Service/MatrixSDK/MXRoomNotificationSettingsService.swift
@@ -102,7 +102,7 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
         }
         
         // if the user defined one, use it
-        if rule.actionsContains(actionType: MXPushRuleActionTypeDontNotify) {
+        if rule.dontNotify {
             enablePushRule(rule: rule, completion: completion)
         } else {
             removePushRule(rule: rule) {
@@ -136,7 +136,7 @@ final class MXRoomNotificationSettingsService: RoomNotificationSettingsServiceTy
         }
         
         // if the user defined one, use it
-        if rule.actionsContains(actionType: MXPushRuleActionTypeDontNotify) {
+        if rule.dontNotify {
             enablePushRule(rule: rule, completion: completion)
         } else {
             removePushRule(rule: rule) {
@@ -261,7 +261,7 @@ public extension MXRoom {
         // Check whether an override rule has been defined with the roomm id as rule id.
         // This kind of rule is created to mute the room
         guard let rule = overridePushRule,
-              rule.actionsContains(actionType: MXPushRuleActionTypeDontNotify),
+              rule.dontNotify,
               rule.conditionIsEnabled(kind: .eventMatch, for: roomId) else {
             return false
         }
@@ -271,7 +271,7 @@ public extension MXRoom {
     var isMentionsOnly: Bool {
         // Check push rules at room level
         guard let rule = roomPushRule else { return false }
-        return rule.enabled && rule.actionsContains(actionType: MXPushRuleActionTypeDontNotify)
+        return rule.enabled && rule.dontNotify
     }
 }
 

--- a/RiotSwiftUI/Modules/Settings/Notifications/Model/MatrixSDK/MXNotificationPushRule.swift
+++ b/RiotSwiftUI/Modules/Settings/Notifications/Model/MatrixSDK/MXNotificationPushRule.swift
@@ -82,6 +82,10 @@ extension MXPushRule: NotificationPushRuleType {
     }
     
     var dontNotify: Bool {
-        getAction(actionType: MXPushRuleActionTypeDontNotify) != nil
+        guard let actions = actions as? [MXPushRuleAction] else {
+            return true
+        }
+        // Support for MSC3987: The dont_notify push rule action is deprecated and replaced by an empty actions list.
+        return actions.isEmpty || getAction(actionType: MXPushRuleActionTypeDontNotify) != nil
     }
 }

--- a/changelog.d/7576.change
+++ b/changelog.d/7576.change
@@ -1,0 +1,1 @@
+MSC3987 implementation: the 'dont_notify' action for a push_rule is now deprecated and replaced by an empty action list.


### PR DESCRIPTION
This PR implements the change requested by #7576 by adding support for [MSC3987](https://github.com/matrix-org/matrix-spec-proposals/pull/3987) which deprecates the dont_notify action for a push_rule.