### PR TITLE
Also hide session selection with OIDC in the device manager.

### DIFF
--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/View/UserOtherSessionsToolbar.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/View/UserOtherSessionsToolbar.swift
@@ -82,12 +82,14 @@ struct UserOtherSessionsToolbar: ToolbarContent {
     private func optionsMenu() -> some View {
         Button { } label: {
             Menu {
-                Button {
-                    isEditModeEnabled = true
-                } label: {
-                    Label(VectorL10n.userOtherSessionMenuSelectSessions, systemImage: "checkmark.circle")
+                if showDeviceLogout { // As you can only sign out the selected sessions, we don't allow selection when you're unable to sign out devices.
+                    Button {
+                        isEditModeEnabled = true
+                    } label: {
+                        Label(VectorL10n.userOtherSessionMenuSelectSessions, systemImage: "checkmark.circle")
+                    }
+                    .disabled(sessionCount == 0)
                 }
-                .disabled(sessionCount == 0)
                 
                 Button {
                     isShowLocationEnabled.toggle()


### PR DESCRIPTION
Small follow on to #7674 which missed the fact you can multi-select sessions and sign them out too.

Not including a changelog for this as its covered by the previous PR.

![Simulator Screenshot - iPhone 14 - 2023-09-13 at 14 22 13](https://github.com/vector-im/element-ios/assets/6060466/ba2d10ab-cacc-4b3b-abdc-d87d3cc48874)
