### PR TITLE
Hide all Sign Out X/All Sessions buttons in the Device Manager when using OIDC.

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/Coordinator/UserSessionsFlowCoordinator.swift
@@ -188,9 +188,11 @@ final class UserSessionsFlowCoordinator: NSObject, Coordinator, Presentable {
     private func createOtherSessionsCoordinator(sessionInfos: [UserSessionInfo],
                                                 filterBy filter: UserOtherSessionsFilter,
                                                 title: String) -> UserOtherSessionsCoordinator {
+        let shouldShowDeviceLogout = parameters.session.homeserverWellknown.authentication == nil
         let parameters = UserOtherSessionsCoordinatorParameters(sessionInfos: sessionInfos,
                                                                 filter: filter,
-                                                                title: title)
+                                                                title: title,
+                                                                showDeviceLogout: shouldShowDeviceLogout)
         return UserOtherSessionsCoordinator(parameters: parameters)
     }
     

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/Coordinator/UserOtherSessionsCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/Coordinator/UserOtherSessionsCoordinator.swift
@@ -21,6 +21,7 @@ struct UserOtherSessionsCoordinatorParameters {
     let sessionInfos: [UserSessionInfo]
     let filter: UserOtherSessionsFilter
     let title: String
+    let showDeviceLogout: Bool
 }
 
 final class UserOtherSessionsCoordinator: Coordinator, Presentable {
@@ -40,6 +41,7 @@ final class UserOtherSessionsCoordinator: Coordinator, Presentable {
         let viewModel = UserOtherSessionsViewModel(sessionInfos: parameters.sessionInfos,
                                                    filter: parameters.filter,
                                                    title: parameters.title,
+                                                   showDeviceLogout: parameters.showDeviceLogout,
                                                    settingsService: RiotSettings.shared)
         let view = UserOtherSessions(viewModel: viewModel.context)
         userOtherSessionsViewModel = viewModel

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/MockUserOtherSessionsScreenState.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/MockUserOtherSessionsScreenState.swift
@@ -49,26 +49,31 @@ enum MockUserOtherSessionsScreenState: MockScreenState, CaseIterable {
             viewModel = UserOtherSessionsViewModel(sessionInfos: allSessions(),
                                                    filter: .all,
                                                    title: VectorL10n.userSessionsOverviewOtherSessionsSectionTitle,
+                                                   showDeviceLogout: true,
                                                    settingsService: MockUserSessionSettings())
         case .none:
             viewModel = UserOtherSessionsViewModel(sessionInfos: [],
                                                    filter: .all,
                                                    title: VectorL10n.userSessionsOverviewOtherSessionsSectionTitle,
+                                                   showDeviceLogout: true,
                                                    settingsService: MockUserSessionSettings())
         case .inactiveSessions:
             viewModel = UserOtherSessionsViewModel(sessionInfos: inactiveSessions(),
                                                    filter: .inactive,
                                                    title: VectorL10n.userOtherSessionSecurityRecommendationTitle,
+                                                   showDeviceLogout: true,
                                                    settingsService: MockUserSessionSettings())
         case .unverifiedSessions:
             viewModel = UserOtherSessionsViewModel(sessionInfos: unverifiedSessions(),
                                                    filter: .unverified,
                                                    title: VectorL10n.userOtherSessionSecurityRecommendationTitle,
+                                                   showDeviceLogout: true,
                                                    settingsService: MockUserSessionSettings())
         case .verifiedSessions:
             viewModel = UserOtherSessionsViewModel(sessionInfos: verifiedSessions(),
                                                    filter: .verified,
                                                    title: VectorL10n.userOtherSessionSecurityRecommendationTitle,
+                                                   showDeviceLogout: true,
                                                    settingsService: MockUserSessionSettings())
         }
         

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/Test/Unit/UserOtherSessionsViewModelTests.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/Test/Unit/UserOtherSessionsViewModelTests.swift
@@ -63,7 +63,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: VectorL10n.userOtherSessionNoInactiveSessions,
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -81,7 +82,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -104,7 +106,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: VectorL10n.userOtherSessionNoUnverifiedSessions,
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(expectedItems.count, 2)
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -123,7 +126,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: VectorL10n.userOtherSessionNoVerifiedSessions,
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -139,7 +143,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: VectorL10n.userOtherSessionNoVerifiedSessions,
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -155,7 +160,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: VectorL10n.userOtherSessionNoUnverifiedSessions,
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -171,7 +177,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: VectorL10n.userOtherSessionNoInactiveSessions,
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -192,7 +199,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: true,
                                                        enableSignOutButton: true,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -213,7 +221,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -233,7 +242,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: false,
                                                        enableSignOutButton: true,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -253,7 +263,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: true,
                                                        enableSignOutButton: true,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -273,7 +284,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -296,7 +308,8 @@ class UserOtherSessionsViewModelTests: XCTestCase {
                                                        emptyItemsTitle: "",
                                                        allItemsSelected: false,
                                                        enableSignOutButton: false,
-                                                       showLocationInfo: false)
+                                                       showLocationInfo: false,
+                                                       showDeviceLogout: true)
         XCTAssertEqual(sut.state, expectedState)
     }
     
