### PR TITLE
Open MAS Web page when logging out from other sessions on OIDC authenticated homeservers

### DIFF
--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -656,6 +656,20 @@ enum {
 
 - (void)removeDevice
 {
+    NSURL *logoutURL = [self.mainSession.homeserverWellknown.authentication getMasLogoutDeviceURLFromDeviceID:device.deviceId];
+    if (logoutURL)
+    {
+        [UIApplication.sharedApplication openURL:logoutURL options:@{} completionHandler:nil];
+        [self withdrawViewControllerAnimated:YES completion:nil];
+    }
+    else
+    {
+        [self removeDeviceThroughAPI];
+    }
+}
+
+-(void) removeDeviceThroughAPI
+{
     [self startActivityIndicator];
     self.view.userInteractionEnabled = NO;
     

--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -656,7 +656,7 @@ enum {
 
 - (void)removeDevice
 {
-    NSURL *logoutURL = [self.mainSession.homeserverWellknown.authentication getMasLogoutDeviceURLFromDeviceID:device.deviceId];
+    NSURL *logoutURL = [self.mainSession.homeserverWellknown.authentication getLogoutDeviceURLFromID:device.deviceId];
     if (logoutURL)
     {
         [UIApplication.sharedApplication openURL:logoutURL options:@{} completionHandler:nil];

--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
@@ -123,7 +123,7 @@ final class UserSessionsFlowCoordinator: NSObject, Coordinator, Presentable {
                 if sessionInfo.isCurrent {
                     self.showLogoutConfirmationForCurrentSession()
                 } else {
-                    if let logoutURL = self.parameters.session.homeserverWellknown.authentication?.getMasLogoutDeviceURL(fromDeviceID: sessionInfo.id) {
+                    if let logoutURL = self.parameters.session.homeserverWellknown.authentication?.getLogoutDeviceURL(fromID: sessionInfo.id) {
                         self.openMasLogoutURL(logoutURL)
                     } else {
                         self.showLogoutConfirmation(for: [sessionInfo])

--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
@@ -123,7 +123,11 @@ final class UserSessionsFlowCoordinator: NSObject, Coordinator, Presentable {
                 if sessionInfo.isCurrent {
                     self.showLogoutConfirmationForCurrentSession()
                 } else {
-                    self.showLogoutConfirmation(for: [sessionInfo])
+                    if let logoutURL = self.parameters.session.homeserverWellknown.authentication?.getMasLogoutDeviceURL(fromDeviceID: sessionInfo.id) {
+                        self.openMasLogoutURL(logoutURL)
+                    } else {
+                        self.showLogoutConfirmation(for: [sessionInfo])
+                    }
                 }
             case let .showSessionStateInfo(sessionInfo):
                 self.showInfoSheet(parameters: .init(userSessionInfo: sessionInfo, parentSize: self.toPresentable().view.bounds.size))
@@ -180,6 +184,11 @@ final class UserSessionsFlowCoordinator: NSObject, Coordinator, Presentable {
                                                                 filter: filter,
                                                                 title: title)
         return UserOtherSessionsCoordinator(parameters: parameters)
+    }
+    
+    private func openMasLogoutURL(_ url: URL) {
+        UIApplication.shared.open(url)
+        popToSessionsOverview()
     }
     
     /// Shows a confirmation dialog to the user to sign out of a session.

--- a/changelog.d/7646.bugfix
+++ b/changelog.d/7646.bugfix
@@ -1,0 +1,1 @@
+You can now log out from other sessions using MAS on supported OIDC home servers.


### PR DESCRIPTION
fixes #7646 

Requires this to be merged to develop first:
https://github.com/matrix-org/matrix-ios-sdk/pull/1813