### PR TITLE
Update cross-signing status ui after activation in settings

### DIFF
--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -759,6 +759,7 @@ TableViewSectionsDelegate>
     [self setupCrossSigningWithTitle:@"Set up cross-signing"    // TODO
                              message:[VectorL10n securitySettingsUserPasswordDescription]
                              success:^{
+                                [self loadCrossSigning];
                              } failure:^(NSError *error) {
                              }];
 }
@@ -985,6 +986,7 @@ TableViewSectionsDelegate>
         [self setupCrossSigningWithTitle:[VectorL10n secureKeyBackupSetupIntroTitle]
                                  message:[VectorL10n securitySettingsUserPasswordDescription]
                                  success:^{
+                                     [self loadCrossSigning];
                                      [self setupSecureBackup2];
                                  } failure:^(NSError *error) {
                                  }];

--- a/changelog.d/update-cross-signing-status-ui-after-activation.change
+++ b/changelog.d/update-cross-signing-status-ui-after-activation.change
@@ -1,0 +1,1 @@
+Update cross-signing status ui after activation in settings


### PR DESCRIPTION
When activating cross-signing in Security settings, either directly or by activating Secure Backup, the cross-signing status is not updated in UI.

If you leave Security Settings and open it back right away, the cross-signing status is updated.

Update it right after activation without having to leave the screen.


### Pull Request Checklist

- [X ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [X ] Pull request is based on the develop branch
- [X ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [X ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [X ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

