### PR TITLE
Fix a crash when opening v11 rooms.

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -833,35 +833,39 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
             NSString *creatorId;
             MXJSONModelSetString(creatorId, event.content[@"creator"]);
             
-            if (creatorId)
+            if (!creatorId)
             {
-                if ([creatorId isEqualToString:mxSession.myUserId])
+                // Room version 11 removes `creator` in favour of `sender`.
+                // https://github.com/matrix-org/matrix-spec-proposals/pull/2175
+                creatorId = event.sender;
+            }
+            
+            if ([creatorId isEqualToString:mxSession.myUserId])
+            {
+                if (isRoomDirect)
                 {
-                    if (isRoomDirect)
-                    {
-                        displayText = [VectorL10n noticeRoomCreatedByYouForDm];
-                    }
-                    else
-                    {
-                        displayText = [VectorL10n noticeRoomCreatedByYou];
-                    }
+                    displayText = [VectorL10n noticeRoomCreatedByYouForDm];
                 }
                 else
                 {
-                    if (isRoomDirect)
-                    {
-                        displayText = [VectorL10n noticeRoomCreatedForDm:(roomState ? [roomState.members memberName:creatorId] : creatorId)];
-                    }
-                    else
-                    {
-                        displayText = [VectorL10n noticeRoomCreated:(roomState ? [roomState.members memberName:creatorId] : creatorId)];
-                    }
+                    displayText = [VectorL10n noticeRoomCreatedByYou];
                 }
-                // Append redacted info if any
-                if (redactedInfo)
+            }
+            else
+            {
+                if (isRoomDirect)
                 {
-                    displayText = [NSString stringWithFormat:@"%@ %@", displayText, redactedInfo];
+                    displayText = [VectorL10n noticeRoomCreatedForDm:(roomState ? [roomState.members memberName:creatorId] : creatorId)];
                 }
+                else
+                {
+                    displayText = [VectorL10n noticeRoomCreated:(roomState ? [roomState.members memberName:creatorId] : creatorId)];
+                }
+            }
+            // Append redacted info if any
+            if (redactedInfo)
+            {
+                displayText = [NSString stringWithFormat:@"%@ %@", displayText, redactedInfo];
             }
             break;
         }

--- a/changelog.d/7633.bugfix
+++ b/changelog.d/7633.bugfix
@@ -1,0 +1,1 @@
+Fix a crash when opening v11 rooms.


### PR DESCRIPTION
`creator` was removed in `v11` instead favouring `sender`. This field is currently defined in the spec as required, hence the crash.
https://github.com/matrix-org/matrix-spec-proposals/pull/2175

Probably best to hide whitespaces on that diff.

Fixes #7633 