### PR TITLE
Fix: Prevents UserAvatarView from disappearing due to incorrect width.

### DIFF
--- a/Riot/Modules/Home/AllChats/AllChatsCoordinator.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsCoordinator.swift
@@ -379,8 +379,12 @@ class AllChatsCoordinator: NSObject, SplitViewMasterCoordinatorProtocol {
         let avatarView = UserAvatarView(frame: view.bounds.inset(by: avatarInsets))
         avatarView.isUserInteractionEnabled = false
         avatarView.update(theme: ThemeService.shared().theme)
-        avatarView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        avatarView.autoresizingMask = [.flexibleTopMargin, .flexibleBottomMargin]
         view.addSubview(avatarView)
+        NSLayoutConstraint.activate([
+            view.widthAnchor.constraint(equalToConstant: 36),
+            view.heightAnchor.constraint(equalToConstant: 36)
+        ])
         self.avatarMenuView = avatarView
         updateAvatarButtonItem()
         viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: view)

--- a/changelog.d/pr-7587.bugfix
+++ b/changelog.d/pr-7587.bugfix
@@ -1,0 +1,1 @@
+Prevents user avatar from disappearing due to incorrect width.


### PR DESCRIPTION
This PR fixes an issue where the user's avatar can disappear from the top left menu of `AllChatsViewController` because the width of the AvatarView has become 0.
