### PR TITLE
Fix: Remove the “Quote” action from the menu of the selected message.

### DIFF
--- a/Riot/Modules/Room/EventMenu/EventMenuItemType.swift
+++ b/Riot/Modules/Room/EventMenu/EventMenuItemType.swift
@@ -25,7 +25,6 @@ enum EventMenuItemType: Int {
     case cancelSending
     case cancelDownloading
     case saveMedia
-    case quote
     case forward
     case permalink
     case share

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -4056,26 +4056,6 @@ static CGSize kThreadListBarButtonItemImageSize;
                 [self cancelEventSelection];
             }]];
         }
-
-        if (!isJitsiCallEvent && !selectedEvent.isTimelinePollEvent &&
-            selectedEvent.eventType != MXEventTypeBeaconInfo)
-        {
-            [self.eventMenuBuilder addItemWithType:EventMenuItemTypeQuote
-                                            action:[UIAlertAction actionWithTitle:[VectorL10n roomEventActionQuote]
-                                                                            style:UIAlertActionStyleDefault
-                                                                          handler:^(UIAlertAction * action) {
-                MXStrongifyAndReturnIfNil(self);
-                
-                [self cancelEventSelection];
-
-                // Quote the message a la Markdown into the input toolbar composer
-                NSString *prefix = [self.inputToolbarView.textMessage length] ? [NSString stringWithFormat:@"%@\n", self.inputToolbarView.textMessage] : @"";
-                self.inputToolbarView.textMessage = [NSString stringWithFormat:@"%@>%@\n\n", prefix, selectedComponent.textMessage];
-                
-                // And display the keyboard
-                [self.inputToolbarView becomeFirstResponder];
-            }]];
-        }
         
         if (selectedEvent.sentState == MXEventSentStateSent &&
             !selectedEvent.isTimelinePollEvent &&

--- a/changelog.d/7691.bugfix
+++ b/changelog.d/7691.bugfix
@@ -1,0 +1,1 @@
+The "Quote" action has been removed from the menu of the selected message.


### PR DESCRIPTION
This PR fixes #7691 by removing the `Quote` action from the menu of the selected message.
