### PR TITLE
Update posthog URL to posthog.element.io

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -192,7 +192,7 @@ final class BuildSettings: NSObject {
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: BuildSettings.baseBundleIdentifier.starts(with: "im.vector.app"),
-                                                               host: "https://posthog.hss.element.io",
+                                                               host: "https://posthog.element.io",
                                                                apiKey: "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
                                                                termsURL: URL(string: "https://element.io/cookie-policy")!)
     #endif


### PR DESCRIPTION
The posthog ingress is no longer posthog.hss.element.io, and, although it is running in parallel it will be removed in the future.