### PR TITLE
Fix event forwarding

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4577,7 +4577,8 @@ static CGSize kThreadListBarButtonItemImageSize;
 {
     ForwardingShareItemSender *shareItemSender = [[ForwardingShareItemSender alloc] initWithEvent:selectedEvent];
     self.shareManager = [[ShareManager alloc] initWithShareItemSender:shareItemSender
-                                                                 type:ShareManagerTypeForward];
+                                                                 type:ShareManagerTypeForward
+                                                              session:self.mainSession];
     
     MXWeakify(self);
     [self.shareManager setCompletionCallback:^(ShareManagerResult result) {

--- a/RiotShareExtension/Shared/ForwardingShareItemSender.swift
+++ b/RiotShareExtension/Shared/ForwardingShareItemSender.swift
@@ -56,6 +56,7 @@ class ForwardingShareItemSender: NSObject, ShareItemSenderProtocol {
                 case .failure(let innerError):
                     errors.append(innerError)
                 default:
+                    room.summary.resetLastMessage(nil, failure: nil, commit: false)
                     break
                 }
                 

--- a/RiotShareExtension/Shared/ShareManager.h
+++ b/RiotShareExtension/Shared/ShareManager.h
@@ -36,7 +36,9 @@ typedef NS_ENUM(NSUInteger, ShareManagerResult) {
 @property (nonatomic, copy) void (^completionCallback)(ShareManagerResult);
 
 - (instancetype)initWithShareItemSender:(id<ShareItemSenderProtocol>)itemSender
-                                   type:(ShareManagerType)type;
+                                   type:(ShareManagerType)type
+                                   session:(nullable MXSession*)session;
+
 
 - (UIViewController *)mainViewController;
 

--- a/changelog.d/7641.bugfix
+++ b/changelog.d/7641.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where rooms were not correctly sorted after forwarding a message.


### PR DESCRIPTION
This PR fixes #7641 
There were two issues:
- The `ShareManager` was using a specific session and store.
- The `MXRoom`, during its initialization, resets the timestamp of outgoing messages. 

The fix is in two parts:
- `ShareManager` can now be used with a specific session (in this case, message forwarding is done inside the application and not using a share extension, so using the current session seems fine).
- The corresponding room summary is reset once the message has been sent (to take account of the fact that it may have been created with an incorrect timestamp).