### PR TITLE
Add initial support for configuration through MDM

### DIFF
--- a/BroadcastUploadExtension/target.yml
+++ b/BroadcastUploadExtension/target.yml
@@ -38,5 +38,6 @@ targets:
     sources:
     - path: .
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Riot/Categories/Bundle.swift
     - path: ../Riot/Modules/Room/TimelineCells/Styles/RoomTimelineStyleIdentifier.swift

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -102,13 +102,16 @@ final class BuildSettings: NSObject {
     static let forceHomeserverSelection = false
 
     /// Default server proposed on the authentication screen
-    static let serverConfigDefaultHomeserverUrlString = "https://matrix.org"
+    static var serverConfigDefaultHomeserverUrlString: String {
+        MDMSettings.serverConfigDefaultHomeserverUrlString ?? "https://matrix.org"
+    }
     
     /// Default identity server
     static let serverConfigDefaultIdentityServerUrlString = "https://vector.im"
         
-    static let serverConfigSygnalAPIUrlString = "https://matrix.org/_matrix/push/v1/notify"
-    
+    static var serverConfigSygnalAPIUrlString: String {
+        MDMSettings.serverConfigSygnalAPIUrlString ?? "https://matrix.org/_matrix/push/v1/notify"
+    }
     
     // MARK: - Legal URLs
     
@@ -144,7 +147,9 @@ final class BuildSettings: NSObject {
     // This baseURL is used to generate permalinks within the app (E.g. timeline message permalinks).
     // Optional String that when set is used as permalink base, when nil matrix.to format is used.
     // Example value would be "https://www.example.com", note there is no trailing '/'.
-    static let clientPermalinkBaseUrl: String? = nil
+    static var clientPermalinkBaseUrl: String? {
+        MDMSettings.clientPermalinkBaseUrl
+    }
     
     // MARK: - VoIP
     static var allowVoIPUsage: Bool {

--- a/Config/MDMSettings.swift
+++ b/Config/MDMSettings.swift
@@ -1,0 +1,49 @@
+// 
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+enum MDMSettings {
+    private static let appleManagedConfigurationKey = "com.apple.configuration.managed"
+    
+    private enum Key: String {
+        case serverConfigDefaultHomeserverUrlString = "im.vector.app.serverConfigDefaultHomeserverUrlString"
+        case serverConfigSygnalAPIUrlString = "im.vector.app.serverConfigSygnalAPIUrlString"
+        case clientPermalinkBaseUrl = "im.vector.app.clientPermalinkBaseUrl"
+    }
+    
+    static var serverConfigDefaultHomeserverUrlString: String? {
+        valueForKey(.serverConfigDefaultHomeserverUrlString) as? String
+    }
+    
+    static var serverConfigSygnalAPIUrlString: String? {
+        valueForKey(.serverConfigSygnalAPIUrlString) as? String
+    }
+    
+    static var clientPermalinkBaseUrl: String? {
+        valueForKey(.clientPermalinkBaseUrl) as? String
+    }
+    
+    // MARK: - Private
+    
+    static private func valueForKey(_ key: Key) -> Any? {
+        guard let managedConfiguration = UserDefaults.standard.dictionary(forKey: appleManagedConfigurationKey) else {
+            return nil
+        }
+        
+        return managedConfiguration[key.rawValue]
+    }
+}

--- a/Config/MDMSettings.swift
+++ b/Config/MDMSettings.swift
@@ -41,8 +41,11 @@ enum MDMSettings {
     
     static private func valueForKey(_ key: Key) -> Any? {
         guard let managedConfiguration = UserDefaults.standard.dictionary(forKey: appleManagedConfigurationKey) else {
+            print("MDM configuration missing")
             return nil
         }
+        
+        print("Retrieved MDM configuration: \(managedConfiguration)")
         
         return managedConfiguration[key.rawValue]
     }

--- a/RiotNSE/target.yml
+++ b/RiotNSE/target.yml
@@ -44,6 +44,7 @@ targets:
     - path: .
     - path: ../Riot/Managers/Settings/RiotSettings.swift
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Riot/Utils/DataProtectionHelper.swift
     - path: ../Config/CommonConfiguration.swift
     - path: ../Riot/Experiments/

--- a/RiotShareExtension/target.yml
+++ b/RiotShareExtension/target.yml
@@ -48,6 +48,7 @@ targets:
     - path: ../Riot/Managers/Theme/
     - path: ../Riot/Utils/AvatarGenerator.m
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Riot/Categories/Character.swift
     - path: ../Riot/Categories/MXKImageView.swift
     - path: ../Riot/Categories/MXRoom+Riot.m

--- a/RiotSwiftUI/target.yml
+++ b/RiotSwiftUI/target.yml
@@ -52,6 +52,7 @@ targets:
     - path: ../Riot/Managers/Theme/
     - path: ../Riot/Managers/Locale/LocaleProviderType.swift
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Riot/Modules/Room/TimelineCells/Styles/RoomTimelineStyleIdentifier.swift
     - path: ../Riot/Categories/String.swift
     - path: ../Riot/Categories/Character.swift

--- a/RiotSwiftUI/targetUITests.yml
+++ b/RiotSwiftUI/targetUITests.yml
@@ -61,6 +61,7 @@ targets:
     - path: ../Riot/Managers/Theme/
     - path: ../Riot/Managers/Locale/LocaleProviderType.swift
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Riot/Modules/Room/TimelineCells/Styles/RoomTimelineStyleIdentifier.swift
     - path: ../Riot/Categories/String.swift
     - path: ../Riot/Categories/Character.swift

--- a/RiotTests/target.yml
+++ b/RiotTests/target.yml
@@ -61,6 +61,7 @@ targets:
     - path: .
     - path: ../Config/Configurable.swift
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Riot/Categories/Bundle.swift
     - path: ../Riot/Managers/AppInfo/AppInfo.swift
     - path: ../Riot/Managers/AppInfo/AppVersion.swift

--- a/SiriIntents/target.yml
+++ b/SiriIntents/target.yml
@@ -48,6 +48,7 @@ targets:
     - path: ../Config/CommonConfiguration.swift
     - path: ../Riot/Experiments/
     - path: ../Config/BuildSettings.swift
+    - path: ../Config/MDMSettings.swift
     - path: ../Config/Configurable.swift
     - path: ../Riot/Managers/Settings/RiotSettings.swift
     - path: ../Riot/Managers/EncryptionKeyManager/EncryptionKeyManager.swift


### PR DESCRIPTION
This will allow MDM providers to configure the:
* default homeserver URL - `im.vector.app.serverConfigDefaultHomeserverUrlString`
* push gateway URL - `im.vector.app.serverConfigSygnalAPIUrlString`
* permalink base URL - `im.vector.app.clientPermalinkBaseUrl`

These methods will always try to fetch the MDM configuration first, if available, otherwise they will just use the existing defaults.