### PR TITLE
hide account deactivation in OIDC

### DIFF
--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -33,6 +33,7 @@ final class RiotSettings: NSObject {
         static let enableUISIAutoReporting = "enableUISIAutoReporting"
         static let enableLiveLocationSharing = "enableLiveLocationSharing"
         static let showIPAddressesInSessionsManager = "showIPAddressesInSessionsManager"
+        static let isAuthenticatedWithOIDC = "isAuthenticatedWithOIDC"
     }
     
     static let shared = RiotSettings()
@@ -73,6 +74,9 @@ final class RiotSettings: NSObject {
     
     @UserDefault(key: "identityserverurl", defaultValue: BuildSettings.serverConfigDefaultIdentityServerUrlString, storage: defaults)
     var identityServerUrlString
+    
+    @UserDefault(key: UserDefaultsKeys.isAuthenticatedWithOIDC, defaultValue: false, storage: defaults)
+    var isAuthenticatedWithOIDC
     
     // MARK: Notifications
     

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -2190,6 +2190,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     [TimelinePollProvider.shared reset];
     
+    RiotSettings.shared.isAuthenticatedWithOIDC = NO;
+    
 #ifdef MX_CALL_STACK_ENDPOINT
     // Erase all created certificates and private keys by MXEndpointCallStack
     for (MXKAccount *account in MXKAccountManager.sharedManager.accounts)

--- a/Riot/Modules/Authentication/AuthenticationCoordinator.swift
+++ b/Riot/Modules/Authentication/AuthenticationCoordinator.swift
@@ -681,6 +681,8 @@ extension AuthenticationCoordinator: SSOAuthenticationPresenterDelegate {
             return
         }
         
+        RiotSettings.shared.isAuthenticatedWithOIDC = identityProvider?.isOIDC ?? false
+
         Task { await handleLoginToken(token, using: loginWizard) }
     }
     

--- a/Riot/Modules/Authentication/Legacy/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/Legacy/AuthenticationViewController.m
@@ -1524,7 +1524,7 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
 
 - (CGFloat)socialLoginViewHeightFittingWidth:(CGFloat)width
 {
-    NSArray<MXLoginSSOIdentityProvider*> *identityProviders =  self.currentLoginSSOFlow.identityProviders;
+    NSArray<SSOIdentityProvider*> *identityProviders =  self.currentLoginSSOFlow.ssoIdentityProviders;
     
     if (!identityProviders.count && self.socialLoginListView)
     {
@@ -1546,7 +1546,7 @@ static const CGFloat kAuthInputContainerViewMinHeightConstraintConstant = 150.0;
         listView.delegate = self;
     }
     
-    [listView updateWith:loginSSOFlow.identityProviders mode:mode];
+    [listView updateWith: loginSSOFlow.ssoIdentityProviders mode:mode];
     
     [self refreshContentViewHeightConstraint];
 }

