### PR TITLE
Fix RTE sometimes inserting characters in wrong locations after multiple new lines

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "ff5e8054da60212051cb0dec244500ca0f441bac",
-        "version" : "2.1.0"
+        "revision" : "1100b217c04d096dfe072afb4484660ff794d805",
+        "version" : "2.2.2"
       }
     },
     {

--- a/changelog.d/7570.bugfix
+++ b/changelog.d/7570.bugfix
@@ -1,0 +1,1 @@
+Labs: Fix RTE sometimes inserting characters in wrong locations after multiple new lines

--- a/project.yml
+++ b/project.yml
@@ -57,7 +57,7 @@ packages:
     branch: 0.0.1
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    version: 2.1.0
+    version: 2.2.2
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0


### PR DESCRIPTION
Fixes #7570 