@@ -352,6 +365,7 @@ class UserOtherSessionsViewModelTests: XCTestCase {
         UserOtherSessionsViewModel(sessionInfos: sessionInfos,
                                    filter: filter,
                                    title: title,
+                                   showDeviceLogout: true,
                                    settingsService: MockUserSessionSettings())
     }
     

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/UserOtherSessionsModels.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/UserOtherSessionsModels.swift
@@ -43,6 +43,7 @@ struct UserOtherSessionsViewState: BindableState, Equatable {
     var allItemsSelected: Bool
     var enableSignOutButton: Bool
     var showLocationInfo: Bool
+    var showDeviceLogout: Bool
 }
 
 struct UserOtherSessionsBindings: Equatable {

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/UserOtherSessionsViewModel.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/UserOtherSessionsViewModel.swift
@@ -28,6 +28,7 @@ class UserOtherSessionsViewModel: UserOtherSessionsViewModelType, UserOtherSessi
     init(sessionInfos: [UserSessionInfo],
          filter: UserOtherSessionsFilter,
          title: String,
+         showDeviceLogout: Bool,
          settingsService: UserSessionSettingsProtocol) {
         self.sessionInfos = sessionInfos
         defaultTitle = title
@@ -41,7 +42,8 @@ class UserOtherSessionsViewModel: UserOtherSessionsViewModelType, UserOtherSessi
                                                                 emptyItemsTitle: filter.userOtherSessionsViewEmptyResultsTitle,
                                                                 allItemsSelected: false,
                                                                 enableSignOutButton: false,
-                                                                showLocationInfo: settingsService.showIPAddressesInSessionsManager))
+                                                                showLocationInfo: settingsService.showIPAddressesInSessionsManager,
+                                                                showDeviceLogout: showDeviceLogout))
     }
     
     // MARK: - Public

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/View/UserOtherSessions.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/View/UserOtherSessions.swift
@@ -60,6 +60,7 @@ struct UserOtherSessions: View {
                                                                   set: { _ in withAnimation { viewModel.send(viewAction: .showLocationInfo) } }),
                                      allItemsSelected: viewModel.viewState.allItemsSelected,
                                      sessionCount: viewModel.viewState.sessionItems.count,
