### PR TITLE
Only use the sender when rendering the room creation event.

### DIFF
--- a/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
+++ b/Riot/Modules/MatrixKit/Utils/EventFormatter/MXKEventFormatter.m
@@ -830,15 +830,10 @@ static NSString *const kRepliedTextPattern = @"<mx-reply>.*<blockquote>.*<br>(.*
         }
         case MXEventTypeRoomCreate:
         {
-            NSString *creatorId;
-            MXJSONModelSetString(creatorId, event.content[@"creator"]);
-            
-            if (!creatorId)
-            {
-                // Room version 11 removes `creator` in favour of `sender`.
-                // https://github.com/matrix-org/matrix-spec-proposals/pull/2175
-                creatorId = event.sender;
-            }
+            // Room version 11 removes `creator` in favour of `sender`.
+            // https://github.com/matrix-org/matrix-spec-proposals/pull/2175
+            // Just use the sender as it is possible to create a v11 room and spoof the `creator`.
+            NSString *creatorId = event.sender;
             
             if ([creatorId isEqualToString:mxSession.myUserId])
             {


### PR DESCRIPTION
On Room v11 it is possible that the sender could put in a fake creator. Don't allow this to happen.

The changelog already exists for this as #7633