### PR TITLE
Update RTE to 2.19.0

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "dfb74c89bf54b41ea000d564d6435ac6444ba6b4",
-        "version" : "2.18.0"
+        "revision" : "0aa1308c43451fd077e332f72d6a32135f258834",
+        "version" : "2.19.0"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -59,7 +59,7 @@ packages:
     branch: 0.0.1
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    version: 2.18.0
+    version: 2.19.0
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0


### PR DESCRIPTION
Update RTE to 2.19.0 fixes:
- the position of the caret.
- double space shortcut. 

[RTE 2.19.0 - Changelog](https://github.com/matrix-org/matrix-rich-text-editor/blob/main/CHANGELOG.md)