### PR TITLE
Fix SSO generating invalid URLs.

### DIFF
--- a/Riot/Modules/Authentication/SSO/SSOAuthenticationService.swift
+++ b/Riot/Modules/Authentication/SSO/SSOAuthenticationService.swift
@@ -50,7 +50,7 @@ final class SSOAuthenticationService: NSObject {
         
         var ssoRedirectPath = SSOURLConstants.Paths.redirect
         
-        if let identityProvider = identityProvider {
+        if let identityProvider = identityProvider, !identityProvider.isEmpty {
             ssoRedirectPath.append("/\(identityProvider)")
         }
         

--- a/changelog.d/pr-7639.bugfix
+++ b/changelog.d/pr-7639.bugfix
@@ -1,0 +1,1 @@
+Fix bug in SSO URL generation that was non-compliant with the spec.


### PR DESCRIPTION
When signing into to element.io the generated URL was `login/sso/redirect/?redirectUrl=…` but should be `login/sso/redirect?redirectUrl=…` without the trailing slash.