--- a/Riot/Modules/Authentication/Legacy/SocialLogin/SocialLoginButtonFactory.swift
+++ b/Riot/Modules/Authentication/Legacy/SocialLogin/SocialLoginButtonFactory.swift
@@ -28,7 +28,7 @@ class SocialLoginButtonFactory {
     
     // MARK - Public
             
-    func build(with identityProvider: MXLoginSSOIdentityProvider, mode: SocialLoginButtonMode) -> SocialLoginButton {
+    func build(with identityProvider: SSOIdentityProvider, mode: SocialLoginButtonMode) -> SocialLoginButton {
         let button = SocialLoginButton()
         
         let defaultStyle: SocialLoginButtonStyle
@@ -37,7 +37,7 @@ class SocialLoginButtonFactory {
         let buildDefaultButtonStyles: () -> (SocialLoginButtonStyle, [String: SocialLoginButtonStyle]) = {
             let image: SourceImage?
             
-            if let imageStringURL = identityProvider.icon, let imageURL = URL(string: imageStringURL) {
+            if let imageStringURL = identityProvider.iconURL, let imageURL = URL(string: imageStringURL) {
                 image = .remote(imageURL)
             } else {
                 image = nil
@@ -71,7 +71,7 @@ class SocialLoginButtonFactory {
         
         let title = self.buildButtonTitle(with: identityProvider.name, mode: mode)
         
-        let viewData = SocialLoginButtonViewData(identityProvider: identityProvider.ssoIdentityProvider,
+        let viewData = SocialLoginButtonViewData(identityProvider: identityProvider,
                                                  title: title,
                                                  defaultStyle: defaultStyle,
                                                  themeStyles: styles)

--- a/Riot/Modules/Authentication/Legacy/SocialLogin/SocialLoginListView.swift
+++ b/Riot/Modules/Authentication/Legacy/SocialLogin/SocialLoginListView.swift
@@ -61,7 +61,7 @@ final class SocialLoginListView: UIView, NibLoadable {
     
     // MARK: - Public            
     
-    func update(with identityProviders: [MXLoginSSOIdentityProvider], mode: SocialLoginButtonMode) {
+    func update(with identityProviders: [SSOIdentityProvider], mode: SocialLoginButtonMode) {
         self.mode = mode
         
         let title: String
@@ -89,7 +89,7 @@ final class SocialLoginListView: UIView, NibLoadable {
         self.buttons = buttons
     }
         
-    static func contentViewHeight(identityProviders: [MXLoginSSOIdentityProvider],
+    static func contentViewHeight(identityProviders: [SSOIdentityProvider],
                                   mode: SocialLoginButtonMode,
                                   fitting width: CGFloat) -> CGFloat {
         let sizingView = self.sizingView
@@ -113,7 +113,7 @@ final class SocialLoginListView: UIView, NibLoadable {
         self.buttons = []
     }
         
-    private func socialLoginButtons(for identityProviders: [MXLoginSSOIdentityProvider], mode: SocialLoginButtonMode) -> [SocialLoginButton] {
+    private func socialLoginButtons(for identityProviders: [SSOIdentityProvider], mode: SocialLoginButtonMode) -> [SocialLoginButton] {
         
         var buttons: [SocialLoginButton] = []
         
@@ -122,7 +122,7 @@ final class SocialLoginListView: UIView, NibLoadable {
             if let firstIdentityProviderBrand = firstIdentityProvider.brand, let secondIdentityProviderBrand = secondIdentityProvider.brand {
                 return firstIdentityProviderBrand < secondIdentityProviderBrand
             } else {
-                return firstIdentityProvider.identifier < secondIdentityProvider.identifier
+                return firstIdentityProvider.id < secondIdentityProvider.id
             }
         }
         

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -607,8 +607,8 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
             [tmpSections addObject:sectionLabs];
         }
     }
-    
-    if (BuildSettings.settingsScreenAllowDeactivatingAccount)
+        
+    if (BuildSettings.settingsScreenAllowDeactivatingAccount && !RiotSettings.shared.isAuthenticatedWithOIDC)
     {
         Section *sectionDeactivate = [Section sectionWithTag:SECTION_TAG_DEACTIVATE_ACCOUNT];
         [sectionDeactivate addRowWithTag:0];

--- a/RiotSwiftUI/Modules/Authentication/Common/AuthenticationModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/AuthenticationModels.swift
@@ -112,11 +112,14 @@ class HomeserverAddress: NSObject {
     let brand: String?
     /// The icon field is an optional field that points to an icon representing the identity provider. If present then it must be an HTTPS URL to an image resource.
     let iconURL: String?
+    /// Dertermines if this provider uses OIDC
+    let isOIDC: Bool
     
-    init(id: String, name: String, brand: String?, iconURL: String?) {
+    init(id: String = "", name: String, brand: String?, iconURL: String?, isOIDC: Bool = false) {
         self.id = id
         self.name = name
         self.brand = brand
         self.iconURL = iconURL
+        self.isOIDC = isOIDC
     }
 }

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
@@ -295,7 +295,7 @@ class AuthenticationService: NSObject {
         if identityProviders.isEmpty {
             // Provide a backup for homeservers that support SSO but don't offer any identity providers
             // https://spec.matrix.org/latest/client-server-api/#client-login-via-sso
-            identityProviders = [SSOIdentityProvider(name: "SSO", brand: nil, iconURL: nil, isOIDC: loginFlow?.isOIDC ?? false)]
+            identityProviders = [SSOIdentityProvider(name: "SSO", brand: nil, iconURL: nil, isOIDC: loginFlow?.delegatedOIDCCompatibility ?? false)]
         }
         
         return LoginFlowResult(supportedLoginTypes: loginFlowResponse.flows?.compactMap { $0 } ?? [],
@@ -323,7 +323,7 @@ extension MXLoginSSOIdentityProvider {
 
 extension MXLoginSSOFlow {
     @objc var ssoIdentityProviders: [SSOIdentityProvider] {
-        identityProviders.map { $0.makeSSOIdentityProvider(isOIDC: isOIDC)}
+        identityProviders.map { $0.makeSSOIdentityProvider(isOIDC: delegatedOIDCCompatibility)}
     }
 }
 

--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/LoginModels.swift
@@ -52,9 +52,7 @@ enum LoginMode {
     var ssoIdentityProviders: [SSOIdentityProvider]? {
         switch self {
         case .sso(let ssoIdentityProviders), .ssoAndPassword(let ssoIdentityProviders):
-            // Provide a backup for homeservers that support SSO but don't offer any identity providers
-            // https://spec.matrix.org/latest/client-server-api/#client-login-via-sso
-            return ssoIdentityProviders.count > 0 ? ssoIdentityProviders : [SSOIdentityProvider(id: "", name: "SSO", brand: nil, iconURL: nil)]
+            return ssoIdentityProviders
         default:
             return nil
         }

--- a/changelog.d/7648.bugfix
+++ b/changelog.d/7648.bugfix
@@ -1,0 +1,1 @@
+Deactivate account option is disabled when logging in with OIDC.


### PR DESCRIPTION
fixes #7648 

This PR also includes a way to make the app remember that the last SSO login was using OIDC. This will only work from the next new hard login.

- [x] Require the SDK develop branch to be updated.