+                                     showDeviceLogout: viewModel.viewState.showDeviceLogout,
                                      onToggleSelection: { viewModel.send(viewAction: .toggleAllSelection) },
                                      onSignOut: { viewModel.send(viewAction: .logoutAllUserSessions) })
         }

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/View/UserOtherSessionsToolbar.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/View/UserOtherSessionsToolbar.swift
@@ -24,6 +24,7 @@ struct UserOtherSessionsToolbar: ToolbarContent {
     @Binding var isShowLocationEnabled: Bool
     let allItemsSelected: Bool
     let sessionCount: Int
+    let showDeviceLogout: Bool
     let onToggleSelection: () -> Void
     let onSignOut: () -> Void
     
@@ -94,7 +95,7 @@ struct UserOtherSessionsToolbar: ToolbarContent {
                     Label(showLocationInfo: isShowLocationEnabled)
                 }
                 
-                if sessionCount > 0 {
+                if sessionCount > 0, showDeviceLogout {
                     DestructiveButton {
                         onSignOut()
                     } label: {

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Coordinator/UserSessionsOverviewCoordinator.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Coordinator/UserSessionsOverviewCoordinator.swift
@@ -39,7 +39,10 @@ final class UserSessionsOverviewCoordinator: Coordinator, Presentable {
         self.parameters = parameters
         service = parameters.service
         
-        viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: parameters.service, settingsService: RiotSettings.shared)
+        let shouldShowDeviceLogout = parameters.session.homeserverWellknown.authentication == nil
+        viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: parameters.service,
+                                                  settingsService: RiotSettings.shared,
+                                                  showDeviceLogout: shouldShowDeviceLogout)
         
         hostingViewController = VectorHostingController(rootView: UserSessionsOverview(viewModel: viewModel.context))
         hostingViewController.vc_setLargeTitleDisplayMode(.never)

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/MockUserSessionsOverviewScreenState.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/MockUserSessionsOverviewScreenState.swift
@@ -51,7 +51,7 @@ enum MockUserSessionsOverviewScreenState: MockScreenState, CaseIterable {
             fatalError()
         }
         
-        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: service, settingsService: MockUserSessionSettings())
+        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: service, settingsService: MockUserSessionSettings(), showDeviceLogout: true)
         
         return (
             [service, viewModel],

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Test/Unit/UserSessionsOverviewViewModelTests.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/Test/Unit/UserSessionsOverviewViewModelTests.swift
@@ -21,7 +21,9 @@ import XCTest
 
 class UserSessionsOverviewViewModelTests: XCTestCase {
     func testInitialStateEmpty() {
-        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: MockUserSessionsOverviewService(), settingsService: MockUserSessionSettings())
+        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: MockUserSessionsOverviewService(),
+                                                      settingsService: MockUserSessionSettings(),
+                                                      showDeviceLogout: true)
         
         XCTAssertNil(viewModel.state.currentSessionViewData)
         XCTAssertTrue(viewModel.state.unverifiedSessionsViewData.isEmpty)
@@ -31,7 +33,9 @@ class UserSessionsOverviewViewModelTests: XCTestCase {
     }
     
     func testLoadOnDidAppear() {
-        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: MockUserSessionsOverviewService(), settingsService: MockUserSessionSettings())
+        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: MockUserSessionsOverviewService(),
+                                                      settingsService: MockUserSessionSettings(),
+                                                      showDeviceLogout: true)
         viewModel.process(viewAction: .viewAppeared)
         
         XCTAssertNotNil(viewModel.state.currentSessionViewData)
@@ -42,7 +46,9 @@ class UserSessionsOverviewViewModelTests: XCTestCase {
     }
     
     func testSimpleActionProcessing() {
-        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: MockUserSessionsOverviewService(), settingsService: MockUserSessionSettings())
+        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: MockUserSessionsOverviewService(),
+                                                      settingsService: MockUserSessionSettings(),
+                                                      showDeviceLogout: true)
         
         var result: UserSessionsOverviewViewModelResult?
         viewModel.completion = { action in
@@ -69,7 +75,9 @@ class UserSessionsOverviewViewModelTests: XCTestCase {
         let service = MockUserSessionsOverviewService()
         service.updateOverviewData { _ in }
         
-        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: service, settingsService: MockUserSessionSettings())
+        let viewModel = UserSessionsOverviewViewModel(userSessionsOverviewService: service,
+                                                      settingsService: MockUserSessionSettings(),
+                                                      showDeviceLogout: true)
         
         var result: UserSessionsOverviewViewModelResult?
         viewModel.completion = { action in

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewModels.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewModels.swift
@@ -51,6 +51,7 @@ struct UserSessionsOverviewViewState: BindableState {
     var showLoadingIndicator = false
     var linkDeviceButtonVisible = false
     var showLocationInfo: Bool
+    var showDeviceLogout: Bool
 }
 
 enum UserSessionsOverviewViewAction {

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewViewModel.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/UserSessionsOverviewViewModel.swift
@@ -24,11 +24,11 @@ class UserSessionsOverviewViewModel: UserSessionsOverviewViewModelType, UserSess
     
     var completion: ((UserSessionsOverviewViewModelResult) -> Void)?
 
-    init(userSessionsOverviewService: UserSessionsOverviewServiceProtocol, settingsService: UserSessionSettingsProtocol) {
+    init(userSessionsOverviewService: UserSessionsOverviewServiceProtocol, settingsService: UserSessionSettingsProtocol, showDeviceLogout: Bool) {
         self.userSessionsOverviewService = userSessionsOverviewService
         self.settingsService = settingsService
         
-        super.init(initialViewState: .init(showLocationInfo: settingsService.showIPAddressesInSessionsManager))
+        super.init(initialViewState: .init(showLocationInfo: settingsService.showIPAddressesInSessionsManager, showDeviceLogout: showDeviceLogout))
         
         userSessionsOverviewService.overviewDataPublisher.sink { [weak self] overviewData in
             self?.updateViewState(with: overviewData)

--- a/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionsOverview.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserSessionsOverview/View/UserSessionsOverview.swift
@@ -125,7 +125,7 @@ struct UserSessionsOverview: View {
                     Label(VectorL10n.signOut, systemImage: "rectangle.portrait.and.arrow.right.fill")
                 }
             }
-            if viewModel.viewState.otherSessionsViewData.count > 0 {
+            if viewModel.viewState.otherSessionsViewData.count > 0, viewModel.viewState.showDeviceLogout {
                 DestructiveButton {
                     viewModel.send(viewAction: .logoutOtherSessions)
                 } label: {
@@ -149,10 +149,12 @@ struct UserSessionsOverview: View {
                 Label(showLocationInfo: viewModel.viewState.showLocationInfo)
             }
             
-            DestructiveButton {
-                viewModel.send(viewAction: .logoutOtherSessions)
-            } label: {
-                Label(VectorL10n.userOtherSessionMenuSignOutSessions(String(viewModel.viewState.otherSessionsViewData.count)), systemImage: "rectangle.portrait.and.arrow.forward.fill")
+            if viewModel.viewState.showDeviceLogout {
+                DestructiveButton {
+                    viewModel.send(viewAction: .logoutOtherSessions)
+                } label: {
+                    Label(VectorL10n.userOtherSessionMenuSignOutSessions(String(viewModel.viewState.otherSessionsViewData.count)), systemImage: "rectangle.portrait.and.arrow.forward.fill")
+                }
             }
         } label: {
             menuImage

--- a/changelog.d/7672.bugfix
+++ b/changelog.d/7672.bugfix
@@ -1,0 +1,1 @@
+Hide Sign Out X/All Sessions buttons in the Device Manager when using OIDC.


### PR DESCRIPTION
Fixes #7672 by hiding the mentioned buttons when the homeserver is using OIDC.