### PR TITLE
Sliding to end a Jitsi call for everyone successfully ends the call for the user.

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -8053,7 +8053,7 @@ static CGSize kThreadListBarButtonItemImageSize;
         self.removeJitsiWidgetView.delegate = nil;
         
         //  end active call if exists
-        if ([self isRoomHavingAJitsiCallForWidgetId:jitsiWidget.widgetId])
+        if ([self isRoomHavingAJitsiCall])
         {
             [self endActiveJitsiCall];
         }

--- a/changelog.d/7704.bugfix
+++ b/changelog.d/7704.bugfix
@@ -1,0 +1,1 @@
+The slide to end call for everyone button for the Jitsi widget now also ends the call for the current user.


### PR DESCRIPTION
fixes #7704 