### PR TITLE
Release kMXKAccountAPNSActivityDidChangeNotification observer when de…

### DIFF
--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -347,6 +347,9 @@ SSOAuthenticationPresenterDelegate>
         [[NSNotificationCenter defaultCenter] removeObserver:pushInfoUpdateObserver name:kMXKAccountAPNSActivityDidChangeNotification object:nil];
         pushInfoUpdateObserver = nil;
     }
+
+    // Fix for destroy not being called
+    [self destroy];
 }
 
 - (void)updateSections

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -341,13 +341,6 @@ SSOAuthenticationPresenterDelegate>
 }
 
 - (void)dealloc {
-    // Remove observers
-    if (pushInfoUpdateObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:pushInfoUpdateObserver name:kMXKAccountAPNSActivityDidChangeNotification object:nil];
-        pushInfoUpdateObserver = nil;
-    }
-
     // Fix for destroy not being called
     [self destroy];
 }

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -340,6 +340,15 @@ SSOAuthenticationPresenterDelegate>
     self.screenTracker = [[AnalyticsScreenTracker alloc] initWithScreen:AnalyticsScreenSettings];
 }
 
+- (void)dealloc {
+    // Remove observers
+    if (pushInfoUpdateObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:pushInfoUpdateObserver name:kMXKAccountAPNSActivityDidChangeNotification object:nil];
+        pushInfoUpdateObserver = nil;
+    }
+}
+
 - (void)updateSections
 {
     NSMutableArray<Section*> *tmpSections = [NSMutableArray arrayWithCapacity:SECTION_TAG_DEACTIVATE_ACCOUNT + 1];

--- a/changelog.d/Settings-controller-dealloc-observer.bugfix
+++ b/changelog.d/Settings-controller-dealloc-observer.bugfix
@@ -1,1 +1,1 @@
-Remove registered observer kMXKAccountAPNSActivityDidChangeNotification in dealloc of SettingsViewController
+Call destroy in dealloc to remove all observers of SettingsViewController

--- a/changelog.d/Settings-controller-dealloc-observer.bugfix
+++ b/changelog.d/Settings-controller-dealloc-observer.bugfix
@@ -1,0 +1,1 @@
+Remove registered observer kMXKAccountAPNSActivityDidChangeNotification in dealloc of SettingsViewController


### PR DESCRIPTION
Remove registered observer `kMXKAccountAPNSActivityDidChangeNotification` in dealloc of SettingsViewController.

### Pull Request Checklist

- [X] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [X] Pull request is based on the develop branch
- [X] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [X] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
